### PR TITLE
feat(protocol): v1 envelope + sink-side allowlist + replay defense (U6)

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -1,0 +1,62 @@
+# agentcookie protocol v1
+
+This document captures the wire format between source and sink so future clients (a Linux sink, a Chrome extension on the sink, a hosted relay) can interoperate.
+
+## Layers, outside to inside
+
+1. **Transport.** HTTP over a Tailscale tailnet. POST `/sync` on the sink machine carries the sealed payload as the request body with `Content-Type: application/octet-stream`.
+2. **Authenticated encryption.** AES-256-GCM. The key is derived from the source-sink pair via X25519 + HKDF-SHA256 (see `internal/pairing`), or from the legacy `security.shared_secret` YAML field. Each message carries a fresh 12-byte nonce as the first 12 bytes of the ciphertext; the GCM tag is appended automatically. Wrong-secret payloads are rejected by the AEAD tag check.
+3. **Envelope.** Inside the seal, the plaintext is a JSON `SyncEnvelope`.
+
+## SyncEnvelope (JSON)
+
+```
+{
+  "protocol_version": 1,
+  "source_hostname": "my-laptop.tailnet.ts.net",
+  "sequence": 1747432817,
+  "cookies": [ { ... }, { ... } ]
+}
+```
+
+Field-by-field:
+
+- `protocol_version` (int, required). Sinks reject envelopes whose value does not equal the sink's compiled-in version. Bumping the version is a breaking change.
+- `source_hostname` (string, required). The source's announced hostname. The sink uses this as the key in its replay-defense bookkeeping. The same hostname appears in the paired key file under `~/.config/agentcookie/keys/`.
+- `sequence` (int64, required). Monotonically increasing per source. Sinks reject an envelope whose `sequence` is less than or equal to the highest sequence seen for that source since process start. The source uses `time.Now().Unix()` by default; any monotonically increasing source is acceptable.
+- `cookies` (array, required). Each cookie matches the `chrome.Cookie` Go struct: `host_key`, `name`, `value` (plaintext after source-side decrypt), `path`, `expires_utc`, `is_secure`, `is_httponly`, `last_access_utc`, `has_expires`, `is_persistent`, `priority`, `samesite`, `source_scheme`, `source_port`. Values are integers and strings, never raw bytes.
+
+## Sink validation order
+
+1. Decrypt the body with the configured shared/paired key. Reject `401 Unauthorized` on failure.
+2. JSON-unmarshal the envelope. Reject `400 Bad Request` on failure.
+3. Check `protocol_version == 1`. Reject `400` with a clear message otherwise.
+4. Check `sequence` against the in-memory tracker for `source_hostname`. Reject `409 Conflict` if not strictly greater than the last seen value.
+5. Filter `cookies` against the sink's local `allowlist.yaml`. Cookies whose `host_key` matches no pattern are silently dropped; the sink logs the dropped host counts and reports them to the source via the response body.
+6. Write the remaining cookies. CDP path first if `cdp.enabled` and Chrome reachable; otherwise SQLite path.
+
+## Replay defense (v0.1 limits)
+
+The sequence tracker is in-memory only. Restarting the sink clears it; a captured payload could be replayed once after a restart. Durable replay defense is a v0.2 follow-up; the envelope is shaped so it can absorb a timestamp window or a server-issued nonce without breaking the version.
+
+## Allowlist (sink side, defense in depth)
+
+The sink reads `~/.config/agentcookie/allowlist.yaml` independently of the source. If the source pushes a cookie for a host the sink has not allowlisted, the sink drops it. This means the sink owner has the final say on what state may land in their Chrome, even if the paired source is fully compromised. The source-side allowlist still runs first as a bandwidth and privacy optimization (no point sealing cookies that will be dropped).
+
+Allowlist schema:
+
+```yaml
+version: 1
+domains:
+  - pattern: "%instacart.com"
+    description: ...
+  - pattern: "%granola.so"
+```
+
+Patterns use SQLite LIKE semantics (`%` wildcard). Matching is case-insensitive and matches against Chrome's `host_key` column, which includes a leading dot for subdomain cookies.
+
+## Versioning
+
+- v1 is the current wire format. Source and sink must both speak it.
+- Future versions: bump `protocol_version` and update both source and sink. Sinks may carry compatibility shims for one prior version during transition windows.
+- Out-of-band fields (e.g. allowlist sync, signed bundles, cookie diffs) will arrive as additional optional envelope fields under v1 first, then potentially graduate to required in v2.

