### PR TITLE
feat(cdp): live-Chrome cookie injection on the sink (U4)

### DIFF
--- a/examples/sink.yaml
+++ b/examples/sink.yaml
@@ -11,6 +11,15 @@ chrome:
   # if omitted.
   db_path: ~/Library/Application Support/Google/Chrome/Default/Cookies
 
+cdp:
+  # When enabled, the sink probes Chrome's --remote-debugging-port and
+  # injects cookies via Storage.setCookies for instant in-memory visibility.
+  # Falls back to the SQLite write path if Chrome is not reachable.
+  # Launch Chrome with: open -na "Google Chrome" --args --remote-debugging-port=9222
+  enabled: true
+  host: 127.0.0.1
+  port: 9222
+
 peer:
   # Hostname of the source machine. After `agentcookie pair --as sink ...`
   # finishes, this is the filename under ~/.config/agentcookie/keys/.

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/mvanhorn/agentcookie
 go 1.26.2
 
 require (
+	github.com/gorilla/websocket v1.5.3
 	github.com/mattn/go-sqlite3 v1.14.44
 	github.com/spf13/cobra v1.10.2
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/mattn/go-sqlite3 v1.14.44 h1:3VSe+xafpbzsLbdr2AWlAZk9yRHiBhTBakioXaCKTF8=

--- a/internal/cdp/client.go
+++ b/internal/cdp/client.go
@@ -1,0 +1,194 @@
+// Package cdp is a minimal Chrome DevTools Protocol client tailored to the
+// cookie-injection use case. It can probe whether Chrome is running with
+// remote debugging enabled and call Storage.setCookies over a single
+// browser-level WebSocket connection. It does not aim to be a general CDP
+// client; chromedp covers that ground with a much larger dependency footprint.
+package cdp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"sync/atomic"
+
+	"github.com/gorilla/websocket"
+)
+
+// VersionInfo is the shape returned by Chrome's /json/version endpoint.
+type VersionInfo struct {
+	Browser              string `json:"Browser"`
+	WebSocketDebuggerURL string `json:"webSocketDebuggerUrl"`
+}
+
+// Probe checks whether Chrome is running with --remote-debugging-port on the
+// given host:port. Returns the browser-level webSocketDebuggerUrl, or an
+// error if no debuggable Chrome is reachable.
+func Probe(ctx context.Context, host string, port int) (*VersionInfo, error) {
+	url := fmt.Sprintf("http://%s:%d/json/version", host, port)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("probe %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("probe %s: status %d", url, resp.StatusCode)
+	}
+	var v VersionInfo
+	if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
+		return nil, fmt.Errorf("decode /json/version: %w", err)
+	}
+	if v.WebSocketDebuggerURL == "" {
+		return nil, fmt.Errorf("Chrome at %s:%d returned no webSocketDebuggerUrl", host, port)
+	}
+	return &v, nil
+}
+
+// Conn is a thin CDP WebSocket client. It serializes one method call at a time
+// (write-side mutex) and demultiplexes responses by id from a single reader
+// goroutine.
+type Conn struct {
+	ws *websocket.Conn
+
+	writeMu sync.Mutex
+	nextID  atomic.Int64
+
+	pendMu  sync.Mutex
+	pending map[int64]chan rawResponse
+	closed  bool
+}
+
+type request struct {
+	ID     int64       `json:"id"`
+	Method string      `json:"method"`
+	Params interface{} `json:"params,omitempty"`
+}
+
+type rawResponse struct {
+	ID     int64           `json:"id"`
+	Result json.RawMessage `json:"result,omitempty"`
+	Error  *errorObj       `json:"error,omitempty"`
+}
+
+type errorObj struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    string `json:"data,omitempty"`
+}
+
+// Dial opens a WebSocket to the given browser-level debugger URL.
+func Dial(ctx context.Context, wsURL string) (*Conn, error) {
+	dialer := *websocket.DefaultDialer
+	ws, _, err := dialer.DialContext(ctx, wsURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("dial cdp %s: %w", wsURL, err)
+	}
+	c := &Conn{
+		ws:      ws,
+		pending: make(map[int64]chan rawResponse),
+	}
+	go c.readLoop()
+	return c, nil
+}
+
+// readLoop pumps inbound messages and routes responses to their waiting
+// goroutines. CDP events (no id) are dropped; this client doesn't subscribe.
+func (c *Conn) readLoop() {
+	defer c.cleanup()
+	for {
+		_, msg, err := c.ws.ReadMessage()
+		if err != nil {
+			return
+		}
+		var r rawResponse
+		if err := json.Unmarshal(msg, &r); err != nil {
+			continue
+		}
+		if r.ID == 0 {
+			continue
+		}
+		c.pendMu.Lock()
+		ch, ok := c.pending[r.ID]
+		if ok {
+			delete(c.pending, r.ID)
+		}
+		c.pendMu.Unlock()
+		if ok {
+			ch <- r
+			close(ch)
+		}
+	}
+}
+
+func (c *Conn) cleanup() {
+	c.pendMu.Lock()
+	defer c.pendMu.Unlock()
+	c.closed = true
+	for id, ch := range c.pending {
+		close(ch)
+		delete(c.pending, id)
+	}
+}
+
+// Call sends a method and waits for the response. If result is non-nil, the
+// response's "result" field is decoded into it.
+func (c *Conn) Call(ctx context.Context, method string, params interface{}, result interface{}) error {
+	id := c.nextID.Add(1)
+	ch := make(chan rawResponse, 1)
+
+	c.pendMu.Lock()
+	if c.closed {
+		c.pendMu.Unlock()
+		return fmt.Errorf("cdp connection closed")
+	}
+	c.pending[id] = ch
+	c.pendMu.Unlock()
+
+	req := request{ID: id, Method: method, Params: params}
+	data, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("marshal %s: %w", method, err)
+	}
+
+	c.writeMu.Lock()
+	err = c.ws.WriteMessage(websocket.TextMessage, data)
+	c.writeMu.Unlock()
+	if err != nil {
+		// Drain the pending entry on write failure so it doesn't leak.
+		c.pendMu.Lock()
+		delete(c.pending, id)
+		c.pendMu.Unlock()
+		return fmt.Errorf("write %s: %w", method, err)
+	}
+
+	select {
+	case <-ctx.Done():
+		c.pendMu.Lock()
+		delete(c.pending, id)
+		c.pendMu.Unlock()
+		return ctx.Err()
+	case r, ok := <-ch:
+		if !ok {
+			return fmt.Errorf("cdp connection closed waiting for %s response", method)
+		}
+		if r.Error != nil {
+			return fmt.Errorf("cdp %s: %s (code %d)", method, r.Error.Message, r.Error.Code)
+		}
+		if result != nil && len(r.Result) > 0 {
+			if err := json.Unmarshal(r.Result, result); err != nil {
+				return fmt.Errorf("decode %s result: %w", method, err)
+			}
+		}
+		return nil
+	}
+}
+
+// Close shuts down the WebSocket. Safe to call multiple times.
+func (c *Conn) Close() error {
+	return c.ws.Close()
+}

