### PR TITLE
feat(v0.2 phase A): App-Bound prefix strip + LaunchAgent plist gen (U1, U5)

### DIFF
--- a/internal/chrome/appbound.go
+++ b/internal/chrome/appbound.go
@@ -1,0 +1,28 @@
+package chrome
+
+import (
+	"bytes"
+	"crypto/sha256"
+)
+
+// stripAppBoundPrefix detects and removes the per-host_key prefix Chrome 127+
+// embeds in cookie plaintext on macOS. Observed empirically against
+// Chrome 146.0.7680.80 on 2026-05-16: every cookie's decrypted plaintext for a
+// given host_key starts with an identical 32-byte sequence, and the sequence
+// matches SHA-256(host_key). Cookies for different host_keys carry different
+// prefixes. Pre-127 Chrome plaintext has no prefix and is returned unchanged.
+//
+// Decision: strip only when the first 32 bytes match SHA-256(host_key) exactly.
+// Any other shape (pre-127 plaintext, future Chrome changes, malformed data)
+// passes through. This is defensive against silently corrupting cookie values
+// when Chrome changes its derivation in a future release.
+func stripAppBoundPrefix(plaintext []byte, hostKey string) []byte {
+	if len(plaintext) < sha256.Size {
+		return plaintext
+	}
+	want := sha256.Sum256([]byte(hostKey))
+	if !bytes.Equal(plaintext[:sha256.Size], want[:]) {
+		return plaintext
+	}
+	return plaintext[sha256.Size:]
+}

--- a/internal/chrome/appbound_test.go
+++ b/internal/chrome/appbound_test.go
@@ -1,0 +1,93 @@
+package chrome
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"testing"
+)
+
+func TestStripAppBoundPrefix_StripsCorrectHost(t *testing.T) {
+	host := ".github.com"
+	value := "actual-cookie-value"
+	prefix := sha256.Sum256([]byte(host))
+	plaintext := append(prefix[:], value...)
+
+	got := stripAppBoundPrefix(plaintext, host)
+	if string(got) != value {
+		t.Errorf("expected %q, got %q", value, string(got))
+	}
+}
+
+func TestStripAppBoundPrefix_PreservesPlaintextWhenHostMismatches(t *testing.T) {
+	// Plaintext claims to be for host_key A but bears SHA256(B) prefix.
+	// Defense: do not strip. Return as-is so the cookie either round-trips
+	// unchanged (sink can detect the mismatch later) or surfaces as
+	// malformed at the destination.
+	host := "github.com"
+	otherPrefix := sha256.Sum256([]byte("example.com"))
+	value := "actual-cookie-value"
+	plaintext := append(otherPrefix[:], value...)
+
+	got := stripAppBoundPrefix(plaintext, host)
+	if !bytes.Equal(got, plaintext) {
+		t.Error("expected plaintext to pass through unchanged when prefix mismatches host")
+	}
+}
+
+func TestStripAppBoundPrefix_PassesThroughPre127Plaintext(t *testing.T) {
+	// Pre-127 Chrome: no prefix at all. Plaintext is just the cookie value.
+	host := ".github.com"
+	value := "actual-cookie-value"
+	plaintext := []byte(value)
+
+	got := stripAppBoundPrefix(plaintext, host)
+	if !bytes.Equal(got, plaintext) {
+		t.Errorf("expected plaintext to pass through unchanged, got %q", string(got))
+	}
+}
+
+func TestStripAppBoundPrefix_ShortPlaintextUnchanged(t *testing.T) {
+	// Plaintext shorter than 32 bytes cannot have a prefix.
+	got := stripAppBoundPrefix([]byte("short"), ".github.com")
+	if string(got) != "short" {
+		t.Errorf("expected short plaintext unchanged, got %q", string(got))
+	}
+}
+
+func TestStripAppBoundPrefix_EmptyPlaintext(t *testing.T) {
+	got := stripAppBoundPrefix(nil, ".github.com")
+	if len(got) != 0 {
+		t.Errorf("expected empty plaintext, got %v", got)
+	}
+}
+
+func TestStripAppBoundPrefix_DifferentHostsProduceDifferentResults(t *testing.T) {
+	// Same value bytes, different host_keys: stripping with the wrong host
+	// returns unchanged plaintext (no false-positive strip).
+	valueBytes := []byte("payload")
+	prefixGithub := sha256.Sum256([]byte("github.com"))
+	plaintext := append(prefixGithub[:], valueBytes...)
+
+	rightHost := stripAppBoundPrefix(plaintext, "github.com")
+	if !bytes.Equal(rightHost, valueBytes) {
+		t.Error("right host_key did not strip prefix")
+	}
+
+	wrongHost := stripAppBoundPrefix(plaintext, "github.io")
+	if !bytes.Equal(wrongHost, plaintext) {
+		t.Error("wrong host_key falsely stripped prefix")
+	}
+}
+
+func TestStripAppBoundPrefix_HandlesValueThatLooksLikePrefix(t *testing.T) {
+	// Edge case: a cookie whose actual value happens to start with 32 random
+	// bytes that don't match SHA256(host_key). We must not strip them.
+	host := ".github.com"
+	value := append([]byte{0xde, 0xad, 0xbe, 0xef}, bytes.Repeat([]byte{0x42}, 28)...)
+	value = append(value, []byte("trailing")...)
+
+	got := stripAppBoundPrefix(value, host)
+	if !bytes.Equal(got, value) {
+		t.Error("plaintext that does not match SHA256(host_key) prefix was incorrectly stripped")
+	}
+}

