### PR TITLE
feat(v0.2 phase C): watcher + wizard + agent-runnable skill (U4, U6, U7)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/mvanhorn/agentcookie
 go 1.26.2
 
 require (
+	github.com/fsnotify/fsnotify v1.10.1
 	github.com/gorilla/websocket v1.5.3
 	github.com/mattn/go-sqlite3 v1.14.44
 	github.com/spf13/cobra v1.10.2
@@ -12,4 +13,5 @@ require (
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
+	golang.org/x/sys v0.13.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
+github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
@@ -11,6 +13,8 @@ github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiT
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
+golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -46,7 +46,7 @@ func Execute() {
 	rootCmd.PersistentFlags().StringVar(&common.ConfigDir, "config-dir", defaultConfigDir(), "directory holding source.yaml, sink.yaml, allowlist.yaml")
 	rootCmd.PersistentFlags().BoolVar(&common.JSON, "json", false, "emit machine-readable JSON output where the subcommand supports it")
 
-	rootCmd.AddCommand(sourceCmd, sinkCmd, pairCmd, statusCmd, versionCmd)
+	rootCmd.AddCommand(sourceCmd, sinkCmd, pairCmd, statusCmd, versionCmd, wizardCmd)
 
 	if err := rootCmd.Execute(); err != nil {
 		// Cobra already prints usage on flag errors; surface RunE errors here.

--- a/internal/cli/source.go
+++ b/internal/cli/source.go
@@ -17,36 +17,46 @@ import (
 	"github.com/mvanhorn/agentcookie/internal/pairing"
 	"github.com/mvanhorn/agentcookie/internal/protocol"
 	"github.com/mvanhorn/agentcookie/internal/transport"
+	"github.com/mvanhorn/agentcookie/internal/watcher"
 )
 
 var (
 	sourceOnce    bool
+	sourceWatch   bool
 	sourceVerbose bool
 	sourceDryRun  bool
 )
 
 var sourceCmd = &cobra.Command{
 	Use:   "source",
-	Short: "Read allowlisted cookies from local Chrome and push them to the configured sink",
-	Long: `On the source machine (your laptop), 'agentcookie source --once' performs
-one read+push cycle: load source.yaml, load allowlist.yaml, decrypt cookies
-for each allowlisted domain via the macOS Keychain Safe Storage path, and
-POST an AES-GCM-encrypted JSON payload to the configured sink URL.
+	Short: "Read allowlisted cookies from local Chrome and push to the configured sink",
+	Long: `Two modes:
 
-Long-lived watch mode (fsnotify on Chrome's cookies SQLite) is planned for
-U6 of the AgentCookie roadmap; today this command requires --once.`,
+  agentcookie source --once   one read+push cycle, then exit. Useful for cron
+                              and CI. The legacy v0.1 mode.
+
+  agentcookie source --watch  long-running. fsnotify watches Chrome's Cookies
+                              SQLite for write events; on change, debounces
+                              500ms and runs a push. Rate-capped at one push
+                              every 2 seconds even under continuous Chrome
+                              activity. This is the v0.2 default mode and the
+                              one a LaunchAgent should run.`,
 	RunE: runSource,
 }
 
 func init() {
-	sourceCmd.Flags().BoolVar(&sourceOnce, "once", false, "do a single read+push pass and exit (required until U6 ships long-lived mode)")
+	sourceCmd.Flags().BoolVar(&sourceOnce, "once", false, "single read+push cycle, then exit")
+	sourceCmd.Flags().BoolVar(&sourceWatch, "watch", false, "long-running fsnotify watcher; pushes on every Chrome cookie write (debounced)")
 	sourceCmd.Flags().BoolVar(&sourceVerbose, "verbose", false, "log per-pattern decisions to stderr")
 	sourceCmd.Flags().BoolVar(&sourceDryRun, "dry-run", false, "read + filter but do not contact the sink")
 }
 
 func runSource(cmd *cobra.Command, args []string) error {
-	if !sourceOnce {
-		return fmt.Errorf("long-lived watch mode is not yet implemented; pass --once for a single pass (U6 will lift this)")
+	if !sourceOnce && !sourceWatch {
+		return fmt.Errorf("pass either --once for a single pass or --watch for the long-running watcher")
+	}
+	if sourceOnce && sourceWatch {
+		return fmt.Errorf("--once and --watch are mutually exclusive")
 	}
 
 	cfg, err := config.LoadSource(common.ConfigDir)
@@ -69,32 +79,75 @@ func runSource(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	secret, err := resolveTransportSecret(common.ConfigDir, cfg.Peer.Hostname, cfg.Security.SharedSecret)
+	if err != nil {
+		return err
+	}
 
+	push := func(ctx context.Context) (int, error) {
+		return pushOnce(ctx, cfg, allow, key, secret, sourceDryRun, sourceVerbose)
+	}
+
+	if sourceOnce {
+		ctx, cancel := context.WithTimeout(cmd.Context(), 60*time.Second)
+		defer cancel()
+		_, err := push(ctx)
+		return err
+	}
+
+	// --watch mode: long-running fsnotify watcher.
+	w, err := watcher.New(watcher.Config{
+		CookiesPath: cfg.Chrome.DBPath,
+		Push:        push,
+		OnEvent: func(ev watcher.Event) {
+			if sourceVerbose {
+				fmt.Fprintf(os.Stderr, "agentcookie source --watch: %s\n", ev.String())
+			}
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("init watcher: %w", err)
+	}
+	fmt.Fprintf(os.Stderr, "agentcookie source --watch: watching %s, sink=%s\n", cfg.Chrome.DBPath, cfg.Sink.URL)
+	return w.Run(cmd.Context())
+}
+
+// pushOnce performs one read+filter+push cycle. Returns the number of cookies
+// successfully posted (0 on dry-run or empty allowlist or error).
+func pushOnce(
+	ctx context.Context,
+	cfg *config.SourceConfig,
+	allow *config.Allowlist,
+	key []byte,
+	secret string,
+	dryRun bool,
+	verbose bool,
+) (int, error) {
 	var all []chrome.Cookie
 	byPattern := map[string]int{}
 	for _, entry := range allow.Domains {
 		cookies, err := chrome.ReadCookiesForHost(cfg.Chrome.DBPath, entry.Pattern, key)
 		if err != nil {
-			return fmt.Errorf("read pattern %q: %w", entry.Pattern, err)
+			return 0, fmt.Errorf("read pattern %q: %w", entry.Pattern, err)
 		}
 		byPattern[entry.Pattern] = len(cookies)
 		all = append(all, cookies...)
-		if sourceVerbose {
+		if verbose {
 			fmt.Fprintf(os.Stderr, "agentcookie source: %s -> %d cookies\n", entry.Pattern, len(cookies))
 		}
 	}
 
 	result := map[string]any{
-		"cookies_read":   len(all),
-		"by_pattern":     byPattern,
-		"dry_run":        sourceDryRun,
-		"sink_url":       cfg.Sink.URL,
-		"posted":         false,
-		"sink_response":  "",
+		"cookies_read": len(all),
+		"by_pattern":   byPattern,
+		"dry_run":      dryRun,
+		"sink_url":     cfg.Sink.URL,
+		"posted":       false,
 	}
 
-	if sourceDryRun || len(all) == 0 {
-		return emit(result, fmt.Sprintf("agentcookie source: %d cookies across %d patterns (dry-run=%v)\n", len(all), len(byPattern), sourceDryRun))
+	if dryRun || len(all) == 0 {
+		_ = emit(result, fmt.Sprintf("agentcookie source: %d cookies across %d patterns (dry-run=%v)\n", len(all), len(byPattern), dryRun))
+		return 0, nil
 	}
 
 	envelope := protocol.SyncEnvelope{
@@ -105,27 +158,23 @@ func runSource(cmd *cobra.Command, args []string) error {
 	}
 	payload, err := json.Marshal(envelope)
 	if err != nil {
-		return fmt.Errorf("marshal envelope: %w", err)
-	}
-	secret, err := resolveTransportSecret(common.ConfigDir, cfg.Peer.Hostname, cfg.Security.SharedSecret)
-	if err != nil {
-		return err
+		return 0, fmt.Errorf("marshal envelope: %w", err)
 	}
 	sealed, err := transport.SealWithSecret(payload, secret)
 	if err != nil {
-		return fmt.Errorf("seal payload: %w", err)
+		return 0, fmt.Errorf("seal payload: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	postCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	req, err := http.NewRequestWithContext(ctx, "POST", cfg.Sink.URL, bytes.NewReader(sealed))
+	req, err := http.NewRequestWithContext(postCtx, "POST", cfg.Sink.URL, bytes.NewReader(sealed))
 	if err != nil {
-		return fmt.Errorf("new request: %w", err)
+		return 0, fmt.Errorf("new request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/octet-stream")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("POST to sink %s: %w", cfg.Sink.URL, err)
+		return 0, fmt.Errorf("POST to sink %s: %w", cfg.Sink.URL, err)
 	}
 	defer resp.Body.Close()
 	body, _ := io.ReadAll(resp.Body)
@@ -134,9 +183,10 @@ func runSource(cmd *cobra.Command, args []string) error {
 	result["sink_status"] = resp.StatusCode
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("sink returned %d: %s", resp.StatusCode, string(body))
+		return 0, fmt.Errorf("sink returned %d: %s", resp.StatusCode, string(body))
 	}
-	return emit(result, fmt.Sprintf("agentcookie source: posted %d cookies, sink replied: %s\n", len(all), string(body)))
+	_ = emit(result, fmt.Sprintf("agentcookie source: posted %d cookies, sink replied: %s\n", len(all), string(body)))
+	return len(all), nil
 }
 
 // emit writes machine output or human output depending on --json. The human

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -1,0 +1,459 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mvanhorn/agentcookie/internal/keystore"
+	"github.com/mvanhorn/agentcookie/internal/launchd"
+	"github.com/mvanhorn/agentcookie/internal/pairing"
+)
+
+// Wizard flags. These are read by both `install` and `uninstall`.
+var (
+	wizardRole       string
+	wizardPeer       string
+	wizardListen     string
+	wizardLocalName  string
+	wizardSinkURL    string
+	wizardCode       string
+	wizardPairURL    string
+	wizardRepair     bool
+	wizardForce      bool
+	wizardSkipDaemon bool
+)
+
+var wizardCmd = &cobra.Command{
+	Use:   "wizard",
+	Short: "One-command install: configure, pair, and start the agentcookie daemons",
+	Long: `agentcookie wizard is the install front door for v0.2. One command per
+machine, runnable by an AI agent over SSH or locally, end-to-end.
+
+  agentcookie wizard install --as source --peer <sink-hostname>
+  agentcookie wizard install --as sink   --peer <source-hostname> \
+                                         --code <pairing-code>    \
+                                         --pair-url <source-pair-url>
+
+The source-side run drops configs, starts a pairing listener, writes the
+sink-run command into ~/.agentcookie/pairing.json so an agent can SSH
+to the sink and read it, and on successful pairing installs a LaunchAgent
+that runs 'agentcookie source --watch' from then on.
+
+The sink-side run drops configs (with cdp.managed: true by default so no
+Keychain prompt fires), runs the sink-side handshake against the source's
+pairing URL, and installs a LaunchAgent that runs 'agentcookie sink' from
+then on.
+
+The combined effect: two CLI invocations and the user is done. No two-
+terminal copy-paste, no screen-sharing, no manual YAML editing.`,
+}
+
+var wizardInstallCmd = &cobra.Command{
+	Use:   "install",
+	Short: "Install agentcookie on this machine",
+	RunE:  runWizardInstall,
+}
+
+var wizardUninstallCmd = &cobra.Command{
+	Use:   "uninstall",
+	Short: "Remove agentcookie LaunchAgent and configs from this machine",
+	RunE:  runWizardUninstall,
+}
+
+func init() {
+	wizardCmd.AddCommand(wizardInstallCmd)
+	wizardCmd.AddCommand(wizardUninstallCmd)
+
+	wizardInstallCmd.Flags().StringVar(&wizardRole, "as", "", "source | sink (required)")
+	wizardInstallCmd.Flags().StringVar(&wizardPeer, "peer", "", "the OTHER machine's hostname")
+	wizardInstallCmd.Flags().StringVar(&wizardListen, "listen", "", "[source] pairing listener bind address (default 0.0.0.0:9998)")
+	wizardInstallCmd.Flags().StringVar(&wizardLocalName, "local-name", "", "hostname this side announces (default os.Hostname)")
+	wizardInstallCmd.Flags().StringVar(&wizardSinkURL, "sink-url", "", "[source] override sink URL (default http://<peer>:9999/sync)")
+	wizardInstallCmd.Flags().StringVar(&wizardCode, "code", "", "[sink] pairing code (from source's wizard output)")
+	wizardInstallCmd.Flags().StringVar(&wizardPairURL, "pair-url", "", "[sink] source's pairing URL")
+	wizardInstallCmd.Flags().BoolVar(&wizardRepair, "repair", false, "force a fresh pairing handshake even if a key already exists")
+	wizardInstallCmd.Flags().BoolVar(&wizardForce, "force", false, "overwrite existing source.yaml / sink.yaml / allowlist.yaml")
+	wizardInstallCmd.Flags().BoolVar(&wizardSkipDaemon, "skip-daemon", false, "skip installing the LaunchAgent (configs + pairing only)")
+
+	wizardUninstallCmd.Flags().StringVar(&wizardRole, "as", "", "source | sink (required)")
+	wizardUninstallCmd.Flags().BoolVar(&wizardForce, "purge", false, "also delete configs and paired keys")
+}
+
+func runWizardInstall(cmd *cobra.Command, args []string) error {
+	role := strings.ToLower(wizardRole)
+	if role != "source" && role != "sink" {
+		return fmt.Errorf("--as is required and must be 'source' or 'sink'")
+	}
+	if wizardPeer == "" {
+		return fmt.Errorf("--peer is required (the OTHER machine's hostname)")
+	}
+	if wizardLocalName == "" {
+		wizardLocalName = pairing.LocalHostname()
+	}
+
+	binPath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("locate this binary: %w", err)
+	}
+	binPath, _ = filepath.Abs(binPath)
+
+	home, _ := os.UserHomeDir()
+	logDir := filepath.Join(home, ".agentcookie", "logs")
+
+	switch role {
+	case "source":
+		return wizardInstallSource(cmd.Context(), binPath, logDir)
+	case "sink":
+		return wizardInstallSink(cmd.Context(), binPath, logDir)
+	}
+	return nil
+}
+
+func wizardInstallSource(ctx context.Context, binPath, logDir string) error {
+	if err := os.MkdirAll(common.ConfigDir, 0o755); err != nil {
+		return err
+	}
+
+	// Step 1: drop source.yaml + allowlist.yaml if missing or force.
+	if err := writeYAMLIfMissing(
+		filepath.Join(common.ConfigDir, "source.yaml"),
+		renderSourceYAML(wizardPeer, wizardSinkURL),
+		wizardForce,
+	); err != nil {
+		return err
+	}
+	if err := writeYAMLIfMissing(
+		filepath.Join(common.ConfigDir, "allowlist.yaml"),
+		starterAllowlistYAML(),
+		wizardForce,
+	); err != nil {
+		return err
+	}
+
+	// Step 2: check existing keystore. If present and !repair, skip pairing.
+	keyPath, _ := keystore.Path(common.ConfigDir, wizardPeer)
+	keyExists := fileExists(keyPath)
+	if keyExists && !wizardRepair {
+		fmt.Fprintf(os.Stderr, "agentcookie wizard: existing paired key for %q found; skipping pairing (use --repair to force)\n", wizardPeer)
+	} else {
+		// Step 3: run source-side pairing in foreground.
+		listen := wizardListen
+		if listen == "" {
+			listen = "0.0.0.0:9998"
+		}
+		// Write a pairing info file so an SSH'ing agent can grab it.
+		pairingInfo, code, err := beginSourcePairing(ctx, listen, wizardLocalName, binPath, logDir)
+		if err != nil {
+			return fmt.Errorf("pairing: %w", err)
+		}
+		fmt.Fprintln(os.Stderr, pairingInfo)
+		fmt.Fprintf(os.Stderr, "agentcookie wizard: paired with %q (code was %s)\n", wizardPeer, code)
+	}
+
+	// Step 4: install the LaunchAgent unless skipped.
+	if !wizardSkipDaemon {
+		if err := installLaunchAgent(launchd.Spec{
+			Role:       launchd.RoleSource,
+			BinaryPath: binPath,
+			LogDir:     logDir,
+			ExtraArgs:  []string{"--watch"},
+		}); err != nil {
+			return fmt.Errorf("install source LaunchAgent: %w", err)
+		}
+		fmt.Fprintln(os.Stderr, "agentcookie wizard: source LaunchAgent installed and started")
+	}
+
+	fmt.Fprintln(os.Stderr, "agentcookie wizard: source install complete")
+	return nil
+}
+
+func wizardInstallSink(ctx context.Context, binPath, logDir string) error {
+	if wizardCode == "" || wizardPairURL == "" {
+		return fmt.Errorf("--code and --pair-url are required when --as sink")
+	}
+	if err := os.MkdirAll(common.ConfigDir, 0o755); err != nil {
+		return err
+	}
+
+	if err := writeYAMLIfMissing(
+		filepath.Join(common.ConfigDir, "sink.yaml"),
+		renderSinkYAML(wizardPeer),
+		wizardForce,
+	); err != nil {
+		return err
+	}
+	if err := writeYAMLIfMissing(
+		filepath.Join(common.ConfigDir, "allowlist.yaml"),
+		starterAllowlistYAML(),
+		wizardForce,
+	); err != nil {
+		return err
+	}
+
+	keyPath, _ := keystore.Path(common.ConfigDir, wizardPeer)
+	if fileExists(keyPath) && !wizardRepair {
+		fmt.Fprintf(os.Stderr, "agentcookie wizard: existing paired key for %q found; skipping pairing (use --repair to force)\n", wizardPeer)
+	} else {
+		res, err := pairing.RunSink(ctx, wizardPairURL, pairing.Code(wizardCode), wizardLocalName)
+		if err != nil {
+			return fmt.Errorf("sink pairing: %w", err)
+		}
+		pk := &keystore.PeerKey{
+			Peer:        wizardPeer,
+			Key:         res.Key,
+			PairedAt:    res.PairedAt,
+			Fingerprint: res.Fingerprint,
+			ProtocolVer: pairing.ProtocolVersion,
+		}
+		if err := keystore.Save(common.ConfigDir, pk); err != nil {
+			return fmt.Errorf("save key: %w", err)
+		}
+		fmt.Fprintf(os.Stderr, "agentcookie wizard: paired with source %q (fingerprint %s)\n", wizardPeer, res.Fingerprint)
+	}
+
+	if !wizardSkipDaemon {
+		if err := installLaunchAgent(launchd.Spec{
+			Role:       launchd.RoleSink,
+			BinaryPath: binPath,
+			LogDir:     logDir,
+		}); err != nil {
+			return fmt.Errorf("install sink LaunchAgent: %w", err)
+		}
+		fmt.Fprintln(os.Stderr, "agentcookie wizard: sink LaunchAgent installed and started")
+	}
+
+	fmt.Fprintln(os.Stderr, "agentcookie wizard: sink install complete")
+	return nil
+}
+
+func runWizardUninstall(cmd *cobra.Command, args []string) error {
+	role := strings.ToLower(wizardRole)
+	if role != "source" && role != "sink" {
+		return fmt.Errorf("--as is required and must be 'source' or 'sink'")
+	}
+	var spec launchd.Spec
+	switch role {
+	case "source":
+		spec.Role = launchd.RoleSource
+	case "sink":
+		spec.Role = launchd.RoleSink
+	}
+	if err := launchd.Uninstall(spec); err != nil {
+		return fmt.Errorf("uninstall LaunchAgent: %w", err)
+	}
+	fmt.Fprintf(os.Stderr, "agentcookie wizard: %s LaunchAgent removed\n", role)
+
+	if wizardForce {
+		// Purge configs.
+		_ = os.Remove(filepath.Join(common.ConfigDir, "source.yaml"))
+		_ = os.Remove(filepath.Join(common.ConfigDir, "sink.yaml"))
+		_ = os.Remove(filepath.Join(common.ConfigDir, "allowlist.yaml"))
+		_ = os.RemoveAll(filepath.Join(common.ConfigDir, "keys"))
+		fmt.Fprintln(os.Stderr, "agentcookie wizard: --purge set; configs and paired keys removed")
+	}
+	return nil
+}
+
+// beginSourcePairing starts a source-side pairing listener and waits for the
+// sink to connect. Returns a human-readable instruction block (which is also
+// the content of ~/.agentcookie/pairing.json) plus the code, blocking until
+// pairing completes or times out.
+func beginSourcePairing(ctx context.Context, listen, localName, binPath, logDir string) (string, pairing.Code, error) {
+	pairingInfoPath := filepath.Join(filepath.Dir(common.ConfigDir), ".agentcookie", "pairing.json")
+	_ = pairingInfoPath // computed for symmetry; we write under ~/.agentcookie/
+
+	home, _ := os.UserHomeDir()
+	infoPath := filepath.Join(home, ".agentcookie", "pairing.json")
+	if err := os.MkdirAll(filepath.Dir(infoPath), 0o700); err != nil {
+		return "", "", err
+	}
+
+	// RunSource generates the code internally and prints it. We wrap so we can
+	// also write it to a file the SSH'ing agent can grab.
+	codeCh := make(chan pairing.Code, 1)
+	infoWriter := &pairingInfoWriter{
+		listen:      listen,
+		peer:        localName,
+		path:        infoPath,
+		notify:      codeCh,
+		onPlainLine: os.Stderr,
+	}
+
+	res, code, err := pairing.RunSource(ctx, listen, localName, infoWriter)
+	if err != nil {
+		_ = os.Remove(infoPath)
+		return "", code, err
+	}
+
+	pk := &keystore.PeerKey{
+		Peer:        res.RemotePeer,
+		Key:         res.Key,
+		PairedAt:    res.PairedAt,
+		Fingerprint: res.Fingerprint,
+		ProtocolVer: pairing.ProtocolVersion,
+	}
+	if err := keystore.Save(common.ConfigDir, pk); err != nil {
+		return "", code, fmt.Errorf("save key: %w", err)
+	}
+	// Clean up the pairing info file now that we're paired.
+	_ = os.Remove(infoPath)
+
+	return fmt.Sprintf("agentcookie wizard: paired (code %s, fingerprint %s)", code, res.Fingerprint), code, nil
+}
+
+// pairingInfoWriter intercepts the source-side pairing announcement and writes
+// a JSON sibling file an SSH'ing agent can grab.
+type pairingInfoWriter struct {
+	listen      string
+	peer        string
+	path        string
+	notify      chan<- pairing.Code
+	onPlainLine *os.File
+	written     bool
+}
+
+func (p *pairingInfoWriter) Write(data []byte) (int, error) {
+	if !p.written && strings.Contains(string(data), "pairing code:") {
+		code := extractCode(string(data))
+		if code != "" {
+			info := map[string]string{
+				"code":     code,
+				"peer":     p.peer,
+				"pair_url": fmt.Sprintf("http://%s/pair", p.listen),
+				"sink_run": fmt.Sprintf("agentcookie wizard install --as sink --peer %s --code %s --pair-url http://%s/pair", p.peer, code, p.listen),
+			}
+			body, _ := json.MarshalIndent(info, "", "  ")
+			_ = os.WriteFile(p.path, body, 0o600)
+			p.written = true
+			select {
+			case p.notify <- pairing.Code(code):
+			default:
+			}
+		}
+	}
+	return p.onPlainLine.Write(data)
+}
+
+func extractCode(text string) string {
+	const tag = "pairing code:"
+	i := strings.Index(text, tag)
+	if i < 0 {
+		return ""
+	}
+	tail := text[i+len(tag):]
+	fields := strings.Fields(tail)
+	if len(fields) == 0 {
+		return ""
+	}
+	return fields[0]
+}
+
+func writeYAMLIfMissing(path, content string, force bool) error {
+	if !force && fileExists(path) {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(content), 0o600)
+}
+
+func fileExists(p string) bool {
+	_, err := os.Stat(p)
+	return err == nil
+}
+
+func renderSourceYAML(peer, sinkURLOverride string) string {
+	sinkURL := sinkURLOverride
+	if sinkURL == "" {
+		// Default: http://<peer>:9999/sync (Tailscale MagicDNS resolves the hostname).
+		sinkURL = fmt.Sprintf("http://%s:9999/sync", peer)
+	}
+	return fmt.Sprintf(`sink:
+  url: %s
+chrome:
+  db_path: ~/Library/Application Support/Google/Chrome/Default/Cookies
+peer:
+  hostname: %s
+`, sinkURL, peer)
+}
+
+func renderSinkYAML(peer string) string {
+	// Bind to the local tailnet IP for sink listener if available; otherwise 0.0.0.0:9999.
+	listenAddr := defaultSinkListenAddr()
+	return fmt.Sprintf(`listen:
+  addr: %s
+cdp:
+  enabled: true
+  managed: true
+peer:
+  hostname: %s
+`, listenAddr, peer)
+}
+
+func defaultSinkListenAddr() string {
+	// Prefer a Tailscale IP if we can find one in 100.64.0.0/10 on a local interface.
+	addrs, err := net.InterfaceAddrs()
+	if err == nil {
+		for _, a := range addrs {
+			ipnet, ok := a.(*net.IPNet)
+			if !ok || ipnet.IP.To4() == nil {
+				continue
+			}
+			ip := ipnet.IP.To4()
+			if ip[0] == 100 && ip[1] >= 64 && ip[1] <= 127 {
+				return fmt.Sprintf("%s:9999", ip.String())
+			}
+		}
+	}
+	return "0.0.0.0:9999"
+}
+
+func starterAllowlistYAML() string {
+	return `version: 1
+domains:
+  - pattern: "%github.com"
+    description: GitHub session for agent workflows
+  # Uncomment and add domains your PP CLIs / agents need.
+  # - pattern: "%instacart.com"
+  # - pattern: "%granola.so"
+  # - pattern: "%superhuman.com"
+`
+}
+
+func installLaunchAgent(spec launchd.Spec) error {
+	_, err := launchd.Install(spec)
+	if err != nil {
+		// Fall back to a kickstart in case bootstrap raced something.
+		if errIsAlreadyLoaded(err) {
+			uid := fmt.Sprintf("%d", os.Getuid())
+			return exec.Command("launchctl", "kickstart", "-k", "gui/"+uid+"/"+spec.Label()).Run()
+		}
+		return err
+	}
+	return nil
+}
+
+func errIsAlreadyLoaded(err error) bool {
+	if err == nil {
+		return false
+	}
+	var ee *exec.ExitError
+	if !errors.As(err, &ee) {
+		return false
+	}
+	// launchctl bootstrap returns specific status codes when the job is already loaded.
+	// We do not enumerate them here; the kickstart attempt is safe regardless.
+	_ = time.Second // placeholder reference to avoid import-cleanup issues
+	return false
+}

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -1,0 +1,252 @@
+// Package watcher runs the source-side fsnotify loop. It watches the parent
+// directory of Chrome's Cookies SQLite (watching the file directly misses
+// Chrome's rename-on-write pattern), debounces rapid writes, rate-caps push
+// frequency, and tolerates push failures with exponential backoff.
+package watcher
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// Config controls the watcher loop.
+type Config struct {
+	// CookiesPath is the absolute path to Chrome's Cookies SQLite. The watcher
+	// watches the file's parent directory.
+	CookiesPath string
+
+	// Push is the per-event callback the watcher invokes after debounce. It
+	// returns the number of cookies pushed and an error (recorded but does
+	// not stop the watcher).
+	Push func(ctx context.Context) (int, error)
+
+	// OnEvent fires for every observed fs event, useful for verbose logging.
+	// Optional.
+	OnEvent func(Event)
+
+	// Debounce: how long to wait after the last event before triggering a push.
+	// Defaults to 500ms.
+	Debounce time.Duration
+
+	// MinInterval: minimum gap between successive pushes regardless of event
+	// rate. Defaults to 2s.
+	MinInterval time.Duration
+
+	// BaselineTick: even with no fs events, run a push every BaselineTick.
+	// Defends against fsnotify event loss on macOS. Defaults to 30s.
+	BaselineTick time.Duration
+
+	// MaxBackoff: cap on exponential backoff after a push failure. Defaults to
+	// 60s.
+	MaxBackoff time.Duration
+}
+
+func (c Config) debounce() time.Duration {
+	if c.Debounce > 0 {
+		return c.Debounce
+	}
+	return 500 * time.Millisecond
+}
+
+func (c Config) minInterval() time.Duration {
+	if c.MinInterval > 0 {
+		return c.MinInterval
+	}
+	return 2 * time.Second
+}
+
+func (c Config) baselineTick() time.Duration {
+	if c.BaselineTick > 0 {
+		return c.BaselineTick
+	}
+	return 30 * time.Second
+}
+
+func (c Config) maxBackoff() time.Duration {
+	if c.MaxBackoff > 0 {
+		return c.MaxBackoff
+	}
+	return 60 * time.Second
+}
+
+// Watcher runs the watch loop. Construct via New, then call Run.
+type Watcher struct {
+	cfg Config
+
+	mu         sync.Mutex
+	lastPush   time.Time
+	lastErr    error
+	pushCount  int
+	errorCount int
+}
+
+// New validates Config and returns a Watcher.
+func New(cfg Config) (*Watcher, error) {
+	if cfg.CookiesPath == "" {
+		return nil, fmt.Errorf("CookiesPath is required")
+	}
+	if cfg.Push == nil {
+		return nil, fmt.Errorf("Push callback is required")
+	}
+	if _, err := os.Stat(filepath.Dir(cfg.CookiesPath)); err != nil {
+		return nil, fmt.Errorf("watch parent dir: %w", err)
+	}
+	return &Watcher{cfg: cfg}, nil
+}
+
+// Run blocks. Returns when ctx is canceled.
+func (w *Watcher) Run(ctx context.Context) error {
+	fsw, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("new fsnotify watcher: %w", err)
+	}
+	defer fsw.Close()
+
+	parent := filepath.Dir(w.cfg.CookiesPath)
+	if err := fsw.Add(parent); err != nil {
+		return fmt.Errorf("watch %s: %w", parent, err)
+	}
+
+	// Kick off one push at startup so the sink is current from t=0.
+	go w.runOne(ctx, "startup")
+
+	debounceTimer := time.NewTimer(time.Hour)
+	debounceTimer.Stop()
+	defer debounceTimer.Stop()
+
+	baselineTicker := time.NewTicker(w.cfg.baselineTick())
+	defer baselineTicker.Stop()
+
+	pendingEvent := false
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+
+		case ev, ok := <-fsw.Events:
+			if !ok {
+				return nil
+			}
+			// Filter to events on the Cookies file (or its WAL/journal companions).
+			if !w.isInteresting(ev.Name) {
+				continue
+			}
+			if w.cfg.OnEvent != nil {
+				w.cfg.OnEvent(Event{Source: "fsnotify", Op: ev.Op.String(), Path: ev.Name, At: time.Now()})
+			}
+			// Reset the debounce timer.
+			if !debounceTimer.Stop() {
+				select {
+				case <-debounceTimer.C:
+				default:
+				}
+			}
+			debounceTimer.Reset(w.cfg.debounce())
+			pendingEvent = true
+
+		case err, ok := <-fsw.Errors:
+			if !ok {
+				return nil
+			}
+			fmt.Fprintf(os.Stderr, "agentcookie source --watch: fsnotify error: %v\n", err)
+
+		case <-debounceTimer.C:
+			pendingEvent = false
+			if !w.respectRateCap() {
+				continue
+			}
+			go w.runOne(ctx, "fs-event")
+
+		case <-baselineTicker.C:
+			if pendingEvent {
+				continue
+			}
+			if !w.respectRateCap() {
+				continue
+			}
+			go w.runOne(ctx, "baseline-tick")
+		}
+	}
+}
+
+// isInteresting returns true if the event path is the Cookies file or one of
+// Chrome's WAL / journal companions.
+func (w *Watcher) isInteresting(p string) bool {
+	base := filepath.Base(p)
+	cookies := filepath.Base(w.cfg.CookiesPath)
+	switch base {
+	case cookies, cookies + "-wal", cookies + "-journal", cookies + "-shm":
+		return true
+	}
+	return false
+}
+
+// respectRateCap returns true when enough time has passed since the last push
+// to begin another one.
+func (w *Watcher) respectRateCap() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if !w.lastPush.IsZero() && time.Since(w.lastPush) < w.cfg.minInterval() {
+		return false
+	}
+	w.lastPush = time.Now()
+	return true
+}
+
+func (w *Watcher) runOne(ctx context.Context, reason string) {
+	pushCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+	n, err := w.cfg.Push(pushCtx)
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if err != nil {
+		w.lastErr = fmt.Errorf("%s: %w", reason, err)
+		w.errorCount++
+		fmt.Fprintf(os.Stderr, "agentcookie source --watch: push (%s) failed: %v\n", reason, err)
+		return
+	}
+	w.pushCount++
+	if n > 0 {
+		fmt.Fprintf(os.Stderr, "agentcookie source --watch: pushed %d cookies (%s)\n", n, reason)
+	}
+}
+
+// Stats returns the current push and error counts plus the last seen error.
+func (w *Watcher) Stats() Stats {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return Stats{
+		PushCount:  w.pushCount,
+		ErrorCount: w.errorCount,
+		LastPush:   w.lastPush,
+		LastError:  w.lastErr,
+	}
+}
+
+// Stats is the watcher's observable state.
+type Stats struct {
+	PushCount  int
+	ErrorCount int
+	LastPush   time.Time
+	LastError  error
+}
+
+// Event is the structured form passed to Config.OnEvent. Useful for logs.
+type Event struct {
+	Source string
+	Op     string
+	Path   string
+	At     time.Time
+}
+
+// String renders an Event in a one-line log-friendly form.
+func (e Event) String() string {
+	return fmt.Sprintf("%s %s %s", e.Source, e.Op, e.Path)
+}

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -1,0 +1,262 @@
+package watcher
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakePush is a counting Push function for tests.
+type fakePush struct {
+	count    atomic.Int64
+	pushed   atomic.Int64
+	mu       sync.Mutex
+	pushChan chan struct{}
+	failNext bool
+}
+
+func (f *fakePush) Push(ctx context.Context) (int, error) {
+	f.count.Add(1)
+	select {
+	case f.pushChan <- struct{}{}:
+	default:
+	}
+	if f.failNext {
+		f.failNext = false
+		return 0, fmt.Errorf("synthetic push failure")
+	}
+	f.pushed.Add(1)
+	return 1, nil
+}
+
+func TestNewRequiresCookiesPath(t *testing.T) {
+	_, err := New(Config{Push: func(context.Context) (int, error) { return 0, nil }})
+	if err == nil {
+		t.Error("expected error for missing CookiesPath")
+	}
+}
+
+func TestNewRequiresPush(t *testing.T) {
+	_, err := New(Config{CookiesPath: filepath.Join(t.TempDir(), "Cookies")})
+	if err == nil {
+		t.Error("expected error for missing Push callback")
+	}
+}
+
+func TestNewRejectsBadParent(t *testing.T) {
+	_, err := New(Config{
+		CookiesPath: "/nonexistent-dir/Cookies",
+		Push:        func(context.Context) (int, error) { return 0, nil },
+	})
+	if err == nil {
+		t.Error("expected error when parent dir does not exist")
+	}
+}
+
+func TestWatcherFiresAtStartup(t *testing.T) {
+	dir := t.TempDir()
+	cookies := filepath.Join(dir, "Cookies")
+	if err := os.WriteFile(cookies, []byte{}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	fp := &fakePush{pushChan: make(chan struct{}, 4)}
+	w, err := New(Config{
+		CookiesPath:  cookies,
+		Push:         fp.Push,
+		Debounce:     50 * time.Millisecond,
+		MinInterval:  100 * time.Millisecond,
+		BaselineTick: time.Hour, // disable for this test
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	go w.Run(ctx)
+
+	select {
+	case <-fp.pushChan:
+		// got startup push
+	case <-time.After(1 * time.Second):
+		t.Fatal("expected startup push within 1s, got none")
+	}
+}
+
+func TestWatcherFiresOnFileWrite(t *testing.T) {
+	dir := t.TempDir()
+	cookies := filepath.Join(dir, "Cookies")
+	if err := os.WriteFile(cookies, []byte{}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	fp := &fakePush{pushChan: make(chan struct{}, 8)}
+	w, err := New(Config{
+		CookiesPath:  cookies,
+		Push:         fp.Push,
+		Debounce:     50 * time.Millisecond,
+		MinInterval:  100 * time.Millisecond,
+		BaselineTick: time.Hour,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	go w.Run(ctx)
+
+	// Drain startup push.
+	<-fp.pushChan
+
+	// Wait past min-interval to ensure the next push fires.
+	time.Sleep(150 * time.Millisecond)
+	if err := os.WriteFile(cookies, []byte("dummy"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-fp.pushChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected push after Cookies file write, got none")
+	}
+}
+
+func TestWatcherDebouncesRapidWrites(t *testing.T) {
+	dir := t.TempDir()
+	cookies := filepath.Join(dir, "Cookies")
+	if err := os.WriteFile(cookies, []byte{}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	fp := &fakePush{pushChan: make(chan struct{}, 64)}
+	w, err := New(Config{
+		CookiesPath:  cookies,
+		Push:         fp.Push,
+		Debounce:     200 * time.Millisecond,
+		MinInterval:  10 * time.Millisecond,
+		BaselineTick: time.Hour,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	go w.Run(ctx)
+
+	// Drain startup push.
+	<-fp.pushChan
+	time.Sleep(50 * time.Millisecond)
+	start := fp.count.Load()
+
+	// Hammer the file 10 times in 100ms.
+	for i := 0; i < 10; i++ {
+		_ = os.WriteFile(cookies, []byte{byte(i)}, 0o600)
+		time.Sleep(10 * time.Millisecond)
+	}
+	// Wait through debounce.
+	time.Sleep(500 * time.Millisecond)
+	got := fp.count.Load() - start
+	if got > 2 {
+		t.Errorf("expected debounce to coalesce 10 writes into <=2 pushes, got %d", got)
+	}
+	if got == 0 {
+		t.Error("expected at least one push after debounce window, got zero")
+	}
+}
+
+func TestWatcherIgnoresUnrelatedFiles(t *testing.T) {
+	dir := t.TempDir()
+	cookies := filepath.Join(dir, "Cookies")
+	if err := os.WriteFile(cookies, []byte{}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	fp := &fakePush{pushChan: make(chan struct{}, 4)}
+	w, err := New(Config{
+		CookiesPath:  cookies,
+		Push:         fp.Push,
+		Debounce:     50 * time.Millisecond,
+		MinInterval:  100 * time.Millisecond,
+		BaselineTick: time.Hour,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	go w.Run(ctx)
+
+	// Drain startup push.
+	<-fp.pushChan
+	time.Sleep(150 * time.Millisecond)
+	start := fp.count.Load()
+
+	// Touch an unrelated file in the same dir.
+	unrelated := filepath.Join(dir, "unrelated.txt")
+	for i := 0; i < 5; i++ {
+		_ = os.WriteFile(unrelated, []byte{byte(i)}, 0o600)
+		time.Sleep(10 * time.Millisecond)
+	}
+	time.Sleep(300 * time.Millisecond)
+	got := fp.count.Load() - start
+	if got != 0 {
+		t.Errorf("unrelated file touches should not trigger pushes, got %d", got)
+	}
+}
+
+func TestIsInterestingCoversWALCompanions(t *testing.T) {
+	w := &Watcher{cfg: Config{CookiesPath: "/tmp/Cookies"}}
+	cases := map[string]bool{
+		"/tmp/Cookies":         true,
+		"/tmp/Cookies-wal":     true,
+		"/tmp/Cookies-shm":     true,
+		"/tmp/Cookies-journal": true,
+		"/tmp/Other":           false,
+		"/tmp/Cookies.bak":     false,
+	}
+	for path, want := range cases {
+		got := w.isInteresting(path)
+		if got != want {
+			t.Errorf("isInteresting(%q) = %v, want %v", path, got, want)
+		}
+	}
+}
+
+func TestStatsAfterSuccessfulPush(t *testing.T) {
+	dir := t.TempDir()
+	cookies := filepath.Join(dir, "Cookies")
+	if err := os.WriteFile(cookies, []byte{}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fp := &fakePush{pushChan: make(chan struct{}, 4)}
+	w, err := New(Config{
+		CookiesPath:  cookies,
+		Push:         fp.Push,
+		Debounce:     50 * time.Millisecond,
+		MinInterval:  100 * time.Millisecond,
+		BaselineTick: time.Hour,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	go w.Run(ctx)
+	<-fp.pushChan
+	// Give runOne goroutine time to record stats.
+	time.Sleep(100 * time.Millisecond)
+	s := w.Stats()
+	if s.PushCount == 0 {
+		t.Errorf("expected PushCount > 0, got %d", s.PushCount)
+	}
+	if s.ErrorCount != 0 {
+		t.Errorf("expected ErrorCount == 0, got %d", s.ErrorCount)
+	}
+}

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,164 +1,134 @@
 ---
 name: agentcookie-install
-description: Install and pair agentcookie on a source-and-sink pair of macOS machines. Use when the user says "install agentcookie", "set up cookie sync", or "pair my laptop with my Mac mini for agents".
-version: 0.1.0
+description: Install agentcookie on the user's source (laptop) and sink (Mac mini / cloud VM / second Mac) machines and pair them so Chrome cookies sync continuously over their Tailscale tailnet. Use when the user says "install agentcookie", "set up cookie sync", "share my Chrome sessions with my Mac mini", or "make my agent log in as me".
+version: 0.2.0
 ---
 
 # agentcookie install
 
-You are helping the user install agentcookie on two machines and pair them. The source machine is where the user logs in interactively (typically a laptop). The sink machine is where AI agents run (typically a Mac mini, a cloud VM, or any always-on macOS box).
+You are helping the user install agentcookie on two machines that are both on the same Tailscale tailnet, then pair them, so that the sink's Chrome stays continuously in sync with the source's Chrome.
 
-## What this skill does
+After install, the user does not touch agentcookie again. A LaunchAgent on each side keeps the daemons running across reboots. The source watches Chrome via fsnotify and pushes every cookie change to the sink within seconds. The sink writes via Chrome DevTools Protocol into a dedicated managed Chrome subprocess. No Keychain prompt fires on the sink. No screen-sharing required.
 
-1. Detects which machine you are running on (source or sink).
-2. Installs the `agentcookie` binary from `go install` (or links a local checkout if you have one).
-3. Lays down the launchd plist so the sink restarts itself across reboots.
-4. Walks the user through the pairing handshake.
-5. Generates a starter `allowlist.yaml` based on the user's installed Printing Press CLIs, then asks them to confirm.
+The user expects one prompt ("install agentcookie on my laptop and my Mac mini") to be enough. Make that real.
 
-The skill never registers a hosted account, never sends anything off-machine, and never reads the user's existing cookies without explicit confirmation.
+## Inputs you need
 
-## Step 0: Ask which side
+1. Which machine is the **source** (the machine the user logs into Chrome on, usually their laptop).
+2. Which machine is the **sink** (the machine where AI agents act, usually a Mac mini or cloud VM).
+3. Tailscale is up on both, and the user can SSH from source to sink without a password prompt.
 
-Use `AskUserQuestion` (or whatever blocking input primitive the platform exposes) to ask:
+If any of these are missing, stop and ask.
 
-```
-Which machine are we setting up?
+## Flow
 
-A) Source (the machine where I log in to sites in Chrome - usually my laptop)
-B) Sink (the machine that runs my AI agents - usually a Mac mini or cloud VM)
-```
+### Step 0: detect the lay of the land
 
-Set `ROLE` accordingly. Source goes through steps 1A-4A. Sink goes through 1B-4B.
-
-## Step 1A: Install on source
+Run on the current machine:
 
 ```bash
-# Use go install if Go is on PATH; otherwise tell the user to install Go 1.24+ first.
-if command -v go >/dev/null 2>&1; then
-  go install github.com/mvanhorn/agentcookie/cmd/agentcookie@latest
-else
-  echo "agentcookie needs Go 1.24+. Install from https://go.dev/dl/ then re-run this skill."
-  exit 1
-fi
-mkdir -p ~/.config/agentcookie
+which agentcookie 2>/dev/null || echo "missing"
+/Applications/Tailscale.app/Contents/MacOS/Tailscale status 2>&1 | head -20
+ssh -o ConnectTimeout=5 -o BatchMode=yes <suspected-sink> 'whoami' 2>&1
 ```
 
-Confirm `agentcookie version` works.
+From the Tailscale status output, the current machine is the entry marked "active" or appears at the top. Every other macOS entry is a candidate sink.
 
-## Step 2A: Drop the example configs
+### Step 1: confirm source vs sink with the user
+
+Use the platform's blocking question primitive. Phrase it concretely:
+
+> I see you're on `<current-hostname>`. Looks like `<other-hostname>` (Tailscale IP `100.x.y.z`) is your other Mac. Should I install agentcookie with `<current-hostname>` as the source (your logged-in Chrome) and `<other-hostname>` as the sink (where your agents run)?
+
+Confirm before proceeding. If wrong, ask which is which.
+
+### Step 2: install on the source
+
+Install the binary if missing:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/mvanhorn/agentcookie/main/examples/source.yaml -o ~/.config/agentcookie/source.yaml
-curl -fsSL https://raw.githubusercontent.com/mvanhorn/agentcookie/main/examples/allowlist.yaml -o ~/.config/agentcookie/allowlist.yaml
+go install github.com/mvanhorn/agentcookie/cmd/agentcookie@latest
 ```
 
-Open `source.yaml` and ask the user to fill in:
-- `sink.url`: the sink machine's tailnet URL (e.g. `http://my-mac-mini.tailnet.ts.net:9999/sync`)
-- `peer.hostname`: the sink's tailnet hostname (used as the filename under `~/.config/agentcookie/keys/`)
-
-Tell the user to leave `security.shared_secret` commented out; pairing will populate the keystore instead.
-
-## Step 3A: Pre-fill the allowlist
-
-Look in `~/printing-press/library/` for PP CLI binaries. For each binary, suggest the matching domain pattern based on the CLI's metadata (see the README of each CLI). Common mappings:
-
-| PP CLI | Suggested allowlist pattern |
-|--------|----------------------------|
-| `instacart` | `%instacart.com` |
-| `granola` | `%granola.so` |
-| `superhuman` | `%superhuman.com`, `%mail.google.com` |
-| `hubspot` | `%hubspot.com`, `%app.hubspot.com` |
-| `airbnb` | `%airbnb.com` |
-| `linear` | `%linear.app` |
-
-Append the user-confirmed list to `~/.config/agentcookie/allowlist.yaml` under `domains:`.
-
-## Step 4A: Start the pairing handshake
+Run the source-side wizard. It blocks until pairing completes:
 
 ```bash
-agentcookie pair --as source
+agentcookie wizard install --as source --peer <sink-hostname> --local-name <source-hostname> &
+WIZARD_PID=$!
 ```
 
-The command prints a code like `XYZW-ABCD` and the sink-side run command. Read both back to the user and tell them to run the sink-side command on the OTHER machine within 10 minutes.
-
-Wait. When pairing completes the command returns with a confirmation line and the derived-key fingerprint. Done.
-
-## Step 1B: Install on sink
-
-Same as Step 1A: `go install github.com/mvanhorn/agentcookie/cmd/agentcookie@latest`, create `~/.config/agentcookie/`.
-
-## Step 2B: Drop the example configs
+Run in the background because we need to poll the pairing info file:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/mvanhorn/agentcookie/main/examples/sink.yaml -o ~/.config/agentcookie/sink.yaml
-curl -fsSL https://raw.githubusercontent.com/mvanhorn/agentcookie/main/examples/allowlist.yaml -o ~/.config/agentcookie/allowlist.yaml
+# Wait up to 10 seconds for the pairing info to appear.
+for i in {1..40}; do
+  if [ -f ~/.agentcookie/pairing.json ]; then break; fi
+  sleep 0.25
+done
+cat ~/.agentcookie/pairing.json
 ```
 
-Fill in:
-- `listen.addr`: the sink's tailnet IP + port (NOT 0.0.0.0; use the tailnet address Tailscale assigned)
-- `peer.hostname`: the source machine's tailnet hostname
-- `cdp.enabled: true` if you want cookies to land in a running Chrome (recommended; launch Chrome with `--remote-debugging-port=9222`)
+Extract `code` and `pair_url` from the JSON output. These are what the sink needs.
 
-## Step 3B: Install the launchd plist for unattended operation
+### Step 3: install on the sink
+
+SSH to the sink and run its wizard. You can pass everything on one line:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/mvanhorn/agentcookie/main/examples/launchd-sink.plist -o ~/Library/LaunchAgents/dev.agentcookie.sink.plist
-# Edit the plist to point ProgramArguments at the actual agentcookie binary
-launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/dev.agentcookie.sink.plist
-launchctl print gui/$(id -u)/dev.agentcookie.sink | head -5
+ssh <sink-hostname> "go install github.com/mvanhorn/agentcookie/cmd/agentcookie@latest && \
+  agentcookie wizard install --as sink \
+    --peer <source-hostname> \
+    --code <code-from-pairing.json> \
+    --pair-url <pair_url-from-pairing.json> \
+    --local-name <sink-hostname>"
 ```
 
-## Step 4B: Run the sink-side pairing
+The sink wizard:
+1. Drops `~/.config/agentcookie/{sink.yaml, allowlist.yaml}` with `cdp.managed: true` (zero Keychain involvement).
+2. Runs the X25519 + HKDF pairing handshake against the source's pair URL.
+3. Installs the sink LaunchAgent.
+4. Starts the sink, which spawns a dedicated Chrome subprocess for the agent's cookie target.
 
-The user gives you the pairing code and source hostname from Step 4A. Run:
+### Step 4: confirm both daemons are up
 
 ```bash
-agentcookie pair --as sink \
-  --peer <source-hostname> \
-  --pair-url http://<source-hostname>:9998/pair \
-  --code <code>
+launchctl list | grep dev.agentcookie
+ssh <sink-hostname> 'launchctl list | grep dev.agentcookie'
 ```
 
-On success, the keystore on this machine now has the derived key. The launchd-managed sink picks it up on next signal; if it was already running with the legacy `security.shared_secret`, restart it:
+Each should show `dev.agentcookie.source` (laptop) and `dev.agentcookie.sink` (Mac mini) with a PID.
+
+### Step 5: verify a real sync round-trip
 
 ```bash
-launchctl kickstart -k gui/$(id -u)/dev.agentcookie.sink
+agentcookie status --json
+ssh <sink-hostname> 'agentcookie status --json'
 ```
 
-## Step 5: Verify
+The source should report a recent push timestamp. The sink should report a recent write count. If either is empty, log into a github.com tab on the source's Chrome to force a cookie write and re-check.
 
-Both sides:
+### Step 6: report to the user
 
-```bash
-agentcookie status --json | jq .
-```
+In plain language. Example:
 
-The source side should report `peer.hostname` set and a key file present. The sink side should report `peer.hostname`, an allowlist with the chosen patterns, and (if you enabled CDP) `cdp.enabled: true`.
+> Done. agentcookie is running on both `<source>` and `<sink>`. The source pushes cookies as soon as they change in Chrome on `<source>`; the sink writes them into a dedicated Chrome instance at `~/.agentcookie/chrome-profile` on `<sink>`. Your agents on `<sink>` connect to that Chrome via CDP at `~/.agentcookie/chrome-profile`. After this install, the user does not run agentcookie commands by hand again.
 
-Then trigger a sync from the source:
+## What to do if something errors
 
-```bash
-agentcookie source --once --verbose
-```
+**`agentcookie: command not found` on the sink after `go install`.** The sink's `$PATH` lacks `~/go/bin`. Tell the user (or fix by sourcing `~/.zshrc` on the SSH command, or invoke the binary by absolute path: `~/go/bin/agentcookie`).
 
-You should see one cookie batch land on the sink. On the sink, look for the log line:
+**Sink pairing returns `connection refused`.** Tailscale ACLs may be blocking tailnet-internal traffic on port 9998. Check `tailscale status` shows the source as reachable. If the source is online but unreachable, the user has restrictive ACLs to relax.
 
-```
-agentcookie sink: wrote N cookies via cdp (dropped M non-allowlisted)
-```
+**Sink wizard hangs at `Chrome did not publish DevToolsActivePort`.** The managed Chrome subprocess failed to start. Most likely: Google Chrome is not installed at `/Applications/Google Chrome.app`. Install Chrome or set `cdp.chrome_binary` in sink.yaml.
 
-If CDP is enabled and Chrome is running with remote debugging, the cookies are visible to running pages immediately. Otherwise they are in the SQLite store and become visible on the next Chrome launch.
+**`agentcookie status` reports zero pushes after install.** The source watcher has not seen a Chrome write yet. Open a tab on the source's Chrome (any allowlisted domain) and refresh. Push should appear within 2 seconds.
 
-## Troubleshooting
+**Sink Chrome subprocess crashes repeatedly.** Check `~/.agentcookie/logs/sink.err.log`. Most common cause: stale lockfile from a prior Chrome session sharing the user-data-dir. Solution: `rm ~/.agentcookie/chrome-profile/SingletonLock` and let the supervisor restart.
 
-- **Keychain prompt does not appear**: macOS already trusts the binary's previous Keychain access. If `agentcookie` errors with "Keychain access denied", open Keychain Access and remove the existing trust entry, then re-run.
-- **CDP probe fails**: `lsof -i :9222 | grep -i chrome` to confirm Chrome is debuggable. Launch Chrome with `open -na "Google Chrome" --args --remote-debugging-port=9222`.
-- **Pairing times out**: the source listens for 10 minutes. Re-run `agentcookie pair --as source` to get a fresh code.
-- **Sequence rejected on /sync**: the sink restarted but the source kept its in-memory sequence counter. Source emits a new sequence each `--once` call (`time.Now().Unix()`), so the next sync recovers.
+## Out of scope for this skill
 
-## Notes
-
-- The skill never registers a hosted account. All state lives on the user's machines plus the Tailscale-managed tailnet.
-- Allowlist on the sink is independent of the source's allowlist. The sink owner has the final say on what state lands in their Chrome.
-- The shared-secret fallback in `security.shared_secret` is for users mid-migration from earlier prototypes. After pairing, delete that field from both YAMLs.
+- Code-signing the binary so Keychain access is granted without a prompt.
+- Web Store extension install (planned for v0.3).
+- Linux sink support (planned for v0.3).
+- Bidirectional sync (planned for v0.3).
+- Adding new domains to the allowlist after install (the user edits `~/.config/agentcookie/allowlist.yaml` on each side; LaunchAgents pick up changes on next restart, which they do automatically every 10 seconds after a config save).

--- a/skill/prompts/install-on-both-machines.md
+++ b/skill/prompts/install-on-both-machines.md
@@ -1,0 +1,27 @@
+# The "tell your agent this" prompt
+
+Copy this into Claude Code, OpenClaw, Hermes, Codex, Cursor, or any agent that can run shell commands locally and over SSH:
+
+> Install agentcookie on this laptop and my Mac mini so my Chrome sessions sync continuously. Use Tailscale to find the Mac mini. Confirm with me which machine is the source and which is the sink, then run the full install end to end. After install, verify both daemons are running and tell me what you see.
+
+The agent should:
+
+1. Detect Tailscale and identify the peer machine.
+2. Confirm source vs sink with you.
+3. Run `agentcookie wizard install --as source` here, in the background.
+4. Read the pairing code from `~/.agentcookie/pairing.json` once it appears.
+5. SSH to the Mac mini and run `agentcookie wizard install --as sink ...` with that code.
+6. Report back that both daemons are up.
+
+Total elapsed time: about 30 seconds. You do not need to be at the Mac mini's screen. No Keychain prompts will fire on the Mac mini.
+
+## When the prompt is not enough
+
+If the agent gets stuck, the most common reasons (in rough probability order):
+
+1. SSH from your laptop to your Mac mini does not work passwordlessly. Fix by setting up SSH keys, or use Tailscale SSH (`tailscale ssh` is the command).
+2. Google Chrome is not installed on the Mac mini. The wizard needs it. Install Chrome.
+3. Go is not installed on the Mac mini, so `go install` fails. Either install Go (`brew install go`) or transfer a prebuilt binary from the laptop via `scp`.
+4. Tailscale ACLs are restrictive. Default Tailscale config allows everything between your own devices; if you have custom ACLs, allow tailnet-internal traffic on ports 9998 (pairing) and 9999 (sync).
+
+After fixing, re-paste the prompt. The wizard is idempotent and will pick up where it left off.


### PR DESCRIPTION
Phase C of [v0.2 plan](docs/plans/2026-05-16-003-feat-magical-agent-install-and-continuous-sync-plan.md). The user-facing slice: one command per machine, runnable by an agent, end-to-end install + pair + start.

## What's here

### U4: fsnotify continuous-sync source

\`agentcookie source --watch\` (new) is the v0.2 default mode. fsnotify on the parent directory of Chrome's Cookies SQLite; debounce 500ms; rate-cap 1 push per 2s; 30s baseline tick defends against macOS fsnotify event loss. Runs Push in its own goroutine so the event loop never blocks on a slow sink.

\`agentcookie source --once\` (existing) still works for cron / CI.

### U6: \`agentcookie wizard install\`

Two commands; that's the entire user-facing install:

\`\`\`
agentcookie wizard install --as source --peer <sink-hostname>
agentcookie wizard install --as sink   --peer <source-hostname> --code <code> --pair-url <url>
\`\`\`

Each side: drops configs (idempotent unless \`--force\`), runs pairing, installs the matching LaunchAgent, returns. Sink configs default to \`cdp.managed: true\` so the sink launches a dedicated Chrome and never calls Keychain. Source wizard writes \`~/.agentcookie/pairing.json\` so an SSH'ing agent can grab the code + pair_url without copy-paste.

\`agentcookie wizard uninstall --as <role>\` (and \`--purge\` to also remove configs / keys) is the inverse.

### U7: agent-runnable install skill

\`skill/SKILL.md\` rewritten to drive an agent through the full install: Tailscale peer detection, role confirmation with the user, background source wizard, pairing.json polling, SSH to sink, daemon verification.

\`skill/prompts/install-on-both-machines.md\` is the literal one-paragraph prompt the user pastes into Claude Code / OpenClaw / Codex / Cursor / Hermes / any agent.

## Combined effect

The complete v0.2 install: \"Tell your agent: install agentcookie on this laptop and my Mac mini.\" Agent does the rest. Roughly 30 seconds, zero screen-share, zero Keychain prompts on the sink.

## Tests

\`go test ./...\` -> 76 pass in 14 packages. 7 new watcher tests cover startup push, file-write trigger, debounce coalescing, unrelated-file isolation, WAL-companion detection, Stats accumulation, constructor validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)