--- a/internal/cdp/client_test.go
+++ b/internal/cdp/client_test.go
@@ -1,0 +1,157 @@
+package cdp
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/mvanhorn/agentcookie/internal/chrome"
+)
+
+// TestProbeRecognizesDebuggerURL spins up a fake /json/version endpoint and
+// confirms Probe returns the embedded webSocketDebuggerUrl.
+func TestProbeRecognizesDebuggerURL(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/json/version" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(`{"Browser":"Chrome/test","webSocketDebuggerUrl":"ws://127.0.0.1:9222/devtools/browser/abc"}`))
+	}))
+	defer srv.Close()
+
+	host, port := splitHostPort(t, srv.Listener.Addr().String())
+	info, err := Probe(context.Background(), host, port)
+	if err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+	if !strings.HasPrefix(info.WebSocketDebuggerURL, "ws://") {
+		t.Errorf("expected ws:// URL, got %q", info.WebSocketDebuggerURL)
+	}
+	if info.Browser != "Chrome/test" {
+		t.Errorf("Browser field wrong: %q", info.Browser)
+	}
+}
+
+// TestProbeFailsWhenChromeDown verifies Probe returns an error when no
+// listener is reachable.
+func TestProbeFailsWhenChromeDown(t *testing.T) {
+	// Pick a free port, immediately close so it's unreachable.
+	ln, _ := net.Listen("tcp", "127.0.0.1:0")
+	host, port := splitHostPort(t, ln.Addr().String())
+	ln.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	if _, err := Probe(ctx, host, port); err == nil {
+		t.Fatal("expected error probing closed port, got nil")
+	}
+}
+
+// TestCallEndToEnd uses a fake CDP server that echoes Storage.setCookies as
+// success. Exercises the request encoding, response demux, and result decode.
+func TestCallEndToEnd(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer ws.Close()
+		for {
+			_, msg, err := ws.ReadMessage()
+			if err != nil {
+				return
+			}
+			var req struct {
+				ID     int             `json:"id"`
+				Method string          `json:"method"`
+				Params json.RawMessage `json:"params"`
+			}
+			if err := json.Unmarshal(msg, &req); err != nil {
+				continue
+			}
+			// Echo a success response.
+			resp, _ := json.Marshal(map[string]interface{}{
+				"id":     req.ID,
+				"result": map[string]interface{}{"ok": true, "method": req.Method},
+			})
+			_ = ws.WriteMessage(websocket.TextMessage, resp)
+		}
+	}))
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, err := Dial(ctx, wsURL)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer conn.Close()
+
+	var result struct {
+		OK     bool   `json:"ok"`
+		Method string `json:"method"`
+	}
+	if err := conn.Call(ctx, "Storage.setCookies", map[string]interface{}{"cookies": []chrome.Cookie{}}, &result); err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if !result.OK {
+		t.Error("expected ok=true in result")
+	}
+	if result.Method != "Storage.setCookies" {
+		t.Errorf("method round-trip wrong: %q", result.Method)
+	}
+}
+
+// TestSetCookiesEmptyIsNoOp guards against firing a CDP call when nothing is
+// to be done.
+func TestSetCookiesEmptyIsNoOp(t *testing.T) {
+	// No connection needed; SetCookies returns early.
+	n, err := SetCookies(context.Background(), nil, nil)
+	if err != nil {
+		t.Errorf("expected no error for empty cookies, got %v", err)
+	}
+	if n != 0 {
+		t.Errorf("expected 0 written for empty input, got %d", n)
+	}
+}
+
+// TestSameSiteMapping pins the int -> CDP enum mapping for SameSite. Changes
+// here would silently break cookies that rely on Strict / Lax semantics.
+func TestSameSiteMapping(t *testing.T) {
+	cases := map[int]string{
+		0:  "None",
+		1:  "Lax",
+		2:  "Strict",
+		-1: "", // Unspecified - omit field
+		99: "", // unknown - omit field
+	}
+	for in, want := range cases {
+		got := sameSiteString(in)
+		if got != want {
+			t.Errorf("sameSiteString(%d) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func splitHostPort(t *testing.T, addr string) (string, int) {
+	t.Helper()
+	host, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		t.Fatalf("SplitHostPort %q: %v", addr, err)
+	}
+	port := 0
+	for _, c := range portStr {
+		port = port*10 + int(c-'0')
+	}
+	return host, port
+}

--- a/internal/cdp/setcookies.go
+++ b/internal/cdp/setcookies.go
@@ -1,0 +1,72 @@
+package cdp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mvanhorn/agentcookie/internal/chrome"
+)
+
+// chromeEpochDeltaSeconds converts Chrome's WebKit microsecond epoch
+// (1601-01-01) into Unix seconds (1970-01-01) by subtracting the offset.
+const chromeEpochDeltaSeconds float64 = 11644473600
+
+// CookieParam matches Chrome's CDP Network.CookieParam type (only the fields
+// we populate). Storage.setCookies accepts an array of these.
+type CookieParam struct {
+	Name     string  `json:"name"`
+	Value    string  `json:"value"`
+	Domain   string  `json:"domain,omitempty"`
+	Path     string  `json:"path,omitempty"`
+	Secure   bool    `json:"secure,omitempty"`
+	HTTPOnly bool    `json:"httpOnly,omitempty"`
+	SameSite string  `json:"sameSite,omitempty"`
+	Expires  float64 `json:"expires,omitempty"`
+}
+
+// SetCookies sends Storage.setCookies via the browser-level CDP connection.
+// Cookies set this way are visible to all pages in the default browser
+// context immediately, regardless of whether any tab is open for the domain.
+func SetCookies(ctx context.Context, conn *Conn, cookies []chrome.Cookie) (int, error) {
+	if len(cookies) == 0 {
+		return 0, nil
+	}
+	params := make([]CookieParam, 0, len(cookies))
+	for _, c := range cookies {
+		cp := CookieParam{
+			Name:     c.Name,
+			Value:    c.Value,
+			Domain:   c.HostKey,
+			Path:     c.Path,
+			Secure:   c.IsSecure != 0,
+			HTTPOnly: c.IsHTTPOnly != 0,
+			SameSite: sameSiteString(c.SameSite),
+		}
+		if c.HasExpires != 0 && c.ExpiresUTC > 0 {
+			cp.Expires = float64(c.ExpiresUTC)/1e6 - chromeEpochDeltaSeconds
+		}
+		params = append(params, cp)
+	}
+	args := map[string]interface{}{"cookies": params}
+	if err := conn.Call(ctx, "Storage.setCookies", args, nil); err != nil {
+		return 0, fmt.Errorf("Storage.setCookies: %w", err)
+	}
+	return len(params), nil
+}
+
+// sameSiteString maps Chrome SQLite samesite int to CDP's enum strings. Empty
+// string means "omit the field"; CDP treats absent SameSite as the platform
+// default.
+func sameSiteString(v int) string {
+	switch v {
+	case 0:
+		return "None"
+	case 1:
+		return "Lax"
+	case 2:
+		return "Strict"
+	default:
+		// Unspecified (-1) or unknown: let Chrome decide.
+		return ""
+	}
+}

--- a/internal/cli/sink.go
+++ b/internal/cli/sink.go
@@ -1,14 +1,17 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 
+	"github.com/mvanhorn/agentcookie/internal/cdp"
 	"github.com/mvanhorn/agentcookie/internal/chrome"
 	"github.com/mvanhorn/agentcookie/internal/config"
 	"github.com/mvanhorn/agentcookie/internal/transport"
@@ -71,17 +74,49 @@ func runSink(cmd *cobra.Command, args []string) error {
 			http.Error(w, "unmarshal cookies: "+err.Error(), http.StatusBadRequest)
 			return
 		}
-		written, err := chrome.WriteCookies(cfg.Chrome.DBPath, cookies, key)
+		written, mode, err := writeCookiesToSink(r.Context(), cfg, cookies, key)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "agentcookie sink: write failed after %d cookies: %v\n", written, err)
+			fmt.Fprintf(os.Stderr, "agentcookie sink: write failed after %d cookies (mode=%s): %v\n", written, mode, err)
 			http.Error(w, fmt.Sprintf("write cookies: %v", err), http.StatusInternalServerError)
 			return
 		}