--- a/internal/chrome/read.go
+++ b/internal/chrome/read.go
@@ -81,7 +81,11 @@ WHERE host_key LIKE ?`
 		if err != nil {
 			return nil, fmt.Errorf("decrypt %s/%s: %w", c.HostKey, c.Name, err)
 		}
-		c.Value = plain
+		// Chrome 127+ on macOS embeds a 32-byte host-bound prefix in the
+		// plaintext. Strip it so downstream consumers (CDP, dumps, fixtures)
+		// see only the real cookie value.
+		stripped := stripAppBoundPrefix([]byte(plain), c.HostKey)
+		c.Value = string(stripped)
 		cookies = append(cookies, c)
 	}
 	if err := rows.Err(); err != nil {

--- a/internal/launchd/plist.go
+++ b/internal/launchd/plist.go
@@ -1,0 +1,185 @@
+// Package launchd generates and installs LaunchAgent plists for the
+// agentcookie source and sink daemons. LaunchAgents run inside the user's GUI
+// login session, so they have the Keychain access and Chrome lifecycle
+// privileges that SSH-launched processes lack.
+package launchd
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"text/template"
+)
+
+// Role identifies which side the plist drives.
+type Role string
+
+const (
+	RoleSource Role = "source"
+	RoleSink   Role = "sink"
+)
+
+// Spec is the input to plist generation. All paths must be absolute.
+type Spec struct {
+	Role        Role
+	BinaryPath  string
+	LogDir      string
+	ExtraArgs   []string
+}
+
+// Label returns the launchd Label corresponding to the spec's role. Labels
+// follow `dev.agentcookie.<role>`. Since LaunchAgents live in per-user
+// ~/Library/LaunchAgents/ there is no risk of cross-user label collision.
+func (s Spec) Label() string {
+	return "dev.agentcookie." + string(s.Role)
+}
+
+// Render produces the plist XML for the spec.
+func (s Spec) Render() ([]byte, error) {
+	if s.BinaryPath == "" {
+		return nil, fmt.Errorf("BinaryPath is required")
+	}
+	if s.LogDir == "" {
+		return nil, fmt.Errorf("LogDir is required")
+	}
+	if s.Role != RoleSource && s.Role != RoleSink {
+		return nil, fmt.Errorf("invalid Role %q", s.Role)
+	}
+
+	args := []string{string(s.Role)}
+	args = append(args, s.ExtraArgs...)
+
+	data := plistData{
+		Label:         s.Label(),
+		BinaryPath:    s.BinaryPath,
+		Args:          args,
+		StandardOut:   filepath.Join(s.LogDir, string(s.Role)+".out.log"),
+		StandardError: filepath.Join(s.LogDir, string(s.Role)+".err.log"),
+	}
+
+	var buf bytes.Buffer
+	if err := plistTmpl.Execute(&buf, data); err != nil {
+		return nil, fmt.Errorf("render plist: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// Path returns the file path the plist installs to under
+// ~/Library/LaunchAgents/.
+func (s Spec) Path() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, "Library", "LaunchAgents", s.Label()+".plist"), nil
+}
+
+// Install writes the plist to disk and bootstraps it via launchctl. Idempotent:
+// running Install on an already-installed spec produces a refresh, not a
+// duplicate. Returns the installed plist path.
+func Install(s Spec) (string, error) {
+	xml, err := s.Render()
+	if err != nil {
+		return "", err
+	}
+	path, err := s.Path()
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return "", fmt.Errorf("mkdir LaunchAgents: %w", err)
+	}
+	if err := os.MkdirAll(s.LogDir, 0o755); err != nil {
+		return "", fmt.Errorf("mkdir log dir: %w", err)
+	}
+	if err := os.WriteFile(path, xml, 0o644); err != nil {
+		return "", fmt.Errorf("write plist: %w", err)
+	}
+	uid := strconv.Itoa(os.Getuid())
+	domain := "gui/" + uid
+
+	// bootout existing job (idempotent: ignore non-zero if not loaded).
+	_ = exec.Command("launchctl", "bootout", domain+"/"+s.Label()).Run()
+	// bootstrap fresh.
+	cmd := exec.Command("launchctl", "bootstrap", domain, path)
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return path, fmt.Errorf("launchctl bootstrap: %w", err)
+	}
+	return path, nil
+}
+
+// Uninstall is the inverse of Install. Removes the launchctl job and deletes
+// the plist file. Idempotent.
+func Uninstall(s Spec) error {
+	uid := strconv.Itoa(os.Getuid())
+	_ = exec.Command("launchctl", "bootout", "gui/"+uid+"/"+s.Label()).Run()
+	path, err := s.Path()
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove plist: %w", err)
+	}
+	return nil
+}
+
+// IsInstalled returns true when launchctl reports the spec's label as loaded.
+func IsInstalled(s Spec) bool {
+	uid := strconv.Itoa(os.Getuid())
+	out, err := exec.Command("launchctl", "print", "gui/"+uid+"/"+s.Label()).Output()
+	if err != nil {
+		return false
+	}
+	return bytes.Contains(out, []byte(s.Label()))
+}
+
+type plistData struct {
+	Label         string
+	BinaryPath    string
+	Args          []string
+	StandardOut   string
+	StandardError string
+}
+
+var plistTmpl = template.Must(template.New("plist").Parse(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>{{.Label}}</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>{{.BinaryPath}}</string>
+{{range .Args}}    <string>{{.}}</string>
+{{end}}  </array>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key>
+    <false/>
+    <key>Crashed</key>
+    <true/>
+  </dict>
+
+  <key>ThrottleInterval</key>
+  <integer>10</integer>
+
+  <key>ProcessType</key>
+  <string>Background</string>
+
+  <key>StandardOutPath</key>
+  <string>{{.StandardOut}}</string>
+
+  <key>StandardErrorPath</key>
+  <string>{{.StandardError}}</string>
+</dict>
+</plist>
+`))

