### PR TITLE
ci+release: GitHub Actions + goreleaser scaffolding (U11)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: vet + test
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+          cache: true
+      - name: go vet
+        run: go vet ./...
+      - name: go test
+        run: go test -race ./...
+      - name: go build
+        run: go build ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+          cache: true
+      - name: goreleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,52 @@
+version: 2
+
+project_name: agentcookie
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: agentcookie
+    main: ./cmd/agentcookie
+    binary: agentcookie
+    env:
+      - CGO_ENABLED=1
+    goos:
+      - darwin
+    goarch:
+      - arm64
+      - amd64
+    ldflags:
+      - -s -w -X github.com/mvanhorn/agentcookie/internal/cli.Version={{ .Version }}
+
+archives:
+  - id: agentcookie
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - LICENSE
+      - README.md
+      - docs/quickstart.md
+      - docs/threat-model.md
+      - docs/architecture.md
+      - docs/protocol.md
+      - docs/faq.md
+      - examples/source.yaml
+      - examples/sink.yaml
+      - examples/allowlist.yaml
+      - examples/launchd-sink.plist
+
+checksum:
+  name_template: checksums.txt
+
+snapshot:
+  version_template: "{{ incpatch .Version }}-next"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+      - merge

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+## [Unreleased]
+
+Tag v0.1.0 to cut the first release. See [docs/quickstart.md](docs/quickstart.md) to install and try it.
+
+### Added (since project start)
+
+- Unified `agentcookie` CLI with subcommands `source`, `sink`, `pair`, `status`, `version`. All support `--json` for agent callers.
+- Pairing handshake: X25519 + HKDF-SHA256 salted with a one-time code. Derived 32-byte keys land in `~/.config/agentcookie/keys/<peer>.json` at mode 0600.
+- Cookie acquisition on macOS Chrome: read SQLite read-only with `immutable=1`, decrypt v10 ciphertext with the Keychain Safe Storage key.
+- Cookie write: schema-aware `INSERT ... ON CONFLICT` that adapts to Chrome's evolving column set.
+- Live-Chrome cookie injection on the sink via Chrome DevTools Protocol (`Storage.setCookies`). Falls back to SQLite write when Chrome is not debuggable.
+- Wire protocol v1: versioned `SyncEnvelope` with monotonic Sequence (in-memory replay defense), source hostname, cookies. Documented at `docs/protocol.md`.
+- Sink-side allowlist enforcement, independent of source's allowlist.
+- Install skill at `skill/SKILL.md` for Claude Code / gstack-style installer flows.
+- launchd plist template for unattended sink operation.
+- Marketing site at `web/index.html`, ready to deploy to any static host.
+- 42 unit tests across the chrome, transport, config, keystore, pairing, CDP, and protocol packages.
+- Apache 2.0 license.
+
+### Not yet shipped (planned for v0.2)
+
+- macOS Keychain storage for paired keys.
+- Long-lived fsnotify-driven watch mode on the source (replacing the current `--once` + cron pattern).
+- Durable replay defense (nonce or timestamp window in the envelope).
+- `agentcookie pair --rotate` for live key rotation.
+- One-to-many fan-out (one source pushing to multiple sinks).
+- Linux sink support.


### PR DESCRIPTION
U11 of the AgentCookie plan, minus the going-public actions that need your hands.

## What's here

\`.github/workflows/ci.yml\` - macos-latest runner runs \`go vet\`, \`go test -race\`, \`go build\` on every push and PR to main. CGO + race detector + the Keychain shell-out work natively on macos-latest.

\`.github/workflows/release.yml\` - On a \`v*\` tag, goreleaser builds darwin/arm64 + darwin/amd64 binaries, packages each archive with the binary + LICENSE + README + all docs + example configs + the launchd plist, attaches them to a GitHub release. Auto-generates the release notes from commits since the previous tag.

\`.goreleaser.yaml\` - Build matrix (darwin x [arm64, amd64]), CGO enabled (sqlite needs it), ldflags burn the version into \`internal/cli.Version\` so \`agentcookie version\` reports the release tag.

\`CHANGELOG.md\` - Frames the current state as \"Unreleased\" with the full v0.1 feature list plus the v0.2 backlog.

## To launch

Once you're happy with the codebase and have done the cross-machine verification:

\`\`\`
git tag v0.1.0
git push origin v0.1.0
\`\`\`

The release workflow runs goreleaser and publishes the GitHub release with installable binaries. \`go install github.com/mvanhorn/agentcookie/cmd/agentcookie@v0.1.0\` works once the tag is pushed.

## What I cannot do for you

- **Register the domain** (your call: agentcookie.dev vs cookieclone.dev vs ...)
- **Deploy the marketing site** (your Vercel / Netlify account; \`cd web && npx vercel\`)
- **Publish the Homebrew tap** (your GitHub tap repo + formula)
- **Post the launch tweet** (your voice, your call on timing)
- **Submit to HN / r/LocalLLM / Anthropic / OpenAI agent communities** (your network, your timing)

Everything technically required for v0.1.0 binaries to land is in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)