-		fmt.Fprintf(os.Stderr, "agentcookie sink: wrote %d cookies to %s\n", written, cfg.Chrome.DBPath)
-		_, _ = fmt.Fprintf(w, "ok: wrote %d cookies\n", written)
+		fmt.Fprintf(os.Stderr, "agentcookie sink: wrote %d cookies via %s\n", written, mode)
+		_, _ = fmt.Fprintf(w, "ok: wrote %d cookies via %s\n", written, mode)
 	})
 
 	srv := &http.Server{Addr: cfg.Listen.Addr, Handler: mux}
-	fmt.Fprintf(os.Stderr, "agentcookie sink: listening on http://%s (db=%s)\n", cfg.Listen.Addr, cfg.Chrome.DBPath)
+	fmt.Fprintf(os.Stderr, "agentcookie sink: listening on http://%s (db=%s cdp=%v)\n", cfg.Listen.Addr, cfg.Chrome.DBPath, cfg.CDP.Enabled)
 	return srv.ListenAndServe()
+}
+
+// writeCookiesToSink tries CDP live injection first when configured, falls
+// back to direct SQLite write. Returns the number of cookies written and the
+// mode used ("cdp" or "sqlite") so the response surfaces visibility to callers.
+func writeCookiesToSink(ctx context.Context, cfg *config.SinkConfig, cookies []chrome.Cookie, key []byte) (int, string, error) {
+	if cfg.CDP.Enabled {
+		probeCtx, cancel := context.WithTimeout(ctx, 1500*time.Millisecond)
+		defer cancel()
+		info, err := cdp.Probe(probeCtx, cfg.CDP.Host, cfg.CDP.Port)
+		if err == nil && info.WebSocketDebuggerURL != "" {
+			dialCtx, cancelDial := context.WithTimeout(ctx, 3*time.Second)
+			defer cancelDial()
+			conn, derr := cdp.Dial(dialCtx, info.WebSocketDebuggerURL)
+			if derr == nil {
+				defer conn.Close()
+				callCtx, cancelCall := context.WithTimeout(ctx, 10*time.Second)
+				defer cancelCall()
+				written, serr := cdp.SetCookies(callCtx, conn, cookies)
+				if serr == nil {
+					return written, "cdp", nil
+				}
+				fmt.Fprintf(os.Stderr, "agentcookie sink: CDP injection failed (%v), falling back to SQLite\n", serr)
+			} else {
+				fmt.Fprintf(os.Stderr, "agentcookie sink: CDP dial failed (%v), falling back to SQLite\n", derr)
+			}
+		} else if err != nil {
+			fmt.Fprintf(os.Stderr, "agentcookie sink: CDP probe failed (%v), falling back to SQLite\n", err)
+		}
+	}
+	written, err := chrome.WriteCookies(cfg.Chrome.DBPath, cookies, key)
+	return written, "sqlite", err
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,8 +28,19 @@ type SourceConfig struct {
 type SinkConfig struct {
 	Listen   ListenRef   `yaml:"listen" json:"listen"`
 	Chrome   ChromeRef   `yaml:"chrome" json:"chrome"`
+	CDP      CDPRef      `yaml:"cdp,omitempty" json:"cdp,omitempty"`
 	Peer     PeerRef     `yaml:"peer,omitempty" json:"peer,omitempty"`
 	Security SecurityRef `yaml:"security,omitempty" json:"security,omitempty"`
+}
+
+// CDPRef configures live-Chrome injection on the sink via Chrome DevTools
+// Protocol. When Enabled and the configured port is reachable, the sink
+// writes cookies through Storage.setCookies for instant in-memory visibility
+// instead of (or in addition to) the SQLite write path.
+type CDPRef struct {
+	Enabled bool   `yaml:"enabled" json:"enabled"`
+	Host    string `yaml:"host,omitempty" json:"host,omitempty"`
+	Port    int    `yaml:"port,omitempty" json:"port,omitempty"`
 }
 
 // PeerRef names the other side of a paired sync relationship. Hostname is
@@ -93,6 +104,14 @@ func LoadSink(dir string) (*SinkConfig, error) {
 	}
 	if cfg.Chrome.DBPath == "" {
 		cfg.Chrome.DBPath = DefaultChromeCookiesPath()
+	}
+	if cfg.CDP.Enabled {
+		if cfg.CDP.Host == "" {
+			cfg.CDP.Host = "127.0.0.1"
+		}
+		if cfg.CDP.Port == 0 {
+			cfg.CDP.Port = 9222
+		}
 	}
 	return &cfg, nil
 }


### PR DESCRIPTION
U4 of the AgentCookie plan: the sink now writes to a running Chrome via Chrome DevTools Protocol when available, not just to SQLite when Chrome is closed.

## What's here

\`sink.yaml\` gains a \`cdp\` block:

\`\`\`yaml
cdp:
  enabled: true
  host: 127.0.0.1
  port: 9222
\`\`\`

When enabled, on each \`/sync\` POST the sink:

1. Probes \`http://<host>:<port>/json/version\` with a 1.5s timeout.
2. If a debuggable Chrome answers, dials the browser-level webSocketDebuggerUrl.
3. Sends \`Storage.setCookies\` with one CookieParam per cookie. The cookies are visible to every page in the default browser context immediately, no tab open or restart required.
4. If any step fails, falls back to the existing SQLite write path.

The \`/sync\` response now reports the mode: \`ok: wrote N cookies via cdp\` or \`ok: wrote N cookies via sqlite\`. Callers know whether a Chrome restart is needed for in-memory visibility.

To make Chrome debuggable:

\`\`\`
open -na \"Google Chrome\" --args --remote-debugging-port=9222
\`\`\`

## Why a custom CDP client instead of chromedp

chromedp pulls ~10MB of generated CDP bindings for every method in the protocol. For v0 we use exactly one method (\`Storage.setCookies\`) plus the \`/json/version\` probe. The custom client is ~200 LOC: gorilla/websocket for the WebSocket, one mux goroutine that demultiplexes by message id, one \`Call(ctx, method, params, result)\` shape.

## Tests

\`go test ./...\` -> 35 passed in 10 packages. 5 new CDP tests:

- Probe recognizes a debuggable Chrome from \`/json/version\` payload
- Probe fails cleanly when Chrome is not reachable
- Call round-trips a method + params over a fake WebSocket server
- SetCookies with no input is a no-op (no CDP call, no error)
- SameSite int -> CDP enum mapping (None/Lax/Strict, -1 and unknown omit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)