--- a/internal/launchd/plist_test.go
+++ b/internal/launchd/plist_test.go
@@ -1,0 +1,108 @@
+package launchd
+
+import (
+	"encoding/xml"
+	"strings"
+	"testing"
+)
+
+func TestSpecRenderSourceRole(t *testing.T) {
+	s := Spec{
+		Role:       RoleSource,
+		BinaryPath: "/Users/test/bin/agentcookie",
+		LogDir:     "/Users/test/.agentcookie/logs",
+		ExtraArgs:  []string{"--watch"},
+	}
+	out, err := s.Render()
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	str := string(out)
+	for _, want := range []string{
+		"dev.agentcookie.source",
+		"/Users/test/bin/agentcookie",
+		"<string>source</string>",
+		"<string>--watch</string>",
+		"/Users/test/.agentcookie/logs/source.out.log",
+		"/Users/test/.agentcookie/logs/source.err.log",
+		"<key>RunAtLoad</key>",
+		"<key>KeepAlive</key>",
+		"<key>ProcessType</key>",
+		"<string>Background</string>",
+	} {
+		if !strings.Contains(str, want) {
+			t.Errorf("rendered plist missing %q\nFull output:\n%s", want, str)
+		}
+	}
+}
+
+func TestSpecRenderSinkRole(t *testing.T) {
+	s := Spec{
+		Role:       RoleSink,
+		BinaryPath: "/Users/test/bin/agentcookie",
+		LogDir:     "/Users/test/.agentcookie/logs",
+	}
+	out, err := s.Render()
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	str := string(out)
+	if !strings.Contains(str, "dev.agentcookie.sink") {
+		t.Errorf("rendered plist missing sink label")
+	}
+	if strings.Contains(str, "--watch") {
+		t.Errorf("sink plist should not contain --watch arg by default")
+	}
+}
+
+func TestSpecRenderProducesValidXML(t *testing.T) {
+	s := Spec{
+		Role:       RoleSource,
+		BinaryPath: "/Users/test/bin/agentcookie",
+		LogDir:     "/Users/test/.agentcookie/logs",
+		ExtraArgs:  []string{"--watch"},
+	}
+	out, err := s.Render()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Parse as XML; if the template is malformed it errors here.
+	var parsed any
+	if err := xml.Unmarshal(out, &parsed); err != nil {
+		t.Errorf("rendered plist failed XML parse: %v", err)
+	}
+}
+
+func TestSpecRenderRequiresBinaryPath(t *testing.T) {
+	s := Spec{Role: RoleSource, LogDir: "/tmp/logs"}
+	if _, err := s.Render(); err == nil {
+		t.Error("expected error for missing BinaryPath")
+	}
+}
+
+func TestSpecRenderRequiresLogDir(t *testing.T) {
+	s := Spec{Role: RoleSource, BinaryPath: "/x"}
+	if _, err := s.Render(); err == nil {
+		t.Error("expected error for missing LogDir")
+	}
+}
+
+func TestSpecRenderRejectsInvalidRole(t *testing.T) {
+	s := Spec{Role: Role("bogus"), BinaryPath: "/x", LogDir: "/y"}
+	if _, err := s.Render(); err == nil {
+		t.Error("expected error for invalid Role")
+	}
+}
+
+func TestSpecLabelIsRoleBased(t *testing.T) {
+	cases := map[Role]string{
+		RoleSource: "dev.agentcookie.source",
+		RoleSink:   "dev.agentcookie.sink",
+	}
+	for role, want := range cases {
+		got := Spec{Role: role}.Label()
+		if got != want {
+			t.Errorf("Label for %s = %q, want %q", role, got, want)
+		}
+	}
+}


