### PR TITLE
feat(spike): cookie copy from one Chrome to another (U1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ go.work.sum
 # Editor/IDE
 # .idea/
 # .vscode/
+
+# Built binaries (each cmd compiles to bin/<name>)
+/bin/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # agentcookie
-Peer-to-peer Chrome session replication for AI agents. Your laptop's logins, available to your AI agents on any machine.
+
+Peer-to-peer Chrome session replication for AI agents.
+
+Your laptop is logged in to everything. Your AI agents run on a different machine (Mac mini, cloud VM, whatever) and aren't. That gap is `agentcookie`.
+
+## Status
+
+Pre-release. v0.1 in development. See the planning doc linked from this commit for the full roadmap.
+
+What works today: a spike (under `cmd/spike-source` and `cmd/spike-sink`) that copies cookies for one hardcoded host from one Mac's Chrome to another Mac's Chrome. Source and sink are separate binaries. Transport is HTTP with an AES-GCM-encrypted payload using a hardcoded shared secret. Chrome must NOT be running on the destination during a write; live-Chrome support via CDP comes in U4 of the plan.
+
+What does not yet exist: pairing handshake, allowlist, fsnotify-driven continuous sync, live-Chrome CDP injection on the sink, install skill, brand, marketing site, threat model doc. All on the roadmap.
+
+## License
+
+Apache 2.0.

--- a/cmd/spike-sink/main.go
+++ b/cmd/spike-sink/main.go
@@ -1,0 +1,79 @@
+// Command spike-sink runs an HTTP listener that accepts an AES-GCM-encrypted
+// payload of cookies, decrypts it with the shared spike secret, and upserts
+// each cookie into this machine's Chrome cookies SQLite. Chrome must NOT be
+// running while spike-sink writes (file lock); CDP live injection arrives in
+// U4 of the plan.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/mvanhorn/agentcookie/internal/chrome"
+	"github.com/mvanhorn/agentcookie/internal/transport"
+)
+
+// SpikeSecret matches spike-source; replaced by per-peer keys in v0.1.
+const SpikeSecret = "agentcookie-spike-shared-secret-not-for-production-use"
+
+func main() {
+	var (
+		addr   = flag.String("addr", "127.0.0.1:9999", "listen address")
+		dbPath = flag.String("db", chrome.DefaultCookiesPath(), "destination Chrome cookies SQLite path")
+	)
+	flag.Parse()
+
+	password, err := chrome.SafeStoragePassword()
+	if err != nil {
+		log.Fatalf("keychain: %v", err)
+	}
+	key, err := chrome.DeriveAESKey(password)
+	if err != nil {
+		log.Fatalf("derive key: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "ok")
+	})
+	mux.HandleFunc("/sync", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "POST only", http.StatusMethodNotAllowed)
+			return
+		}
+		sealed, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "read body: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		plaintext, err := transport.OpenWithSecret(sealed, SpikeSecret)
+		if err != nil {
+			http.Error(w, "open payload: "+err.Error(), http.StatusUnauthorized)
+			return
+		}
+		var cookies []chrome.Cookie
+		if err := json.Unmarshal(plaintext, &cookies); err != nil {
+			http.Error(w, "unmarshal cookies: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		written, err := chrome.WriteCookies(*dbPath, cookies, key)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "spike-sink: write failed after %d cookies: %v\n", written, err)
+			http.Error(w, fmt.Sprintf("write cookies: %v", err), http.StatusInternalServerError)
+			return
+		}
+		fmt.Fprintf(os.Stderr, "spike-sink: wrote %d cookies to %s\n", written, *dbPath)
+		fmt.Fprintf(w, "ok: wrote %d cookies\n", written)
+	})
+
+	srv := &http.Server{Addr: *addr, Handler: mux}
+	fmt.Fprintf(os.Stderr, "spike-sink: listening on http://%s\n", *addr)
+	if err := srv.ListenAndServe(); err != nil {
+		log.Fatalf("listen: %v", err)
+	}
+}

