### PR TITLE
feat(web): marketing site for agentcookie.dev (U10)

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,29 @@
+# agentcookie web
+
+Single self-contained marketing page for the project. No build step, no JS dependencies, no runtime.
+
+## Local preview
+
+```
+cd web
+python3 -m http.server 8000
+open http://localhost:8000
+```
+
+## Deploy to Vercel
+
+```
+cd web
+npx vercel
+```
+
+The page is one HTML file with inlined CSS, so any static host works (Vercel, Netlify, GitHub Pages, S3, your own nginx).
+
+## To register the domain
+
+Pick from candidates:
+- agentcookie.dev (preferred)
+- agentcookie.com
+- cookieclone.dev
+
+Buy from any registrar, point DNS at your static host, ship.

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,211 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>agentcookie - peer-to-peer Chrome session replication for AI agents</title>
+  <meta name="description" content="Your laptop is logged in to everything. Your AI agents run on a different machine and aren't. agentcookie closes that gap, one-way, allowlisted, encrypted, no third-party data plane.">
+  <meta property="og:title" content="agentcookie">
+  <meta property="og:description" content="Peer-to-peer Chrome session replication for AI agents.">
+  <meta property="og:type" content="website">
+  <style>
+    :root {
+      --bg: #faf8f4;
+      --ink: #18181b;
+      --muted: #6b6b70;
+      --accent: #9b4d1f;
+      --accent-soft: #f1e6d8;
+      --rule: #e3ddd2;
+      --mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+      --serif: ui-serif, "Iowan Old Style", "Source Serif Pro", Georgia, serif;
+      --sans: -apple-system, BlinkMacSystemFont, "Inter", "Helvetica Neue", sans-serif;
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; background: var(--bg); color: var(--ink); }
+    body { font-family: var(--sans); line-height: 1.5; font-size: 17px; }
+    main { max-width: 720px; margin: 0 auto; padding: 64px 24px 96px; }
+    h1, h2, h3 { font-family: var(--serif); line-height: 1.2; margin: 0; letter-spacing: -0.01em; }
+    h1 { font-size: 56px; margin-bottom: 16px; }
+    h2 { font-size: 30px; margin: 56px 0 16px; }
+    h3 { font-size: 20px; margin: 24px 0 8px; }
+    p { margin: 0 0 18px; max-width: 60ch; }
+    a { color: var(--accent); text-decoration: none; border-bottom: 1px solid var(--accent-soft); }
+    a:hover { border-bottom-color: var(--accent); }
+    code, pre { font-family: var(--mono); font-size: 14px; }
+    pre {
+      background: var(--ink); color: #f4efe5;
+      padding: 16px 20px; border-radius: 6px;
+      overflow-x: auto; margin: 0 0 24px;
+    }
+    pre code { background: none; color: inherit; padding: 0; }
+    code:not(pre code) { background: var(--accent-soft); padding: 2px 6px; border-radius: 4px; color: var(--ink); }
+    .lede { font-size: 22px; line-height: 1.4; color: var(--ink); max-width: 56ch; margin-bottom: 32px; }
+    .muted { color: var(--muted); }
+    .pill {
+      display: inline-block; padding: 4px 10px; border-radius: 999px;
+      background: var(--accent-soft); color: var(--accent);
+      font-size: 13px; letter-spacing: 0.03em; text-transform: uppercase;
+      margin-bottom: 24px;
+    }
+    .diagram {
+      font-family: var(--mono); font-size: 13px; line-height: 1.4;
+      background: var(--bg); border: 1px solid var(--rule); border-radius: 6px;
+      padding: 20px; margin: 24px 0; white-space: pre; overflow-x: auto;
+    }
+    .pair {
+      display: grid; grid-template-columns: 1fr 1fr; gap: 24px; margin: 24px 0;
+    }
+    @media (max-width: 600px) { .pair { grid-template-columns: 1fr; } }
+    .pair > div {
+      background: white; border: 1px solid var(--rule); border-radius: 6px;
+      padding: 20px;
+    }
+    .pair h3 { margin-top: 0; }
+    .pair p:last-child { margin-bottom: 0; }
+    ul { padding-left: 20px; max-width: 60ch; }
+    li { margin-bottom: 6px; }
+    hr { border: none; border-top: 1px solid var(--rule); margin: 56px 0; }
+    footer { margin-top: 72px; color: var(--muted); font-size: 14px; }
+    footer a { color: var(--muted); border-bottom-color: var(--rule); }
+  </style>
+</head>
+<body>
+<main>
+  <div class="pill">v0.1 in development</div>
+  <h1>agentcookie</h1>
+  <p class="lede">
+    Your laptop is logged in to everything. Your AI agents run on a different machine and aren't.
+    agentcookie closes that gap. One-way, allowlisted, end-to-end encrypted, no third-party data plane.
+  </p>
+
+  <pre><code>go install github.com/mvanhorn/agentcookie/cmd/agentcookie@latest</code></pre>
+
+  <p>
+    <a href="https://github.com/mvanhorn/agentcookie">GitHub</a> &middot;
+    <a href="https://github.com/mvanhorn/agentcookie/blob/main/docs/quickstart.md">Quickstart</a> &middot;
+    <a href="https://github.com/mvanhorn/agentcookie/blob/main/docs/threat-model.md">Threat model</a> &middot;
+    <a href="https://github.com/mvanhorn/agentcookie/blob/main/docs/protocol.md">Protocol v1</a>
+  </p>
+
+  <hr>
+
+  <h2>The problem</h2>
+  <p>
+    AI agents are great at clicking through web apps. They are terrible at logging in.
+    Every authenticated workflow today either burns ten minutes asking the user to paste cookies,
+    burns hours setting up a fragile sync extension, or just fails when the session expires.
+  </p>
+  <p>
+    Existing Chrome cookie sync tools are built for humans switching accounts between two laptops they both touch.
+    They assume someone will click Merge or open Chrome periodically. agentcookie is built for the opposite workflow:
+    continuous one-way replication from the machine you live in to the machine your AI agents act from.
+    No human in the loop on the sink side. No browser open. No third-party storage.
+  </p>
+
+  <hr>
+
+  <h2>How it works</h2>
+
+  <div class="diagram">
+SOURCE (laptop)                                  SINK (Mac mini / cloud VM)
+
+  agentcookie source     ==== AES-GCM ====>      agentcookie sink (launchd)
+    read Chrome SQLite       over HTTPS            verify proto + sequence
+    decrypt w/ Keychain      on tailnet            filter by allowlist
+    filter by allowlist                            inject via Chrome DevTools
+    wrap in envelope                                 (or write SQLite)
+    seal w/ peer key
+
+           Tailscale tailnet, WireGuard, peer-to-peer
+  </div>
+
+  <div class="pair">
+    <div>
+      <h3>Pairing</h3>
+      <p>
+        X25519 ephemeral exchange salted with a one-time pairing code.
+        Both sides derive an identical 32-byte symmetric key via HKDF-SHA256.
+        MITM defense: an attacker who intercepts the channel without the code derives a different key.
+      </p>
+    </div>
+    <div>
+      <h3>Allowlist on both sides</h3>
+      <p>
+        The source filters cookies before sending. The sink filters again on receive,
+        independently, against its own allowlist. The sink owner has the final say on what state
+        lands in their Chrome, even if the paired source is compromised.
+      </p>
+    </div>
+    <div>
+      <h3>Live-Chrome injection</h3>
+      <p>
+        When Chrome is up with remote debugging, the sink writes cookies via Chrome DevTools Protocol
+        (<code>Storage.setCookies</code>) so they are visible to running pages immediately.
+        Falls back to SQLite write when Chrome is closed.
+      </p>
+    </div>
+    <div>
+      <h3>Replay defense + protocol versioning</h3>
+      <p>
+        Every payload carries a monotonic Sequence and a protocol version.
+        The sink rejects out-of-order or duplicate payloads (replay defense)
+        and rejects protocol mismatches loudly.
+      </p>
+    </div>
+  </div>
+
+  <hr>
+
+  <h2>What's in v0.1</h2>
+  <ul>
+    <li>Unified <code>agentcookie</code> CLI: <code>source</code>, <code>sink</code>, <code>pair</code>, <code>status</code>, <code>version</code>. All support <code>--json</code> for agent callers.</li>
+    <li>macOS source + macOS sink. Chrome stable channel.</li>
+    <li>X25519 + HKDF pairing handshake with one-time code.</li>
+    <li>Per-pair 32-byte symmetric key stored at <code>~/.config/agentcookie/keys/&lt;peer&gt;.json</code> mode 0600.</li>
+    <li>AES-256-GCM transport over Tailscale tailnet.</li>
+    <li>Live-Chrome cookie injection via Chrome DevTools Protocol; SQLite write fallback.</li>
+    <li>Wire protocol v1 with envelope, source hostname, monotonic Sequence.</li>
+    <li>Allowlist enforced on both source and sink, independently.</li>
+    <li>42 unit tests across the crypto, transport, config, keystore, pairing, CDP, and protocol layers.</li>
+    <li>Apache 2.0 license. No telemetry. No hosted dependencies.</li>
+  </ul>
+
+  <hr>
+
+  <h2>Threat model in one paragraph</h2>
+  <p>
+    agentcookie protects cookies in transit, defends against MITM during pairing, rejects wrong-secret payloads,
+    and gives the sink owner final say via its own allowlist. It does not protect against root on either machine,
+    Chrome compromise, OS user account compromise, or sites that bind sessions to device fingerprints.
+    See <a href="https://github.com/mvanhorn/agentcookie/blob/main/docs/threat-model.md">docs/threat-model.md</a> for the full read.
+  </p>
+
+  <hr>
+
+  <h2>FAQ</h2>
+  <p>
+    Highlights below. Full FAQ at
+    <a href="https://github.com/mvanhorn/agentcookie/blob/main/docs/faq.md">docs/faq.md</a>.
+  </p>
+  <h3>Why not a Chrome extension?</h3>
+  <p>Extensions assume a human will click Merge. agentcookie is for unattended sync to a machine you don't sit in front of.</p>
+
+  <h3>Why Tailscale?</h3>
+  <p>Zero third-party data plane, end-to-end WireGuard, free for personal use. Transport adapters for raw SSH and Cloudflare Tunnel are tracked for follow-up versions.</p>
+
+  <h3>What about Linux sinks / Firefox / Safari?</h3>
+  <p>v0.1 is macOS source + macOS sink, Chrome stable. Linux, Brave, Arc, and Edge are easy follow-ups. Firefox and Safari use different cookie stores entirely; bigger lifts.</p>
+
+  <h3>Is this open source?</h3>
+  <p>Apache 2.0. PRs welcome at <a href="https://github.com/mvanhorn/agentcookie">github.com/mvanhorn/agentcookie</a>.</p>
+
+  <footer>
+    <p>
+      Built by <a href="https://x.com/mvanhorn">Matt Van Horn</a>.
+      Source at <a href="https://github.com/mvanhorn/agentcookie">github.com/mvanhorn/agentcookie</a>.
+      Apache 2.0.
+    </p>
+  </footer>
+</main>
+</body>
+</html>

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        { "key": "Strict-Transport-Security", "value": "max-age=63072000; includeSubDomains; preload" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
U10: a real front door. Single self-contained HTML page ready to deploy.

## What's here

\`web/index.html\` - One file. Inlined CSS, no JS, no build step. Page sections:

- Pill (\"v0.1 in development\"), title, lede, install command
- Links row: GitHub / Quickstart / Threat model / Protocol v1
- The problem (two paragraphs framing the agent-operator workflow)
- How it works (ASCII data-flow diagram + four feature cards in a 2x2 grid)
- What's in v0.1 (feature checklist)
- One-paragraph threat model summary linking to the full doc
- FAQ highlights linking to the full FAQ
- Footer with X handle and repo link

\`web/README.md\` - Local-preview + deploy instructions.

\`web/vercel.json\` - HSTS, X-Content-Type-Options, Referrer-Policy headers since this is the front door for a security-sensitive product.

## Design

- Off-white background, dark ink text, cookie-brown accent for links
- Serif headers (Iowan Old Style stack), sans body, monospace code blocks
- 720px max content width; single column at <600px viewport
- No emdashes, no bold inline emphasis (per personal style guide)

## What's NOT here

- The agentcookie.dev domain is not registered yet (Matt's call). Page is portable to any host the moment a domain is wired up.
- No analytics, no telemetry, no third-party fonts or scripts. Just HTML and inlined CSS.
- Launch tweet / HN post / X thread - U11 territory.

## Preview

\`\`\`
cd web && python3 -m http.server 8000 && open http://localhost:8000
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)