--- a/internal/cli/sink.go
+++ b/internal/cli/sink.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mvanhorn/agentcookie/internal/cdp"
 	"github.com/mvanhorn/agentcookie/internal/chrome"
 	"github.com/mvanhorn/agentcookie/internal/config"
+	"github.com/mvanhorn/agentcookie/internal/protocol"
 	"github.com/mvanhorn/agentcookie/internal/transport"
 )
 
@@ -50,6 +51,19 @@ func runSink(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Sink-side allowlist (optional but recommended defense in depth). If the
+	// file is missing, log a warning and accept all decrypted cookies; the
+	// source still filters its own side.
+	var allowMatcher *protocol.AllowlistMatcher
+	if al, alErr := config.LoadAllowlist(common.ConfigDir); alErr == nil {
+		allowMatcher = protocol.NewAllowlistMatcher(al)
+		fmt.Fprintf(os.Stderr, "agentcookie sink: allowlist loaded with %d patterns\n", len(al.Domains))
+	} else {
+		fmt.Fprintf(os.Stderr, "agentcookie sink: no allowlist found (%v); accepting all source-pushed cookies\n", alErr)
+	}
+
+	seqTracker := protocol.NewSequenceTracker()
+
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		_, _ = fmt.Fprintln(w, "ok")
@@ -69,19 +83,39 @@ func runSink(cmd *cobra.Command, args []string) error {
 			http.Error(w, "open payload: "+err.Error(), http.StatusUnauthorized)
 			return
 		}
-		var cookies []chrome.Cookie
-		if err := json.Unmarshal(plaintext, &cookies); err != nil {
-			http.Error(w, "unmarshal cookies: "+err.Error(), http.StatusBadRequest)
+		var envelope protocol.SyncEnvelope
+		if err := json.Unmarshal(plaintext, &envelope); err != nil {
+			http.Error(w, "unmarshal envelope: "+err.Error(), http.StatusBadRequest)
 			return
 		}
+		if envelope.ProtocolVersion != protocol.Version {
+			http.Error(w, fmt.Sprintf("protocol version mismatch: got %d, sink speaks %d", envelope.ProtocolVersion, protocol.Version), http.StatusBadRequest)
+			return
+		}
+		if !seqTracker.Accept(envelope.SourceHostname, envelope.Sequence) {
+			http.Error(w, fmt.Sprintf("sequence %d not greater than last seen for %q (replay defense)", envelope.Sequence, envelope.SourceHostname), http.StatusConflict)
+			return
+		}
+
+		// Sink-side allowlist filter (defense in depth).
+		cookies := envelope.Cookies
+		var droppedHosts map[string]int
+		if allowMatcher != nil {
+			cookies, droppedHosts = allowMatcher.Filter(cookies)
+		}
+
 		written, mode, err := writeCookiesToSink(r.Context(), cfg, cookies, key)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "agentcookie sink: write failed after %d cookies (mode=%s): %v\n", written, mode, err)
 			http.Error(w, fmt.Sprintf("write cookies: %v", err), http.StatusInternalServerError)
 			return
 		}