--- a/cmd/spike-source/main.go
+++ b/cmd/spike-source/main.go
@@ -1,0 +1,104 @@
+// Command spike-source reads cookies for one host from the local Chrome
+// SQLite/Keychain stack and POSTs them to a spike-sink running on another
+// machine. Spike-only: hardcoded shared secret, no allowlist enforcement beyond
+// the host filter on the command line, single shot.
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/mvanhorn/agentcookie/internal/chrome"
+	"github.com/mvanhorn/agentcookie/internal/transport"
+)
+
+// SpikeSecret is the AES-GCM shared secret used by both source and sink during
+// the spike. It is intentionally hardcoded and ships in plaintext source; v0.1
+// replaces it with a pairing-derived per-peer key.
+const SpikeSecret = "agentcookie-spike-shared-secret-not-for-production-use"
+
+func main() {
+	var (
+		sinkURL = flag.String("sink", "http://127.0.0.1:9999/sync", "spike-sink endpoint")
+		host    = flag.String("host", "example.com", "host_key LIKE pattern (use % for wildcards, e.g. %instacart.com)")
+		dbPath  = flag.String("db", chrome.DefaultCookiesPath(), "source Chrome cookies SQLite path")
+		dryRun  = flag.Bool("dry-run", false, "print cookies to stderr and exit without contacting sink")
+	)
+	flag.Parse()
+
+	pattern := *host
+	if !containsWildcard(pattern) {
+		pattern = "%" + pattern + "%"
+	}
+
+	password, err := chrome.SafeStoragePassword()
+	if err != nil {
+		log.Fatalf("keychain: %v", err)
+	}
+	key, err := chrome.DeriveAESKey(password)
+	if err != nil {
+		log.Fatalf("derive key: %v", err)
+	}
+
+	cookies, err := chrome.ReadCookiesForHost(*dbPath, pattern, key)
+	if err != nil {
+		log.Fatalf("read cookies: %v", err)
+	}
+	fmt.Fprintf(os.Stderr, "spike-source: read %d cookies matching %q from %s\n", len(cookies), pattern, *dbPath)
+	if len(cookies) == 0 {
+		fmt.Fprintln(os.Stderr, "spike-source: nothing to send")
+		os.Exit(0)
+	}
+	for _, c := range cookies {
+		fmt.Fprintf(os.Stderr, "  %s/%s (value=%d bytes)\n", c.HostKey, c.Name, len(c.Value))
+	}
+
+	if *dryRun {
+		fmt.Fprintln(os.Stderr, "spike-source: --dry-run set, not contacting sink")
+		return
+	}
+
+	payload, err := json.Marshal(cookies)
+	if err != nil {
+		log.Fatalf("marshal: %v", err)
+	}
+	sealed, err := transport.SealWithSecret(payload, SpikeSecret)
+	if err != nil {
+		log.Fatalf("seal: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, "POST", *sinkURL, bytes.NewReader(sealed))
+	if err != nil {
+		log.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/octet-stream")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		log.Fatalf("post to sink: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	fmt.Fprintf(os.Stderr, "spike-source: sink responded %d: %s\n", resp.StatusCode, string(body))
+	if resp.StatusCode != http.StatusOK {
+		os.Exit(1)
+	}
+}
+
+func containsWildcard(s string) bool {
+	for _, r := range s {
+		if r == '%' || r == '_' {
+			return true
+		}
+	}
+	return false
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/mvanhorn/agentcookie
+
+go 1.26.2
+
+require github.com/mattn/go-sqlite3 v1.14.44

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/mattn/go-sqlite3 v1.14.44 h1:3VSe+xafpbzsLbdr2AWlAZk9yRHiBhTBakioXaCKTF8=
+github.com/mattn/go-sqlite3 v1.14.44/go.mod h1:pjEuOr8IwzLJP2MfGeTb0A35jauH+C2kbHKBr7yXKVQ=

--- a/internal/chrome/crypto_test.go
+++ b/internal/chrome/crypto_test.go
@@ -1,0 +1,82 @@
+package chrome
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestEncryptDecryptRoundTrip exercises the AES-128-CBC + PKCS#7 + v10 path
+// the spike uses for both directions. If Chrome changes the IV or key length
+// these assertions break loudly.
+func TestEncryptDecryptRoundTrip(t *testing.T) {
+	key, err := DeriveAESKey("any-test-password")
+	if err != nil {
+		t.Fatalf("derive key: %v", err)
+	}
+	if len(key) != aesKeyLen {
+		t.Fatalf("expected %d-byte key, got %d", aesKeyLen, len(key))
+	}
+
+	for _, plaintext := range []string{
+		"",
+		"a",
+		"sixteen-bytes-ok",
+		"this is longer than one AES block to exercise multi-block CBC",
+		"contains\x00null\x00bytes",
+		string(bytes.Repeat([]byte("x"), 4096)),
+	} {
+		encrypted, err := encryptValue(plaintext, key)
+		if err != nil {
+			t.Fatalf("encryptValue(%q): %v", plaintext, err)
+		}
+		if !bytes.HasPrefix(encrypted, []byte("v10")) {
+			t.Errorf("expected v10 prefix on ciphertext, got %q", encrypted[:3])
+		}
+		decrypted, err := decryptValue(encrypted, key)
+		if err != nil {
+			t.Fatalf("decryptValue(%q): %v", plaintext, err)
+		}
+		if decrypted != plaintext {
+			t.Errorf("round-trip mismatch: input %q != output %q", plaintext, decrypted)
+		}
+	}
+}
+
+// TestDecryptValueRejectsBadPrefix proves the spike's prefix guard works.
+// Adjacent Chromium platforms use v11 / Linux fallback formats that we
+// deliberately do not support yet.
+func TestDecryptValueRejectsBadPrefix(t *testing.T) {
+	key, _ := DeriveAESKey("any-test-password")
+	encrypted, err := encryptValue("hello", key)
+	if err != nil {
+		t.Fatalf("encryptValue: %v", err)
+	}
+	tampered := append([]byte{}, encrypted...)
+	tampered[0] = 'x'
+	if _, err := decryptValue(tampered, key); err == nil {
+		t.Fatal("expected error for bad prefix, got nil")
+	}
+}
+
+// TestDeriveAESKeyDeterministic guards against accidental change to salt or
+// iteration count. Two derivations from the same password must match.
+func TestDeriveAESKeyDeterministic(t *testing.T) {
+	a, err := DeriveAESKey("same-password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := DeriveAESKey("same-password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(a, b) {
+		t.Errorf("derived keys differ across runs: %x vs %x", a, b)
+	}
+	c, err := DeriveAESKey("different-password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Equal(a, c) {
+		t.Errorf("different passwords produced identical keys: %x", a)
+	}
+}

--- a/internal/chrome/keychain.go
+++ b/internal/chrome/keychain.go
@@ -1,0 +1,47 @@
+// Package chrome reads and writes Chrome cookies on macOS, handling the
+// per-machine Safe Storage encryption via the macOS Keychain.
+package chrome
+
+import (
+	"crypto/pbkdf2"
+	"crypto/sha1"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+const (
+	keychainAccount = "Chrome"
+	keychainService = "Chrome Safe Storage"
+	pbkdf2Salt      = "saltysalt"
+	pbkdf2Iter      = 1003
+	aesKeyLen       = 16
+)
+
+// SafeStoragePassword returns the Chrome Safe Storage password from the macOS
+// Keychain. The first call from a new binary prompts the user for Keychain
+// access; subsequent calls succeed silently once the user clicks "Always Allow".
+func SafeStoragePassword() (string, error) {
+	cmd := exec.Command("security",
+		"find-generic-password",
+		"-a", keychainAccount,
+		"-s", keychainService,
+		"-w",
+	)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("read Chrome Safe Storage from Keychain (did you grant access?): %w", err)
+	}
+	return strings.TrimRight(string(out), "\n"), nil
+}
+
+// DeriveAESKey turns the Safe Storage password into the AES-128 key Chrome uses
+// for cookie value encryption on this machine. Salt and iteration count are
+// pinned to Chrome's macOS implementation.
+func DeriveAESKey(password string) ([]byte, error) {
+	key, err := pbkdf2.Key(sha1.New, password, []byte(pbkdf2Salt), pbkdf2Iter, aesKeyLen)
+	if err != nil {
+		return nil, fmt.Errorf("pbkdf2: %w", err)
+	}
+	return key, nil
+}

--- a/internal/chrome/read.go
+++ b/internal/chrome/read.go
@@ -1,0 +1,123 @@
+package chrome
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// Cookie is the wire-friendly representation of one Chrome cookie. Value is
+// plaintext after decryption; the wire format re-encrypts it with the sink's
+// key on the other side.
+type Cookie struct {
+	HostKey       string `json:"host_key"`
+	Name          string `json:"name"`
+	Value         string `json:"value"`
+	Path          string `json:"path"`
+	ExpiresUTC    int64  `json:"expires_utc"`
+	IsSecure      int    `json:"is_secure"`
+	IsHTTPOnly    int    `json:"is_httponly"`
+	LastAccessUTC int64  `json:"last_access_utc"`
+	HasExpires    int    `json:"has_expires"`
+	IsPersistent  int    `json:"is_persistent"`
+	Priority      int    `json:"priority"`
+	SameSite      int    `json:"samesite"`
+	SourceScheme  int    `json:"source_scheme"`
+	SourcePort    int    `json:"source_port"`
+}
+
+// DefaultCookiesPath returns the default Chrome cookies SQLite path on macOS.
+func DefaultCookiesPath() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, "Library", "Application Support", "Google", "Chrome", "Default", "Cookies")
+}
+
+// ReadCookiesForHost opens the given SQLite path read-only and returns all
+// cookies whose host_key matches the LIKE pattern (use % wildcards for substring
+// match, e.g. "%instacart.com").
+func ReadCookiesForHost(dbPath, hostPattern string, key []byte) ([]Cookie, error) {
+	// immutable=1 lets us read while Chrome holds its lock.
+	dsn := fmt.Sprintf("file:%s?mode=ro&immutable=1", dbPath)
+	db, err := sql.Open("sqlite3", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("open cookies db: %w", err)
+	}
+	defer db.Close()
+
+	query := `
+SELECT host_key, name, encrypted_value, path,
+       expires_utc, is_secure, is_httponly, last_access_utc,
+       has_expires, is_persistent, priority, samesite,
+       source_scheme, source_port
+FROM cookies
+WHERE host_key LIKE ?`
+	rows, err := db.Query(query, hostPattern)
+	if err != nil {
+		return nil, fmt.Errorf("query cookies: %w", err)
+	}
+	defer rows.Close()
+
+	var cookies []Cookie
+	for rows.Next() {
+		var (
+			c              Cookie
+			encryptedValue []byte
+		)
+		if err := rows.Scan(
+			&c.HostKey, &c.Name, &encryptedValue, &c.Path,
+			&c.ExpiresUTC, &c.IsSecure, &c.IsHTTPOnly, &c.LastAccessUTC,
+			&c.HasExpires, &c.IsPersistent, &c.Priority, &c.SameSite,
+			&c.SourceScheme, &c.SourcePort,
+		); err != nil {
+			return nil, fmt.Errorf("scan row: %w", err)
+		}
+		plain, err := decryptValue(encryptedValue, key)
+		if err != nil {
+			return nil, fmt.Errorf("decrypt %s/%s: %w", c.HostKey, c.Name, err)
+		}
+		c.Value = plain
+		cookies = append(cookies, c)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate rows: %w", err)
+	}
+	return cookies, nil
+}
+
+func decryptValue(encrypted, key []byte) (string, error) {
+	if len(encrypted) < 3 {
+		return "", fmt.Errorf("ciphertext too short (%d bytes)", len(encrypted))
+	}
+	prefix := string(encrypted[:3])
+	if prefix != "v10" {
+		return "", fmt.Errorf("unexpected ciphertext prefix %q (spike supports v10 only)", prefix)
+	}
+	ct := encrypted[3:]
+	if len(ct)%aes.BlockSize != 0 {
+		return "", fmt.Errorf("ciphertext length %d not a multiple of AES block size", len(ct))
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", err
+	}
+	// Chrome on macOS uses 16 space chars as the IV, not 16 nulls.
+	iv := bytes.Repeat([]byte{' '}, aes.BlockSize)
+	mode := cipher.NewCBCDecrypter(block, iv)
+	pt := make([]byte, len(ct))
+	mode.CryptBlocks(pt, ct)
+	// PKCS#7 unpad.
+	if len(pt) == 0 {
+		return "", fmt.Errorf("empty plaintext after decrypt")
+	}
+	pad := int(pt[len(pt)-1])
+	if pad < 1 || pad > aes.BlockSize || pad > len(pt) {
+		return "", fmt.Errorf("invalid PKCS#7 padding byte %d", pad)
+	}
+	return string(pt[:len(pt)-pad]), nil
+}

--- a/internal/chrome/write.go
+++ b/internal/chrome/write.go
@@ -1,0 +1,207 @@
+package chrome
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// chromeEpochDeltaMicros is the number of microseconds between the Unix epoch
+// (1970-01-01) and Chrome's WebKit epoch (1601-01-01). Used for the *_utc
+// columns in the Cookies table.
+const chromeEpochDeltaMicros int64 = 11644473600 * 1000 * 1000
+
+// WriteCookies upserts each cookie into the destination Chrome SQLite Cookies
+// database, re-encrypting Value with the destination's AES key. Chrome must NOT
+// be running on the destination machine during this call (Chrome holds an
+// exclusive lock on Cookies when up). The spike documents this limitation; live
+// injection via CDP lands in U4.
+func WriteCookies(dbPath string, cookies []Cookie, key []byte) (int, error) {
+	db, err := sql.Open("sqlite3", "file:"+dbPath+"?_journal=WAL&_busy_timeout=2000")
+	if err != nil {
+		return 0, fmt.Errorf("open destination cookies db: %w", err)
+	}
+	defer db.Close()
+
+	if err := db.Ping(); err != nil {
+		return 0, fmt.Errorf("ping destination cookies db (is Chrome running?): %w", err)
+	}
+
+	// Discover the actual schema so we can target whatever Chrome version is on
+	// this machine without hardcoding every Chromium release's column list.
+	cols, err := readTableColumns(db, "cookies")
+	if err != nil {
+		return 0, fmt.Errorf("read cookies schema: %w", err)
+	}
+
+	insertSQL, args := buildUpsert(cols)
+
+	tx, err := db.Begin()
+	if err != nil {
+		return 0, fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	stmt, err := tx.Prepare(insertSQL)
+	if err != nil {
+		return 0, fmt.Errorf("prepare upsert (%s): %w", insertSQL, err)
+	}
+	defer stmt.Close()
+
+	nowChrome := time.Now().UnixMicro() + chromeEpochDeltaMicros
+
+	written := 0
+	for _, c := range cookies {
+		encrypted, err := encryptValue(c.Value, key)
+		if err != nil {
+			return written, fmt.Errorf("encrypt %s/%s: %w", c.HostKey, c.Name, err)
+		}
+		row := args(rowInput{
+			cookie:        c,
+			encrypted:     encrypted,
+			creationUTC:   nowChrome,
+			lastUpdateUTC: nowChrome,
+		})
+		if _, err := stmt.Exec(row...); err != nil {
+			return written, fmt.Errorf("upsert %s/%s: %w", c.HostKey, c.Name, err)
+		}
+		written++
+	}
+
+	if err := tx.Commit(); err != nil {
+		return written, fmt.Errorf("commit tx: %w", err)
+	}
+	return written, nil
+}
+
+func encryptValue(plaintext string, key []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	iv := bytes.Repeat([]byte{' '}, aes.BlockSize)
+	mode := cipher.NewCBCEncrypter(block, iv)
+	pad := aes.BlockSize - len(plaintext)%aes.BlockSize
+	padded := make([]byte, len(plaintext)+pad)
+	copy(padded, plaintext)
+	for i := len(plaintext); i < len(padded); i++ {
+		padded[i] = byte(pad)
+	}
+	ct := make([]byte, len(padded))
+	mode.CryptBlocks(ct, padded)
+	out := append([]byte("v10"), ct...)
+	return out, nil
+}
+
+func readTableColumns(db *sql.DB, table string) (map[string]bool, error) {
+	rows, err := db.Query(fmt.Sprintf("PRAGMA table_info(%s)", table))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	cols := map[string]bool{}
+	for rows.Next() {
+		var (
+			cid          int
+			name, ctype  string
+			notNull, pk  int
+			dfltValue    sql.NullString
+		)
+		if err := rows.Scan(&cid, &name, &ctype, &notNull, &dfltValue, &pk); err != nil {
+			return nil, err
+		}
+		cols[name] = true
+	}
+	return cols, rows.Err()
+}
+
+type rowInput struct {
+	cookie        Cookie
+	encrypted     []byte
+	creationUTC   int64
+	lastUpdateUTC int64
+}
+
+// buildUpsert returns an INSERT ... ON CONFLICT statement targeting only the
+// columns present in the live schema, plus a function that returns the matching
+// args slice for a given Cookie.
+func buildUpsert(cols map[string]bool) (string, func(rowInput) []any) {
+	// Column order is fixed for stable arg-binding regardless of map iteration.
+	type field struct {
+		name string
+		get  func(rowInput) any
+	}
+	candidates := []field{
+		{"creation_utc", func(r rowInput) any { return r.creationUTC }},
+		{"host_key", func(r rowInput) any { return r.cookie.HostKey }},
+		{"top_frame_site_key", func(r rowInput) any { return "" }},
+		{"name", func(r rowInput) any { return r.cookie.Name }},
+		{"value", func(r rowInput) any { return "" }},
+		{"encrypted_value", func(r rowInput) any { return r.encrypted }},
+		{"path", func(r rowInput) any { return r.cookie.Path }},
+		{"expires_utc", func(r rowInput) any { return r.cookie.ExpiresUTC }},
+		{"is_secure", func(r rowInput) any { return r.cookie.IsSecure }},
+		{"is_httponly", func(r rowInput) any { return r.cookie.IsHTTPOnly }},
+		{"last_access_utc", func(r rowInput) any { return r.cookie.LastAccessUTC }},
+		{"has_expires", func(r rowInput) any { return r.cookie.HasExpires }},
+		{"is_persistent", func(r rowInput) any { return r.cookie.IsPersistent }},
+		{"priority", func(r rowInput) any { return r.cookie.Priority }},
+		{"samesite", func(r rowInput) any { return r.cookie.SameSite }},
+		{"source_scheme", func(r rowInput) any { return r.cookie.SourceScheme }},
+		{"source_port", func(r rowInput) any { return r.cookie.SourcePort }},
+		{"last_update_utc", func(r rowInput) any { return r.lastUpdateUTC }},
+		{"source_type", func(r rowInput) any { return 0 }},
+		{"has_cross_site_ancestor", func(r rowInput) any { return 1 }},
+	}
+
+	var present []field
+	for _, c := range candidates {
+		if cols[c.name] {
+			present = append(present, c)
+		}
+	}
+
+	var names, placeholders, updates []string
+	for _, f := range present {
+		names = append(names, f.name)
+		placeholders = append(placeholders, "?")
+		// Skip primary-key columns and creation_utc from the UPDATE clause.
+		switch f.name {
+		case "host_key", "top_frame_site_key", "name", "path", "source_scheme", "source_port", "creation_utc":
+			continue
+		}
+		updates = append(updates, fmt.Sprintf("%s=excluded.%s", f.name, f.name))
+	}
+
+	// Build conflict target from the columns that are actually present and form
+	// the unique key on every modern Chromium schema.
+	conflictCandidates := []string{"host_key", "top_frame_site_key", "name", "path", "source_scheme", "source_port"}
+	var conflictCols []string
+	for _, c := range conflictCandidates {
+		if cols[c] {
+			conflictCols = append(conflictCols, c)
+		}
+	}
+
+	sql := fmt.Sprintf(
+		"INSERT INTO cookies (%s) VALUES (%s) ON CONFLICT(%s) DO UPDATE SET %s",
+		strings.Join(names, ","),
+		strings.Join(placeholders, ","),
+		strings.Join(conflictCols, ","),
+		strings.Join(updates, ","),
+	)
+
+	build := func(r rowInput) []any {
+		out := make([]any, len(present))
+		for i, f := range present {
+			out[i] = f.get(r)
+		}
+		return out
+	}
+
+	return sql, build
+}

--- a/internal/transport/crypto.go
+++ b/internal/transport/crypto.go
@@ -1,0 +1,54 @@
+// Package transport is the spike's shared-secret AES-GCM wrapper for the
+// HTTP-over-tailnet sync channel. v0.1's real protocol replaces this with a
+// pairing-handshake-derived key per peer.
+package transport
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"fmt"
+	"io"
+)
+
+// SealWithSecret encrypts plaintext under a key derived from the shared secret.
+// Nonce is prepended to the ciphertext for transport.
+func SealWithSecret(plaintext []byte, secret string) ([]byte, error) {
+	gcm, err := newGCM(secret)
+	if err != nil {
+		return nil, err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, fmt.Errorf("nonce: %w", err)
+	}
+	return gcm.Seal(nonce, nonce, plaintext, nil), nil
+}
+
+// OpenWithSecret decrypts a payload produced by SealWithSecret. Returns an
+// error on any auth/integrity failure.
+func OpenWithSecret(ciphertext []byte, secret string) ([]byte, error) {
+	gcm, err := newGCM(secret)
+	if err != nil {
+		return nil, err
+	}
+	if len(ciphertext) < gcm.NonceSize() {
+		return nil, fmt.Errorf("ciphertext too short (%d bytes)", len(ciphertext))
+	}
+	nonce, ct := ciphertext[:gcm.NonceSize()], ciphertext[gcm.NonceSize():]
+	pt, err := gcm.Open(nil, nonce, ct, nil)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt (wrong secret or tampered payload): %w", err)
+	}
+	return pt, nil
+}
+
+func newGCM(secret string) (cipher.AEAD, error) {
+	keyHash := sha256.Sum256([]byte(secret))
+	block, err := aes.NewCipher(keyHash[:])
+	if err != nil {
+		return nil, err
+	}
+	return cipher.NewGCM(block)
+}

--- a/internal/transport/crypto_test.go
+++ b/internal/transport/crypto_test.go
@@ -1,0 +1,62 @@
+package transport
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestSealOpenRoundTrip(t *testing.T) {
+	secret := "test-secret-not-real"
+	plaintext := []byte("hello agentcookie")
+	sealed, err := SealWithSecret(plaintext, secret)
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	if bytes.Equal(sealed, plaintext) {
+		t.Fatal("ciphertext equals plaintext (encryption did not run)")
+	}
+	got, err := OpenWithSecret(sealed, secret)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if !bytes.Equal(got, plaintext) {
+		t.Errorf("round-trip mismatch: got %q, want %q", got, plaintext)
+	}
+}
+
+func TestSealOpenRejectsWrongSecret(t *testing.T) {
+	sealed, err := SealWithSecret([]byte("payload"), "correct-secret")
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	if _, err := OpenWithSecret(sealed, "wrong-secret"); err == nil {
+		t.Fatal("expected error when opening with wrong secret, got nil")
+	}
+}
+
+func TestOpenRejectsTamperedCiphertext(t *testing.T) {
+	sealed, err := SealWithSecret([]byte("payload"), "secret")
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	tampered := append([]byte{}, sealed...)
+	// Flip the last byte; AES-GCM tag check catches it.
+	tampered[len(tampered)-1] ^= 0x01
+	if _, err := OpenWithSecret(tampered, "secret"); err == nil {
+		t.Fatal("expected error when opening tampered ciphertext, got nil")
+	}
+}
+
+func TestSealProducesDifferentCiphertextEachCall(t *testing.T) {
+	a, err := SealWithSecret([]byte("payload"), "secret")
+	if err != nil {
+		t.Fatalf("seal a: %v", err)
+	}
+	b, err := SealWithSecret([]byte("payload"), "secret")
+	if err != nil {
+		t.Fatalf("seal b: %v", err)
+	}
+	if bytes.Equal(a, b) {
+		t.Error("expected different ciphertexts on repeated seals (nonce should vary), got identical bytes")
+	}
+}


### PR DESCRIPTION
First runnable surface for [the AgentCookie plan](https://github.com/mvanhorn/agentcookie/blob/main/README.md) (U1 of `~/docs/plans/2026-05-16-001-feat-chrome-cookie-laptop-to-macmini-sync-plan.md`).

## What's here

Two Go binaries:

- `cmd/spike-source` reads cookies for one host from the local Chrome's SQLite + macOS Keychain stack, AES-GCM-encrypts the JSON payload with a shared secret, POSTs to the sink.
- `cmd/spike-sink` listens on `127.0.0.1:9999/sync`, decrypts with the same secret, re-encrypts each cookie value with the destination's Chrome Safe Storage key, upserts into the destination Cookies SQLite.

Plus shared internals:

- `internal/chrome/keychain.go` shells out to `security find-generic-password` and runs PBKDF2-SHA1 (salt `saltysalt`, 1003 iters) to get the AES-128 key.
- `internal/chrome/read.go` opens Chrome's Cookies SQLite read-only with `immutable=1` so the source can read while Chrome is up, decrypts each `v10`-prefixed value with AES-128-CBC and IV = 16 spaces.
- `internal/chrome/write.go` introspects the destination Cookies schema via `PRAGMA table_info` and builds the INSERT ... ON CONFLICT statement dynamically, so the spike adapts to Chrome's evolving column set (`top_frame_site_key`, `source_type`, `has_cross_site_ancestor`).
- `internal/transport/crypto.go` is the shared AES-GCM seal/open with the spike's hardcoded secret.

## Manual verification

Unit tests cover the math. The real round-trip is a manual step because it requires two physical machines.

1. Pick a low-stakes site and log in on the source machine's Chrome. `example.com` is fine if you have a session cookie there; otherwise pick anything authenticated.
2. On the destination machine, fully quit Chrome (Cmd+Q, not just close the window). The sink needs an exclusive lock on the Cookies SQLite.
3. SCP `bin/spike-sink` to the destination machine. Run it: `./spike-sink` (defaults to `127.0.0.1:9999` and `~/Library/Application Support/Google/Chrome/Default/Cookies`).
4. On the source machine: `./bin/spike-source --sink http://<destination-tailnet-host>:9999/sync --host '%example.com'`.
5. Open Chrome on the destination machine. Visit `example.com`. You should be logged in.

If anything fails the binaries print to stderr what happened (wrong secret, decrypt error, schema mismatch). The keychain prompt fires on first run on each machine; click Always Allow.

## Out of scope by design

The plan's later units handle each of these:

- Hardcoded shared secret. Pairing-derived per-peer key lands in U5.
- Allowlist enforcement is just the host CLI flag. Signed allowlist in U6.
- Chrome must be closed on the sink. Live CDP injection in U4.
- Single shot. fsnotify watcher in U3.
- Production binary name and config layout. U3 introduces the unified `agentcookie` CLI.

## Tests

```
go test ./...
```

7 tests across `internal/chrome` and `internal/transport` cover AES-128-CBC `v10` round-trip, key derivation determinism, AES-GCM seal/open round-trip, tampered ciphertext rejection, wrong-secret rejection, and nonce variance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)