### PR TITLE
docs+skill: install skill, threat model, architecture, quickstart, FAQ (U8+U9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,53 +4,57 @@ Peer-to-peer Chrome session replication for AI agents.
 
 Your laptop is logged in to everything. Your AI agents run on a different machine (Mac mini, cloud VM, whatever) and aren't. That gap is `agentcookie`.
 
+## Why
+
+Existing cookie-sync tools are built for humans switching accounts between two laptops they both touch. They assume someone will click "Merge" or open Chrome periodically. agentcookie is built for the opposite workflow: continuous, one-way, unattended replication from the machine you live in to the machine your AI agents act from. No browser required on the sink. No third-party data plane. Pairing-derived keys, allowlists on both sides.
+
 ## Status
 
-Pre-release. v0.1 in active development.
+Pre-release. v0.1 in active development. Watch the repo for the launch announcement.
 
-What works today:
+### What works today
 
-- Unified `agentcookie` CLI with subcommands: `source`, `sink`, `pair`, `status`, `version`. All support `--json` output for agent callers.
-- Cookie acquisition on macOS: reads Chrome's Cookies SQLite read-only with `immutable=1`, decrypts with the per-machine Chrome Safe Storage key (PBKDF2-SHA1 of the Keychain password, salt `saltysalt`, 1003 iters, IV = 16 spaces, AES-128-CBC, `v10` prefix).
-- Cookie write on macOS: schema-aware INSERT ... ON CONFLICT that adapts to Chrome's evolving column set (`top_frame_site_key`, `source_type`, `has_cross_site_ancestor`).
-- Pairing handshake: `agentcookie pair --as source` on the laptop prints a one-time 8-char base32 code. Within 10 minutes, `agentcookie pair --as sink --peer <source-host> --pair-url ... --code <code>` on the Mac mini runs an X25519 exchange authenticated by the code. Both sides derive a 32-byte symmetric key via HKDF-SHA256 (info `agentcookie-pair-v1`) and write it to `~/.config/agentcookie/keys/<peer>.json` at mode 0600.
-- Transport: AES-GCM over HTTP. After pairing, both sides look up the per-peer key by `peer.hostname` in the YAML config. Legacy `security.shared_secret` still accepted as fallback.
-- 30 unit tests across `internal/chrome`, `internal/transport`, `internal/config`, `internal/keystore`, `internal/pairing`.
+- Unified `agentcookie` CLI: `source`, `sink`, `pair`, `status`, `version`. All support `--json` for agent callers.
+- Pairing handshake: X25519 + HKDF-SHA256 salted with a one-time code. Derived 32-byte keys land at `~/.config/agentcookie/keys/<peer>.json` mode 0600.
+- Cookie acquisition on macOS: read Chrome cookies SQLite read-only with `immutable=1`, decrypt v10 ciphertext using the Keychain Safe Storage key.
+- Cookie write: schema-aware INSERT ... ON CONFLICT that adapts to Chrome's evolving column set (`top_frame_site_key`, `source_type`, `has_cross_site_ancestor`).
+- Live-Chrome injection: sink probes Chrome's DevTools port and uses `Storage.setCookies` for instant in-memory visibility. Falls back to SQLite write if Chrome isn't debuggable.
+- Wire protocol v1: versioned `SyncEnvelope` with monotonic Sequence (replay defense), source hostname, cookies. Documented in `docs/protocol.md`.
+- Sink-side allowlist enforcement: defense in depth even if the source is compromised.
+- AES-256-GCM transport over HTTP, layered on top of the Tailscale tailnet's WireGuard channel.
+- 42 unit tests across `internal/chrome`, `internal/transport`, `internal/config`, `internal/keystore`, `internal/pairing`, `internal/cdp`, `internal/protocol`.
 
-What does not yet exist:
+### What's coming
 
-- Long-lived watch mode (fsnotify-driven continuous sync) -- planned in U6 of the roadmap.
-- Live-Chrome injection on the sink via CDP (today the sink writes only when Chrome is closed) -- U4.
-- Signed allowlist sync source-to-sink with sink-side enforcement -- U6.
-- macOS Keychain storage for derived keys (today the keys are in `~/.config/agentcookie/keys/` at 0600) -- v0.2.
-- Threat-model docs, install skill, brand decision, marketing site, public launch -- U7-U11.
+- Long-lived watch mode (fsnotify-driven continuous sync). Today `agentcookie source --once` covers the cron / launchd loop.
+- macOS Keychain storage for derived keys. Today the keys live in `~/.config/agentcookie/keys/` at mode 0600.
+- `agentcookie pair --rotate` for live key rotation.
+- Durable replay defense (nonce or timestamp window in the envelope).
+- One-to-many fan-out.
+- Linux sink support.
 
 ## Quickstart
 
+See [docs/quickstart.md](docs/quickstart.md) for the full five-minute install. Short version:
+
 ```
-# 1. Install (both machines)
 go install github.com/mvanhorn/agentcookie/cmd/agentcookie@latest
-
-# 2. Copy example configs
-mkdir -p ~/.config/agentcookie
-cp examples/source.yaml ~/.config/agentcookie/source.yaml  # on laptop
-cp examples/sink.yaml ~/.config/agentcookie/sink.yaml      # on Mac mini
-cp examples/allowlist.yaml ~/.config/agentcookie/allowlist.yaml  # on laptop
-
-# 3. Pair (laptop first)
-agentcookie pair --as source
-# Prints: code XYZW-ABCD; URL http://<laptop-tailnet>:9998/pair
-
-# Then on Mac mini, within 10 minutes:
-agentcookie pair --as sink --peer <laptop-tailnet> \
-  --pair-url http://<laptop-tailnet>:9998/pair --code XYZW-ABCD
-
-# 4. Run sink (Mac mini, long-lived)
-agentcookie sink
-
-# 5. Sync once (laptop)
-agentcookie source --once
+# Drop ~/.config/agentcookie/source.yaml + allowlist.yaml on laptop
+# Drop ~/.config/agentcookie/sink.yaml + allowlist.yaml on Mac mini
+agentcookie pair --as source     # on laptop, prints code
+agentcookie pair --as sink ...   # on Mac mini, with the code
+agentcookie sink                 # long-lived on Mac mini
+agentcookie source --once        # one-shot sync on laptop (cron this)
 ```
+
+## Documentation
+
+- [Quickstart](docs/quickstart.md): five-minute install on a laptop-and-Mac-mini pair
+- [Architecture](docs/architecture.md): module layout, sync lifecycle, pairing lifecycle, security boundaries
+- [Protocol v1](docs/protocol.md): wire format spec for future client implementations
+- [Threat model](docs/threat-model.md): what agentcookie does and does not protect against
+- [FAQ](docs/faq.md): common questions
+- [Install skill](skill/SKILL.md): Claude Code / gstack-style skill for an agent to drive the install
 
 ## License
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,85 @@
+# agentcookie architecture
+
+## The picture
+
+```
+        SOURCE (laptop)                                  SINK (Mac mini / cloud VM)
+   +---------------------------+                    +-----------------------------+
+   |  Chrome stable            |                    |  Chrome stable              |
+   |    Cookies SQLite         |                    |    Cookies SQLite           |
+   |    Safe Storage (Keychain)|                    |    Safe Storage (Keychain)  |
+   |                           |                    |                             |
+   |  agentcookie source       |                    |  agentcookie sink (launchd) |
+   |    - read SQLite (RO)     |                    |    - listen :9999/sync      |
+   |    - decrypt w/ local key |     AES-GCM        |    - decrypt seal           |
+   |    - filter by allowlist  |    over HTTPS      |    - check proto + seq      |
+   |    - wrap in envelope     | ================>  |    - filter by allowlist    |
+   |    - seal w/ peer key     |    on tailnet      |    - try CDP injection      |
+   |                           |                    |    - else write SQLite      |
+   +---------------------------+                    +-----------------------------+
+            ^                                                  ^
+            |                                                  |
+            +-----------  Tailscale tailnet  ------------------+
+            |             (WireGuard, ACLs)                    |
+            +--------------------------------------------------+
+```
+
+## Module layout
+
+| Package | Purpose |
+|---------|---------|
+| `cmd/agentcookie` | CLI entry point (cobra). |
+| `internal/cli` | Subcommand implementations: `source`, `sink`, `pair`, `status`, `version`. |
+| `internal/chrome` | Read + decrypt Chrome cookies on macOS via Keychain Safe Storage + SQLite. Schema-aware INSERT for the write path. |
+| `internal/transport` | AES-GCM seal/open with key = SHA-256(secret). |
+| `internal/config` | YAML loaders for `source.yaml`, `sink.yaml`, `allowlist.yaml`. Tilde expansion, defaults, validation. |
+| `internal/pairing` | X25519 + HKDF handshake. Source listens for pairing; sink connects with the printed code. Both sides derive identical 32-byte keys. |
+| `internal/keystore` | Per-peer key files at `~/.config/agentcookie/keys/<peer>.json` mode 0600. |
+| `internal/protocol` | `SyncEnvelope` (versioned), `SequenceTracker` (in-memory replay defense), `AllowlistMatcher` (SQLite-LIKE patterns, case-insensitive). |
+| `internal/cdp` | Tiny Chrome DevTools Protocol client: `Probe` + `Dial` + `Call`. One method we care about: `Storage.setCookies`. |
+
+## Lifecycle: one sync
+
+1. `agentcookie source --once` runs on the laptop.
+2. Reads `~/.config/agentcookie/source.yaml` for sink URL and `peer.hostname`.
+3. Reads `~/.config/agentcookie/allowlist.yaml` for domain patterns.
+4. Loads the paired key for `peer.hostname` from `~/.config/agentcookie/keys/`.
+5. Calls `security find-generic-password` to get Chrome Safe Storage; derives the per-machine AES key.
+6. Opens Chrome's Cookies SQLite read-only with `immutable=1`. Selects rows matching each allowlist pattern.
+7. Decrypts each `encrypted_value` (v10 prefix, AES-128-CBC, IV = 16 spaces, PKCS#7).
+8. Wraps the cookies in a `SyncEnvelope` with version, hostname, monotonic Sequence.
+9. AES-GCM-seals the envelope with the paired key.
+10. POSTs to the sink's `/sync` URL.
+
+On the sink, in the `/sync` handler:
+
+1. Reads the raw bytes.
+2. Loads the paired key for the configured source hostname; AES-GCM-opens the payload. Wrong key -> 401.
+3. JSON-unmarshals the `SyncEnvelope`.
+4. Checks `ProtocolVersion == 1`. Mismatch -> 400.
+5. Checks `Sequence` against the in-memory `SequenceTracker`. Replay -> 409.
+6. Filters cookies against the sink's own `allowlist.yaml`. Dropped hosts are counted for logging.
+7. If `cdp.enabled`, probes `http://<host>:<port>/json/version`, dials the browser-level WebSocket, sends `Storage.setCookies`. On any failure, falls back to step 8.
+8. Otherwise opens the sink's Cookies SQLite read-write, re-encrypts each value with the SINK's Chrome Safe Storage key, upserts rows via a schema-aware INSERT ... ON CONFLICT (handles Chrome's `top_frame_site_key`, `source_type`, `has_cross_site_ancestor` columns dynamically).
+
+## Lifecycle: pairing
+
+1. Source: `agentcookie pair --as source` generates an X25519 ephemeral keypair and a fresh base32 code (e.g. `YILU-OIVK`). Listens on `:9998/pair`. Prints the code and the sink-run command.
+2. Sink: `agentcookie pair --as sink --peer <source-host> --pair-url ... --code YILU-OIVK` generates its own X25519 keypair, POSTs `(code, sink_pub, sink_hostname)` to source.
+3. Source checks the code (constant-time compare). Computes `shared = X25519(source_priv, sink_pub)`. Derives `key = HKDF-SHA256(shared, salt=code, info="agentcookie-pair-v1")[:32]`. Replies with `(source_pub, source_hostname, fingerprint)`.
+4. Sink computes the same `shared`, derives the same key. Verifies the source's fingerprint matches its own. Writes the key to `~/.config/agentcookie/keys/<source-host>.json` mode 0600.
+5. Source's listener shuts down; the key it derived is also written to disk on the source side, keyed by the sink's hostname.
+
+## Where the security boundaries are
+
+| Boundary | Enforced by |
+|----------|------------|
+| OS user separation on source and sink | macOS user accounts, file mode 0600 on key files and configs |
+| Cookie value at rest | Chrome Safe Storage per-machine AES key + Keychain access prompt |
+| Cookie value in transit | AES-GCM with paired key + Tailscale WireGuard channel |
+| Pairing authenticity | Pairing code mixed into HKDF salt; MITM derives different key |
+| Sink-side opt-in | `allowlist.yaml` on sink; cookies for non-allowlisted hosts are dropped before writing |
+| Replay defense | `SequenceTracker` in sink memory; rejects equal-or-lower Sequence |
+| Protocol stability | `ProtocolVersion` int in every envelope; breaking changes bump the number |
+
+See [threat-model.md](threat-model.md) for what each of these protects against and what they don't.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,64 @@
+# agentcookie FAQ
+
+## Why not just use a Chrome extension to sync cookies?
+
+Existing extensions (sync-my-cookie, sync-your-cookie, cookie-share) are built for humans switching accounts between two laptops they both touch interactively. They assume someone will click "Merge" or open Chrome periodically. The agentcookie target is the opposite: continuous one-way replication from a laptop you live in to a Mac mini or cloud VM where AI agents act on your behalf, with no human in the loop on the sink side.
+
+You can certainly stack agentcookie with an extension if you want; they don't fight. But on its own, agentcookie covers the agent-operator workflow without requiring a browser to be running on the sink at all.
+
+## Why Tailscale?
+
+Because the alternative is a hosted relay, which is a third-party data plane for highly sensitive material (session cookies), and that bar is too high for a v0.1 personal-use tool. Tailscale gives end-to-end WireGuard between your devices with zero infrastructure on your part. agentcookie layers its own AEAD on top so the wire format would survive a transport swap (raw SSH, Cloudflare Tunnel, S3-as-bus); Tailscale is the v0.1 default because it works for almost everyone in the target audience already.
+
+## Why doesn't agentcookie sync Firefox / Safari / Arc / Brave / Edge?
+
+Firefox and Safari have different cookie stores entirely; supporting them is real work and would split test surface, so v0.1 stays Chrome stable on macOS. Chromium-derived browsers (Arc, Brave, Edge, Vivaldi) share the cookie format with Chrome and are easy follow-ups - file an issue and they likely land in v0.2.
+
+## What about Linux sinks?
+
+On the roadmap. The two pieces that change: Chrome's Safe Storage on Linux uses libsecret (`secret-tool`) with a different encryption flag (v10 vs v11), and there's no macOS Keychain for storing paired keys. Both are tractable but were out of scope for v0.1.
+
+## Will syncing cookies log me out of sites on the source machine?
+
+No. The source reads cookies with `immutable=1` (Chrome's recommended read-only flag), and `agentcookie source` never writes to the source's Cookies SQLite. The only writes happen on the sink.
+
+## My agent gets logged out on a particular site after syncing - what happened?
+
+A few sites bind a session to a device fingerprint (canvas, screen size, accept-language, sometimes TLS JA3). Replicating the cookie alone is not enough; the site invalidates the session because the fingerprint differs. agentcookie cannot fix this in v0.1. Workarounds: remove the site from your allowlist and re-auth in the sink's Chrome directly, or use the pair-agent style remote-browser pattern for those sites.
+
+## Can I use one source with multiple sinks?
+
+Not in v0.1. One-to-many fan-out is a planned v0.2 feature. The protocol envelope is shaped so the sink doesn't need to know about other sinks, but the source-side state and config are single-peer today.
+
+## What's in the keystore on disk?
+
+`~/.config/agentcookie/keys/<peer>.json` is a small JSON file at mode 0600 containing the 32-byte paired key (base64), the peer hostname, paired_at timestamp, key fingerprint, and protocol version. macOS Keychain storage is a v0.2 hardening item; today the file mode + your OS user separation is the protection.
+
+## Why is the sink's allowlist independent from the source's?
+
+Defense in depth. The source filters cookies before sending (bandwidth + privacy optimization), but the sink owner ultimately controls what state lands in their Chrome. If the source machine is fully compromised and an attacker tries to push cookies for new domains, the sink-side allowlist drops them. Keep both allowlists in sync if you want the simplest behavior; let them diverge if you want the sink to be more conservative than the source.
+
+## What about durable replay defense?
+
+In v0.1, the sink rejects an envelope whose Sequence is not strictly greater than the highest seen for that source - but the state is in-memory, so a sink restart clears it and an attacker who captured a payload could replay it once before the next legitimate sync. v0.2 adds a nonce-or-timestamp window to the envelope for durable replay defense; the protocol field for it already has space.
+
+## Is the shared_secret fallback safe?
+
+It's safer than nothing if you use a strong randomly-generated secret and never reuse it. It's strictly worse than pairing because:
+- The secret sits in two YAML files unencrypted (file mode 0600 helps, but a compromised user account reads it trivially).
+- Rotation requires manually editing both files.
+- The MITM defense (pairing code in HKDF salt) is missing.
+
+After pairing once, delete the `security.shared_secret` field from both YAMLs. The fallback exists only for the brief migration window from earlier prototypes.
+
+## Can I run this in a Docker container on a cloud VM?
+
+The sink can run anywhere Chrome stable runs (when CDP is enabled and Chrome is reachable) OR anywhere you can mount the destination's Chrome Cookies SQLite (when only the SQLite path is used). On Linux that means the v0.2 Linux sink work needs to land first. On macOS-in-the-cloud (e.g. MacStadium), it works today as long as you can SSH in and the tailnet reaches the host.
+
+## Is this open source?
+
+Apache 2.0. PRs welcome. See the repo at https://github.com/mvanhorn/agentcookie.
+
+## How do I report a security issue?
+
+Open an issue, or for sensitive findings, email the maintainer directly. There's no bug bounty yet; that's not v0.1 territory.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,128 @@
+# agentcookie quickstart
+
+Five-minute install on a laptop-and-Mac-mini pair, assuming Tailscale is already running on both.
+
+## Prerequisites
+
+- Tailscale installed and signed in on both machines (free tier is fine for personal use)
+- Chrome stable channel installed on both
+- Go 1.24+ on both, OR pre-built binaries from the GitHub releases page
+- The Mac mini auto-logs-in to a user session on boot (System Settings -> Users -> Login Options)
+
+## Step 1: Install the binary on both machines
+
+```
+go install github.com/mvanhorn/agentcookie/cmd/agentcookie@latest
+mkdir -p ~/.config/agentcookie
+```
+
+## Step 2: Drop the example configs
+
+On the **source** (laptop):
+
+```
+cd $(mktemp -d) && git clone https://github.com/mvanhorn/agentcookie.git
+cp agentcookie/examples/source.yaml ~/.config/agentcookie/source.yaml
+cp agentcookie/examples/allowlist.yaml ~/.config/agentcookie/allowlist.yaml
+```
+
+Edit `source.yaml`:
+- `sink.url`: the sink's tailnet URL, e.g. `http://my-mac-mini.tailnet.ts.net:9999/sync`
+- `peer.hostname`: the sink's tailnet hostname
+
+Edit `allowlist.yaml`: keep only the domains you want to sync. Comment out the rest.
+
+On the **sink** (Mac mini):
+
+```
+cp agentcookie/examples/sink.yaml ~/.config/agentcookie/sink.yaml
+cp agentcookie/examples/allowlist.yaml ~/.config/agentcookie/allowlist.yaml
+```
+
+Edit `sink.yaml`:
+- `listen.addr`: the sink's tailnet IP + port, e.g. `100.x.y.z:9999`
+- `peer.hostname`: the source's tailnet hostname
+- `cdp.enabled: true` if you want cookies to land in a running Chrome immediately (recommended)
+
+## Step 3: Pair
+
+On the source:
+
+```
+agentcookie pair --as source
+```
+
+You'll see:
+
+```
+agentcookie pair (source side)
+  pairing code: YILU-OIVK
+  source hostname: my-laptop.tailnet.ts.net
+  listening on: 0.0.0.0:9998
+
+  Run this on the sink machine within 10m0s
+    agentcookie pair --as sink --peer my-laptop.tailnet.ts.net \
+      --pair-url http://0.0.0.0:9998/pair --code YILU-OIVK
+
+  Waiting for sink...
+```
+
+On the sink:
+
+```
+agentcookie pair --as sink --peer my-laptop.tailnet.ts.net \
+  --pair-url http://my-laptop.tailnet.ts.net:9998/pair \
+  --code YILU-OIVK
+```
+
+Both sides print a paired confirmation with a matching fingerprint.
+
+## Step 4: Run the sink
+
+On the Mac mini, install the launchd plist for auto-restart:
+
+```
+cp agentcookie/examples/launchd-sink.plist ~/Library/LaunchAgents/dev.agentcookie.sink.plist
+# Edit the plist: replace REPLACE_WITH_FULL_PATH_TO_AGENTCOOKIE and REPLACE_WITH_USERNAME
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/dev.agentcookie.sink.plist
+```
+
+Or just run it interactively while testing:
+
+```
+agentcookie sink
+```
+
+If `cdp.enabled: true`, launch Chrome with remote debugging:
+
+```
+open -na "Google Chrome" --args --remote-debugging-port=9222
+```
+
+## Step 5: Sync from the source
+
+```
+agentcookie source --once --verbose
+```
+
+Expected output:
+
+```
+agentcookie source: %instacart.com -> 12 cookies
+agentcookie source: %granola.so -> 3 cookies
+agentcookie source: posted 15 cookies, sink replied: ok: wrote 15 cookies via cdp; dropped 0 non-allowlisted
+```
+
+Check on the sink: open Chrome (or use the running one), visit a synced site, you should be logged in.
+
+## Step 6: Make it continuous
+
+For now, `agentcookie source --once` is a single shot. Wire it to your preferred trigger (cron, launchd, fswatch on Chrome's Cookies file). Long-lived fsnotify-driven watch mode is on the roadmap.
+
+A reasonable cron:
+
+```
+*/5 * * * * /path/to/agentcookie source --once >> ~/.agentcookie-sync.log 2>&1
+```
+
+Five-minute resolution is fine for most sites; session tokens generally rotate on the order of hours.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,0 +1,53 @@
+# agentcookie threat model
+
+This document captures what agentcookie does and does not protect against. Read it before deploying anywhere you care about; the absence of a threat in this list is a statement of scope, not of safety.
+
+## What agentcookie does
+
+Continuously replicates Chrome session cookies for a user-allowlisted set of domains from one macOS machine (the **source**, where the user logs in) to another (the **sink**, where AI agents run). The replication is one-way, opt-in per domain, and authenticated end-to-end with a pairing-derived symmetric key.
+
+## Trust model
+
+agentcookie trusts:
+
+- The OS on both machines, including the kernel, the user account boundary, file mode 0600, and the Chrome process.
+- macOS Keychain to store the Chrome Safe Storage password (read with `security find-generic-password`).
+- The Tailscale tailnet for transport-layer confidentiality and identity. agentcookie layers its own AES-GCM on top, but the tailnet's WireGuard channel is the first line of defense.
+- The user's local filesystem under `~/.config/agentcookie/`. Anyone with read access to that directory can read the paired keys.
+- The Chrome stable channel's documented cookie storage and DevTools Protocol behavior.
+
+## What agentcookie protects against
+
+- **Plaintext cookies in transit.** Every payload is AES-256-GCM-sealed with a per-pair key. The key is never written unencrypted anywhere on the wire.
+- **Man-in-the-middle during pairing.** X25519 + HKDF salted with the pairing code means an attacker who intercepts the channel without knowing the code derives a different key, and the next AEAD message fails its tag check.
+- **Replay of captured payloads (within a process lifetime).** The sink rejects an envelope whose Sequence is not strictly greater than the highest seen for that source. The protection resets on sink restart; durable replay defense is v0.2.
+- **Source pushing non-allowlisted cookies.** The sink reads its own `allowlist.yaml` and drops cookies whose host_key matches no pattern, even if the source tries to push them. The sink owner has the final say on what lands in their Chrome.
+- **Wrong-secret / unauthenticated requests.** Both legacy `security.shared_secret` and paired keys gate every `/sync` call; AEAD tag mismatch -> 401.
+- **Third-party data plane leakage.** v0.1 has no hosted relay. Cookies never leave the user's tailnet.
+
+## What agentcookie does not protect against
+
+- **Root or sudo on either machine.** Anyone with privileged access can read raw cookies out of Chrome's SQLite + Keychain. agentcookie does not raise that bar.
+- **Compromise of Chrome itself.** A malicious extension on the source or sink, a NaCl exploit in Chrome, or a malicious .dylib injected into Chrome can already read cookie plaintext. agentcookie does not change that.
+- **Compromise of the user's macOS account.** Any process running as the user can read `~/.config/agentcookie/keys/*.json` despite mode 0600. macOS Keychain integration in v0.2 will tighten this against non-Chrome processes that happen to run as the user.
+- **Tailscale account takeover.** Pairing-derived keys live below the Tailscale identity layer, so an attacker on the tailnet still cannot read or sign sync payloads. But they could exhaust ports, run their own sink, or hold the tailnet open for traffic analysis. Out of scope.
+- **Device-fingerprint-bound sessions.** Sites that bind a session to canvas fingerprint, accept-language, screen size, etc. will fail after replication. agentcookie does not (and likely cannot) sync fingerprint hints. Document affected sites in your allowlist comments and re-auth them in-browser on the sink.
+- **Replay of payloads across sink restarts (in v0.1).** Sequence state is process-local. A captured payload could be replayed once if it arrives between a restart and the next legitimate sync.
+- **Coercion of the user.** If someone makes the user run `agentcookie pair --as sink` against a hostile source, the cookies will flow as designed.
+- **Cookie value tampering by the source.** The source is authoritative; if the source machine pushes cookies for an allowlisted domain, the sink writes them. There is no separate authorization layer per domain.
+
+## Cryptographic specifics
+
+- **Cookie at rest on each machine**: Chrome's existing scheme (AES-128-CBC with per-machine Safe Storage key, PBKDF2-SHA1, salt `saltysalt`, 1003 iters, IV = 16 spaces, v10 prefix). agentcookie does not change this; it reads with the local key and re-encrypts with the destination's local key.
+- **Pairing key derivation**: X25519 ECDH -> HKDF-SHA256, salt = pairing code (8 base32 chars uppercase), info = `agentcookie-pair-v1`, output = 32 bytes.
+- **Transport AEAD**: AES-256-GCM with key = SHA-256(secret). Random 12-byte nonce prepended to ciphertext. Bothpairing-derived keys and legacy `security.shared_secret` go through the same SHA-256 step so the AES key is always 32 bytes regardless of source.
+- **Sequence and protocol version**: int64 monotonic Sequence per source, int ProtocolVersion = 1 in every envelope. Bumping the version is a breaking change.
+
+## What changes when
+
+- **v0.2** is expected to land durable replay defense (nonce + timestamp window in the envelope), macOS Keychain storage for paired keys, and `agentcookie pair --rotate` for live key rotation.
+- **v0.3 or later** may add Linux sink support, a Chrome extension on the sink, and one-to-many fan-out. Each of those reopens parts of this document; re-read before adopting.
+
+## Reporting issues
+
+Open an issue at https://github.com/mvanhorn/agentcookie. For sensitive findings, contact the maintainer directly.

--- a/examples/launchd-sink.plist
+++ b/examples/launchd-sink.plist
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Example launchd plist for running agentcookie sink as a user agent on macOS.
+
+  1. Replace REPLACE_WITH_FULL_PATH_TO_AGENTCOOKIE with the absolute path
+     to the binary (e.g. /Users/yourname/go/bin/agentcookie).
+  2. Optionally set HOME and PATH env vars if your shell setup needs them.
+  3. Copy to ~/Library/LaunchAgents/dev.agentcookie.sink.plist
+  4. launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/dev.agentcookie.sink.plist
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>dev.agentcookie.sink</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>REPLACE_WITH_FULL_PATH_TO_AGENTCOOKIE</string>
+    <string>sink</string>
+  </array>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>KeepAlive</key>
+  <true/>
+
+  <key>ThrottleInterval</key>
+  <integer>10</integer>
+
+  <key>StandardOutPath</key>
+  <string>/tmp/agentcookie-sink.out.log</string>
+
+  <key>StandardErrorPath</key>
+  <string>/tmp/agentcookie-sink.err.log</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>HOME</key>
+    <string>/Users/REPLACE_WITH_USERNAME</string>
+  </dict>
+</dict>
+</plist>

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: agentcookie-install
+description: Install and pair agentcookie on a source-and-sink pair of macOS machines. Use when the user says "install agentcookie", "set up cookie sync", or "pair my laptop with my Mac mini for agents".
+version: 0.1.0
+---
+
+# agentcookie install
+
+You are helping the user install agentcookie on two machines and pair them. The source machine is where the user logs in interactively (typically a laptop). The sink machine is where AI agents run (typically a Mac mini, a cloud VM, or any always-on macOS box).
+
+## What this skill does
+
+1. Detects which machine you are running on (source or sink).
+2. Installs the `agentcookie` binary from `go install` (or links a local checkout if you have one).
+3. Lays down the launchd plist so the sink restarts itself across reboots.
+4. Walks the user through the pairing handshake.
+5. Generates a starter `allowlist.yaml` based on the user's installed Printing Press CLIs, then asks them to confirm.
+
+The skill never registers a hosted account, never sends anything off-machine, and never reads the user's existing cookies without explicit confirmation.
+
+## Step 0: Ask which side
+
+Use `AskUserQuestion` (or whatever blocking input primitive the platform exposes) to ask:
+
+```
+Which machine are we setting up?
+
+A) Source (the machine where I log in to sites in Chrome - usually my laptop)
+B) Sink (the machine that runs my AI agents - usually a Mac mini or cloud VM)
+```
+
+Set `ROLE` accordingly. Source goes through steps 1A-4A. Sink goes through 1B-4B.
+
+## Step 1A: Install on source
+
+```bash
+# Use go install if Go is on PATH; otherwise tell the user to install Go 1.24+ first.
+if command -v go >/dev/null 2>&1; then
+  go install github.com/mvanhorn/agentcookie/cmd/agentcookie@latest
+else
+  echo "agentcookie needs Go 1.24+. Install from https://go.dev/dl/ then re-run this skill."
+  exit 1
+fi
+mkdir -p ~/.config/agentcookie
+```
+
+Confirm `agentcookie version` works.
+
+## Step 2A: Drop the example configs
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/mvanhorn/agentcookie/main/examples/source.yaml -o ~/.config/agentcookie/source.yaml
+curl -fsSL https://raw.githubusercontent.com/mvanhorn/agentcookie/main/examples/allowlist.yaml -o ~/.config/agentcookie/allowlist.yaml
+```
+
+Open `source.yaml` and ask the user to fill in:
+- `sink.url`: the sink machine's tailnet URL (e.g. `http://my-mac-mini.tailnet.ts.net:9999/sync`)
+- `peer.hostname`: the sink's tailnet hostname (used as the filename under `~/.config/agentcookie/keys/`)
+
+Tell the user to leave `security.shared_secret` commented out; pairing will populate the keystore instead.
+
+## Step 3A: Pre-fill the allowlist
+
+Look in `~/printing-press/library/` for PP CLI binaries. For each binary, suggest the matching domain pattern based on the CLI's metadata (see the README of each CLI). Common mappings:
+
+| PP CLI | Suggested allowlist pattern |
+|--------|----------------------------|
+| `instacart` | `%instacart.com` |
+| `granola` | `%granola.so` |
+| `superhuman` | `%superhuman.com`, `%mail.google.com` |
+| `hubspot` | `%hubspot.com`, `%app.hubspot.com` |
+| `airbnb` | `%airbnb.com` |
+| `linear` | `%linear.app` |
+
+Append the user-confirmed list to `~/.config/agentcookie/allowlist.yaml` under `domains:`.
+
+## Step 4A: Start the pairing handshake
+
+```bash
+agentcookie pair --as source
+```
+
+The command prints a code like `XYZW-ABCD` and the sink-side run command. Read both back to the user and tell them to run the sink-side command on the OTHER machine within 10 minutes.
+
+Wait. When pairing completes the command returns with a confirmation line and the derived-key fingerprint. Done.
+
+## Step 1B: Install on sink
+
+Same as Step 1A: `go install github.com/mvanhorn/agentcookie/cmd/agentcookie@latest`, create `~/.config/agentcookie/`.
+
+## Step 2B: Drop the example configs
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/mvanhorn/agentcookie/main/examples/sink.yaml -o ~/.config/agentcookie/sink.yaml
+curl -fsSL https://raw.githubusercontent.com/mvanhorn/agentcookie/main/examples/allowlist.yaml -o ~/.config/agentcookie/allowlist.yaml
+```
+
+Fill in:
+- `listen.addr`: the sink's tailnet IP + port (NOT 0.0.0.0; use the tailnet address Tailscale assigned)
+- `peer.hostname`: the source machine's tailnet hostname
+- `cdp.enabled: true` if you want cookies to land in a running Chrome (recommended; launch Chrome with `--remote-debugging-port=9222`)
+
+## Step 3B: Install the launchd plist for unattended operation
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/mvanhorn/agentcookie/main/examples/launchd-sink.plist -o ~/Library/LaunchAgents/dev.agentcookie.sink.plist
+# Edit the plist to point ProgramArguments at the actual agentcookie binary
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/dev.agentcookie.sink.plist
+launchctl print gui/$(id -u)/dev.agentcookie.sink | head -5
+```
+
+## Step 4B: Run the sink-side pairing
+
+The user gives you the pairing code and source hostname from Step 4A. Run:
+
+```bash
+agentcookie pair --as sink \
+  --peer <source-hostname> \
+  --pair-url http://<source-hostname>:9998/pair \
+  --code <code>
+```
+
+On success, the keystore on this machine now has the derived key. The launchd-managed sink picks it up on next signal; if it was already running with the legacy `security.shared_secret`, restart it:
+
+```bash
+launchctl kickstart -k gui/$(id -u)/dev.agentcookie.sink
+```
+
+## Step 5: Verify
+
+Both sides:
+
+```bash
+agentcookie status --json | jq .
+```
+
+The source side should report `peer.hostname` set and a key file present. The sink side should report `peer.hostname`, an allowlist with the chosen patterns, and (if you enabled CDP) `cdp.enabled: true`.
+
+Then trigger a sync from the source:
+
+```bash
+agentcookie source --once --verbose
+```
+
+You should see one cookie batch land on the sink. On the sink, look for the log line:
+
+```
+agentcookie sink: wrote N cookies via cdp (dropped M non-allowlisted)
+```
+
+If CDP is enabled and Chrome is running with remote debugging, the cookies are visible to running pages immediately. Otherwise they are in the SQLite store and become visible on the next Chrome launch.
+
+## Troubleshooting
+
+- **Keychain prompt does not appear**: macOS already trusts the binary's previous Keychain access. If `agentcookie` errors with "Keychain access denied", open Keychain Access and remove the existing trust entry, then re-run.
+- **CDP probe fails**: `lsof -i :9222 | grep -i chrome` to confirm Chrome is debuggable. Launch Chrome with `open -na "Google Chrome" --args --remote-debugging-port=9222`.
+- **Pairing times out**: the source listens for 10 minutes. Re-run `agentcookie pair --as source` to get a fresh code.
+- **Sequence rejected on /sync**: the sink restarted but the source kept its in-memory sequence counter. Source emits a new sequence each `--once` call (`time.Now().Unix()`), so the next sync recovers.
+
+## Notes
+
+- The skill never registers a hosted account. All state lives on the user's machines plus the Tailscale-managed tailnet.
+- Allowlist on the sink is independent of the source's allowlist. The sink owner has the final say on what state lands in their Chrome.
+- The shared-secret fallback in `security.shared_secret` is for users mid-migration from earlier prototypes. After pairing, delete that field from both YAMLs.


### PR DESCRIPTION
U8 + U9 of the AgentCookie plan in one PR: everything an outside user needs to install, understand, and trust the project.

## What's here

\`skill/SKILL.md\` - A Claude Code / gstack-style installer skill. Asks which machine you're on, runs \`go install\`, drops the example configs from this repo, pre-fills the allowlist by scanning \`~/printing-press/library/\` for installed PP CLIs, walks both sides through pairing, verifies with \`agentcookie status\`.

\`examples/launchd-sink.plist\` - User agent that respawns the sink across reboots. Template fields for the binary path and home dir; \`launchctl bootstrap gui/$(id -u) ...\` to install.

\`docs/threat-model.md\` - Trust model + what's protected + what's explicitly NOT protected. Names the cryptographic specifics (X25519 + HKDF salted with pairing code, AES-256-GCM transport, AES-128-CBC v10 cookies at rest). Lists v0.2 hardening items (durable replay defense, Keychain storage).

\`docs/architecture.md\` - Module layout table, per-sync and per-pairing lifecycle, security boundaries mapped to enforcement points.

\`docs/quickstart.md\` - Five-minute install path assuming Tailscale is up. Copy-pasteable.

\`docs/faq.md\` - Real questions: why not a Chrome extension, why Tailscale, what about Firefox / Linux / cloud VMs, is the shared_secret fallback safe, how to report security issues.

README rewritten as the front door. Frames the project clearly: built for agent operators, not for humans switching accounts between two laptops they both touch.

## Out of scope (deferred)

- The marketing site at agentcookie.dev (U10) - separate PR.
- Public launch (U11) - separate PR.
- Linux sink, Firefox/Safari, one-to-many fan-out - v0.2+.

🤖 Generated with [Claude Code](https://claude.com/claude-code)