-		fmt.Fprintf(os.Stderr, "agentcookie sink: wrote %d cookies via %s\n", written, mode)
-		_, _ = fmt.Fprintf(w, "ok: wrote %d cookies via %s\n", written, mode)
+		dropped := 0
+		for _, n := range droppedHosts {
+			dropped += n
+		}
+		fmt.Fprintf(os.Stderr, "agentcookie sink: wrote %d cookies via %s (dropped %d non-allowlisted)\n", written, mode, dropped)
+		_, _ = fmt.Fprintf(w, "ok: wrote %d cookies via %s; dropped %d non-allowlisted\n", written, mode, dropped)
 	})
 
 	srv := &http.Server{Addr: cfg.Listen.Addr, Handler: mux}

--- a/internal/cli/source.go
+++ b/internal/cli/source.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/mvanhorn/agentcookie/internal/chrome"
 	"github.com/mvanhorn/agentcookie/internal/config"
+	"github.com/mvanhorn/agentcookie/internal/pairing"
+	"github.com/mvanhorn/agentcookie/internal/protocol"
 	"github.com/mvanhorn/agentcookie/internal/transport"
 )
 
@@ -95,9 +97,15 @@ func runSource(cmd *cobra.Command, args []string) error {
 		return emit(result, fmt.Sprintf("agentcookie source: %d cookies across %d patterns (dry-run=%v)\n", len(all), len(byPattern), sourceDryRun))
 	}
 