### PR DESCRIPTION
First slice of [v0.2 plan](docs/plans/2026-05-16-003-feat-magical-agent-install-and-continuous-sync-plan.md). Independent leaf units that everything else depends on.

## U1: strip Chrome App-Bound Encryption prefix

Chrome 127+ on macOS embeds a 32-byte prefix in cookie plaintext after our v10 + AES-CBC + PKCS#7 unpad path. The prefix is SHA256(host_key) byte-for-byte.

\`internal/chrome/appbound.go\` strips it when the first 32 bytes of plaintext equal SHA256(c.HostKey). Pre-127 plaintext and any other shape passes through unchanged so the strip is safe even when Chrome ships a new derivation later.

**Empirical verification against Chrome 146.0.7680.80 on Matt's laptop:** post-strip cookie values are clean and readable:

\`\`\`
"name": "dotcom_user", "value": "mvanhorn"
"name": "saved_user_sessions", "value": "455140%3AaAQaN2ipMI-..."
"name": "_octo", "value": "GH1.1.804924784.1777144938"
\`\`\`

Pre-strip these had a 32-byte non-printable prefix that broke any downstream consumer (CDP, dumps, fixtures). Now CDP path can work in phase B.

## U5: LaunchAgent plist generation

\`internal/launchd/plist.go\` renders + installs LaunchAgents to \`~/Library/LaunchAgents/dev.agentcookie.<role>.plist\`. Properties:
- KeepAlive only on crash or non-zero exit (clean exits during wizard upgrade do not trigger respawn).
- ProcessType=Background.
- StandardOut/Err logged under \`~/.agentcookie/logs/\`.
- Install is idempotent: bootout existing, then bootstrap fresh.
- \`IsInstalled(spec)\` probes \`launchctl print\` for status.

Tests: 14 new (7 appbound + 7 launchd) covering match/non-match, pre-127 backward compat, short plaintext, XML validity, role validation, label scheme.

## Combined

\`go test ./...\` -> 56 passed in 12 packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)