-	payload, err := json.Marshal(all)
+	envelope := protocol.SyncEnvelope{
+		ProtocolVersion: protocol.Version,
+		SourceHostname:  pairing.LocalHostname(),
+		Sequence:        time.Now().Unix(),
+		Cookies:         all,
+	}
+	payload, err := json.Marshal(envelope)
 	if err != nil {
-		return fmt.Errorf("marshal cookies: %w", err)
+		return fmt.Errorf("marshal envelope: %w", err)
 	}
 	secret, err := resolveTransportSecret(common.ConfigDir, cfg.Peer.Hostname, cfg.Security.SharedSecret)
 	if err != nil {

--- a/internal/protocol/allowlist.go
+++ b/internal/protocol/allowlist.go
@@ -1,0 +1,89 @@
+package protocol
+
+import (
+	"strings"
+
+	"github.com/mvanhorn/agentcookie/internal/chrome"
+	"github.com/mvanhorn/agentcookie/internal/config"
+)
+
+// AllowlistMatcher checks whether a cookie's host_key matches any of the
+// configured patterns. Patterns mirror SQLite LIKE semantics: '%' is a
+// wildcard, anything else matches literally. This keeps the source and sink
+// using the same matching rules.
+type AllowlistMatcher struct {
+	patterns []string
+}
+
+// NewAllowlistMatcher returns a matcher built from the given allowlist.
+// Patterns are normalized to lowercase for case-insensitive matching.
+func NewAllowlistMatcher(al *config.Allowlist) *AllowlistMatcher {
+	if al == nil {
+		return &AllowlistMatcher{}
+	}
+	patterns := make([]string, 0, len(al.Domains))
+	for _, d := range al.Domains {
+		if d.Pattern != "" {
+			patterns = append(patterns, strings.ToLower(d.Pattern))
+		}
+	}
+	return &AllowlistMatcher{patterns: patterns}
+}
+
+// MatchesHost reports whether host matches at least one configured pattern.
+func (m *AllowlistMatcher) MatchesHost(host string) bool {
+	if m == nil || len(m.patterns) == 0 {
+		return false
+	}
+	h := strings.ToLower(host)
+	for _, p := range m.patterns {
+		if matchLike(p, h) {
+			return true
+		}
+	}
+	return false
+}
+
+// Filter returns only the cookies whose HostKey matches the allowlist. Stats
+// returns the count of accepted and dropped cookies for logging.
+func (m *AllowlistMatcher) Filter(cookies []chrome.Cookie) (accepted []chrome.Cookie, droppedHosts map[string]int) {
+	droppedHosts = map[string]int{}
+	for _, c := range cookies {
+		if m.MatchesHost(c.HostKey) {
+			accepted = append(accepted, c)
+		} else {
+			droppedHosts[c.HostKey]++
+		}
+	}
+	return accepted, droppedHosts
+}
+
+// matchLike implements SQLite-style LIKE matching for our pattern language:
+// '%' matches any sequence of characters (including empty), all other
+// characters match literally. Case-insensitive on the caller's behalf.
+func matchLike(pattern, s string) bool {
+	// Recursive scan; pattern length is small (single hostname), so no risk.
+	if pattern == "" {
+		return s == ""
+	}
+	if pattern[0] == '%' {
+		// Try matching '%' to each suffix of s.
+		rest := pattern[1:]
+		if matchLike(rest, s) {
+			return true
+		}
+		for i := 0; i < len(s); i++ {
+			if matchLike(rest, s[i+1:]) {
+				return true
+			}
+		}
+		return false
+	}
+	if len(s) == 0 {
+		return false
+	}
+	if pattern[0] == s[0] {
+		return matchLike(pattern[1:], s[1:])
+	}
+	return false
+}

--- a/internal/protocol/envelope.go
+++ b/internal/protocol/envelope.go
@@ -1,0 +1,25 @@
+// Package protocol defines the wire format the source uses to send sync
+// payloads to the sink. The envelope carries a protocol version, the source's
+// announced hostname, a monotonic sequence number for replay defense, and
+// the cookie batch itself. Future versions may add diffs and signed
+// allowlists; today's envelope is full-set semantics (every paired domain's
+// current cookies in one batch).
+//
+// See docs/protocol.md for the spec.
+package protocol
+
+import (
+	"github.com/mvanhorn/agentcookie/internal/chrome"
+)
+
+// Version is the current wire protocol version. Sinks reject envelopes whose
+// version does not match.
+const Version = 1
+
+// SyncEnvelope is the JSON shape sent inside the AES-GCM seal.
+type SyncEnvelope struct {
+	ProtocolVersion int             `json:"protocol_version"`
+	SourceHostname  string          `json:"source_hostname"`
+	Sequence        int64           `json:"sequence"`
+	Cookies         []chrome.Cookie `json:"cookies"`
+}

--- a/internal/protocol/jsonshim_test.go
+++ b/internal/protocol/jsonshim_test.go
@@ -1,0 +1,8 @@
+package protocol
+
+import "encoding/json"
+
+// Test-only shims so the test file can avoid pulling encoding/json into the
+// production envelope.go.
+func jsonMarshal(v any) ([]byte, error)    { return json.Marshal(v) }
+func jsonUnmarshal(b []byte, v any) error  { return json.Unmarshal(b, v) }

--- a/internal/protocol/protocol_test.go
+++ b/internal/protocol/protocol_test.go
@@ -1,0 +1,156 @@
+package protocol
+
+import (
+	"testing"
+
+	"github.com/mvanhorn/agentcookie/internal/chrome"
+	"github.com/mvanhorn/agentcookie/internal/config"
+)
+
+func TestSequenceTrackerAcceptsMonotonic(t *testing.T) {
+	st := NewSequenceTracker()
+	if !st.Accept("laptop", 100) {
+		t.Fatal("first sequence must be accepted")
+	}
+	if !st.Accept("laptop", 200) {
+		t.Fatal("higher sequence must be accepted")
+	}
+	if st.Accept("laptop", 200) {
+		t.Fatal("equal sequence must be rejected (replay)")
+	}
+	if st.Accept("laptop", 150) {
+		t.Fatal("lower sequence must be rejected (replay)")
+	}
+	if st.Last("laptop") != 200 {
+		t.Errorf("expected last=200, got %d", st.Last("laptop"))
+	}
+}
+
+func TestSequenceTrackerIsolatesSources(t *testing.T) {
+	st := NewSequenceTracker()
+	st.Accept("laptop-a", 100)
+	if !st.Accept("laptop-b", 50) {
+		t.Fatal("sequence on a different source should be accepted independently")
+	}
+	if st.Last("laptop-a") != 100 || st.Last("laptop-b") != 50 {
+		t.Errorf("per-source state leaked: a=%d b=%d", st.Last("laptop-a"), st.Last("laptop-b"))
+	}
+}
+
+func TestAllowlistMatcher(t *testing.T) {
+	al := &config.Allowlist{
+		Version: 1,
+		Domains: []config.AllowlistEntry{
+			{Pattern: "%instacart.com"},
+			{Pattern: "%granola.so"},
+			{Pattern: "exact.example.com"},
+		},
+	}
+	m := NewAllowlistMatcher(al)
+	cases := map[string]bool{
+		"www.instacart.com": true,
+		"instacart.com":     true,
+		".instacart.com":    true,
+		"foo.granola.so":    true,
+		"exact.example.com": true,
+		"INSTACART.COM":     true, // case-insensitive
+		"not-allowed.com":   false,
+		"":                  false,
+	}
+	for host, want := range cases {
+		got := m.MatchesHost(host)
+		if got != want {
+			t.Errorf("MatchesHost(%q) = %v, want %v", host, got, want)
+		}
+	}
+}
+
+func TestAllowlistFilterCountsDropped(t *testing.T) {
+	al := &config.Allowlist{
+		Version: 1,
+		Domains: []config.AllowlistEntry{{Pattern: "%instacart.com"}},
+	}
+	m := NewAllowlistMatcher(al)
+	cookies := []chrome.Cookie{
+		{HostKey: "www.instacart.com", Name: "session"},
+		{HostKey: "instacart.com", Name: "csrf"},
+		{HostKey: "evil.com", Name: "tracker"},
+		{HostKey: "another-bad.com", Name: "ad"},
+		{HostKey: "evil.com", Name: "second-tracker"},
+	}
+	accepted, dropped := m.Filter(cookies)
+	if len(accepted) != 2 {
+		t.Errorf("expected 2 accepted, got %d", len(accepted))
+	}
+	if dropped["evil.com"] != 2 {
+		t.Errorf("expected evil.com dropped=2, got %d", dropped["evil.com"])
+	}
+	if dropped["another-bad.com"] != 1 {
+		t.Errorf("expected another-bad.com dropped=1, got %d", dropped["another-bad.com"])
+	}
+}
+
+func TestAllowlistMatcherEmpty(t *testing.T) {
+	// Empty allowlist rejects everything (defense in depth: no allowlist
+	// means no opt-ins, so nothing flows).
+	m := NewAllowlistMatcher(&config.Allowlist{Version: 1})
+	if m.MatchesHost("anything.com") {
+		t.Error("empty allowlist must not match")
+	}
+	m2 := NewAllowlistMatcher(nil)
+	if m2.MatchesHost("anything.com") {
+		t.Error("nil allowlist must not match")
+	}
+}
+
+func TestMatchLike(t *testing.T) {
+	cases := []struct {
+		pattern, s string
+		want       bool
+	}{
+		{"%instacart.com", "www.instacart.com", true},
+		{"%instacart.com", "instacart.com", true},
+		{"%instacart.com", "instacart.com.evil.com", false},
+		{"exact", "exact", true},
+		{"exact", "exactly", false},
+		{"%", "anything", true},
+		{"%", "", true},
+		{"%foo%", "barfoofoo", true},
+		{"%foo%", "bar", false},
+	}
+	for _, c := range cases {
+		got := matchLike(c.pattern, c.s)
+		if got != c.want {
+			t.Errorf("matchLike(%q, %q) = %v, want %v", c.pattern, c.s, got, c.want)
+		}
+	}
+}
+
+func TestEnvelopeJSONRoundTrip(t *testing.T) {
+	// Sanity: JSON marshal + unmarshal preserves all fields, including the
+	// cookies slice with all flags.
+	original := SyncEnvelope{
+		ProtocolVersion: Version,
+		SourceHostname:  "laptop.tail.ts.net",
+		Sequence:        12345,
+		Cookies: []chrome.Cookie{
+			{HostKey: "x.com", Name: "a", Value: "1", Path: "/", IsSecure: 1, SameSite: 2, ExpiresUTC: 99},
+		},
+	}
+	data, err := jsonMarshal(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got SyncEnvelope
+	if err := jsonUnmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.ProtocolVersion != original.ProtocolVersion ||
+		got.SourceHostname != original.SourceHostname ||
+		got.Sequence != original.Sequence ||
+		len(got.Cookies) != 1 ||
+		got.Cookies[0].HostKey != "x.com" ||
+		got.Cookies[0].SameSite != 2 {
+		t.Errorf("round-trip lost fields: %+v", got)
+	}
+}

--- a/internal/protocol/sequence.go
+++ b/internal/protocol/sequence.go
@@ -1,0 +1,40 @@
+package protocol
+
+import (
+	"sync"
+)
+
+// SequenceTracker is the sink's in-memory record of the highest Sequence
+// number seen per source. Rejects equal-or-lower numbers to defend against
+// replay of captured payloads. State is process-local; it resets on restart,
+// at which point a stale captured payload could once again be played. That
+// trade-off is acceptable for v0.1; durable replay defense lands when the
+// envelope grows a nonce or timestamp window.
+type SequenceTracker struct {
+	mu   sync.Mutex
+	seen map[string]int64
+}
+
+// NewSequenceTracker returns a fresh tracker.
+func NewSequenceTracker() *SequenceTracker {
+	return &SequenceTracker{seen: make(map[string]int64)}
+}
+
+// Accept returns true if seq is strictly greater than the highest previously
+// seen value for source. Updates the record on accept.
+func (t *SequenceTracker) Accept(source string, seq int64) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if last, ok := t.seen[source]; ok && seq <= last {
+		return false
+	}
+	t.seen[source] = seq
+	return true
+}
+
+// Last returns the highest sequence seen for source, or 0 if none.
+func (t *SequenceTracker) Last(source string) int64 {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.seen[source]
+}


### PR DESCRIPTION
U6 of the AgentCookie plan: lock down the wire format and give the sink defense in depth.

## What's here

**SyncEnvelope** wraps every /sync payload:

\`\`\`json
{
  \"protocol_version\": 1,
  \"source_hostname\": \"my-laptop.tail.ts.net\",
  \"sequence\": 1747432817,
  \"cookies\": [ ... ]
}
\`\`\`

The sink now performs five validation steps on each request:

1. Decrypt with paired key (AES-GCM tag check)
2. Unmarshal the envelope
3. \`protocol_version == 1\` or reject 400
4. \`sequence\` strictly greater than the highest seen for that source, or reject 409 (in-memory replay defense, resets on restart, durable variant in v0.2)
5. Drop cookies whose host_key matches no allowlisted pattern in the sink's OWN allowlist.yaml

The sink-side allowlist is the key new defense: the sink owner controls what state lands in their Chrome even if the paired source is compromised. Source still filters first as a bandwidth and privacy optimization.

## docs/protocol.md

Captures the layered wire format end to end (transport -> AES-GCM seal -> JSON envelope -> chrome.Cookie) so future clients (Linux sink, Chrome extension, hosted relay) can interoperate. Versioning policy spelled out: bumping \`protocol_version\` is a breaking change; new optional envelope fields land under v1 first before graduating to v2-required.

## Tests

\`go test ./...\` -> 42 passed in 11 packages. 7 new in \`internal/protocol\`:

- Sequence tracker accepts monotonic and rejects equal/lower (replay defense)
- Sequence tracker isolates per source (one source's progress doesn't poison another's)
- Allowlist matcher: case-insensitive, leading-dot subdomain cookies, exact + wildcard patterns
- Filter returns dropped-host counts for sink logging
- Empty allowlist matches nothing (defense in depth: no opt-ins -> nothing flows)
- matchLike SQLite-LIKE semantics (\`%\` wildcard, literal otherwise)
- Envelope JSON round-trip preserves all fields including cookie flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)