### PR TITLE
feat(v0.2 phase D): live daemon state surface (U8)

### DIFF
--- a/internal/cli/sink.go
+++ b/internal/cli/sink.go
@@ -18,6 +18,7 @@ import (
 	"github.com/mvanhorn/agentcookie/internal/chromemgr"
 	"github.com/mvanhorn/agentcookie/internal/config"
 	"github.com/mvanhorn/agentcookie/internal/protocol"
+	"github.com/mvanhorn/agentcookie/internal/state"
 	"github.com/mvanhorn/agentcookie/internal/transport"
 )
 
@@ -112,6 +113,15 @@ func runSink(cmd *cobra.Command, args []string) error {
 
 	seqTracker := protocol.NewSequenceTracker()
 
+	// State writer for `agentcookie status` to read.
+	home, _ := os.UserHomeDir()
+	stateWriter := state.NewWriter(state.SinkPath(home))
+	sinkState := &state.SinkState{
+		Role:       "sink",
+		ListenAddr: cfg.Listen.Addr,
+		CDPManaged: cfg.CDP.Enabled && cfg.CDP.Managed,
+	}
+
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		_, _ = fmt.Fprintln(w, "ok")
@@ -168,6 +178,12 @@ func runSink(cmd *cobra.Command, args []string) error {
 				"cookies":         cookies,
 			}, "", "  ")
 			fmt.Fprintf(os.Stderr, "agentcookie sink (dry-run): accepted batch:\n%s\n", string(dump))
+			sinkState.LastWrite = time.Now().UTC()
+			sinkState.LastWriteCount = len(cookies)
+			sinkState.LastWriteMode = "dry-run"
+			sinkState.TotalWrites++
+			sinkState.TotalDropped += dropped
+			_ = stateWriter.Save(sinkState)
 			_, _ = fmt.Fprintf(w, "dry-run ok: accepted %d cookies; dropped %d non-allowlisted\n", len(cookies), dropped)
 			return
 		}
@@ -175,10 +191,20 @@ func runSink(cmd *cobra.Command, args []string) error {
 		written, mode, err := writeCookiesToSink(r.Context(), cfg, cookies, key, chromeMgr)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "agentcookie sink: write failed after %d cookies (mode=%s): %v\n", written, mode, err)
+			sinkState.LastError = err.Error()
+			sinkState.LastErrorAt = time.Now().UTC()
+			sinkState.TotalRejects++
+			_ = stateWriter.Save(sinkState)
 			http.Error(w, fmt.Sprintf("write cookies: %v", err), http.StatusInternalServerError)
 			return
 		}
 		fmt.Fprintf(os.Stderr, "agentcookie sink: wrote %d cookies via %s (dropped %d non-allowlisted)\n", written, mode, dropped)
+		sinkState.LastWrite = time.Now().UTC()
+		sinkState.LastWriteCount = written
+		sinkState.LastWriteMode = mode
+		sinkState.TotalWrites++
+		sinkState.TotalDropped += dropped
+		_ = stateWriter.Save(sinkState)
 		_, _ = fmt.Fprintf(w, "ok: wrote %d cookies via %s; dropped %d non-allowlisted\n", written, mode, dropped)
 	})
 

--- a/internal/cli/source.go
+++ b/internal/cli/source.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mvanhorn/agentcookie/internal/config"
 	"github.com/mvanhorn/agentcookie/internal/pairing"
 	"github.com/mvanhorn/agentcookie/internal/protocol"
+	"github.com/mvanhorn/agentcookie/internal/state"
 	"github.com/mvanhorn/agentcookie/internal/transport"
 	"github.com/mvanhorn/agentcookie/internal/watcher"
 )
@@ -84,8 +85,24 @@ func runSource(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// State writer for `agentcookie status` to read.
+	home, _ := os.UserHomeDir()
+	stateWriter := state.NewWriter(state.SourcePath(home))
+	srcState := &state.SourceState{Role: "source", SinkURL: cfg.Sink.URL}
+
 	push := func(ctx context.Context) (int, error) {
-		return pushOnce(ctx, cfg, allow, key, secret, sourceDryRun, sourceVerbose)
+		n, err := pushOnce(ctx, cfg, allow, key, secret, sourceDryRun, sourceVerbose)
+		if err != nil {
+			srcState.TotalFailures++
+			srcState.LastError = err.Error()
+			srcState.LastErrorAt = time.Now().UTC()
+		} else {
+			srcState.TotalPushes++
+			srcState.LastPushCount = n
+			srcState.LastPush = time.Now().UTC()
+		}
+		_ = stateWriter.Save(srcState)
+		return n, err
 	}
 
 	if sourceOnce {

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -4,67 +4,82 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/mvanhorn/agentcookie/internal/config"
+	"github.com/mvanhorn/agentcookie/internal/state"
 )
 
 var statusCmd = &cobra.Command{
 	Use:   "status",
-	Short: "Print local config, allowlist, and any load errors",
+	Short: "Print local config, allowlist, live daemon state, and any load errors",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		state := struct {
-			Version      string                `json:"version"`
-			ConfigDir    string                `json:"config_dir"`
-			SourceConfig *config.SourceConfig  `json:"source_config,omitempty"`
-			SinkConfig   *config.SinkConfig    `json:"sink_config,omitempty"`
-			Allowlist    *config.Allowlist     `json:"allowlist,omitempty"`
-			Errors       []string              `json:"errors,omitempty"`
+		home, _ := os.UserHomeDir()
+		st := struct {
+			Version      string               `json:"version"`
+			ConfigDir    string               `json:"config_dir"`
+			SourceConfig *config.SourceConfig `json:"source_config,omitempty"`
+			SinkConfig   *config.SinkConfig   `json:"sink_config,omitempty"`
+			Allowlist    *config.Allowlist    `json:"allowlist,omitempty"`
+			SourceState  *state.SourceState   `json:"source_state,omitempty"`
+			SinkState    *state.SinkState     `json:"sink_state,omitempty"`
+			Errors       []string             `json:"errors,omitempty"`
 		}{
 			Version:   Version,
 			ConfigDir: common.ConfigDir,
 		}
 
 		if s, err := config.LoadSource(common.ConfigDir); err == nil {
-			state.SourceConfig = s
+			st.SourceConfig = s
 		} else {
-			state.Errors = append(state.Errors, "source.yaml: "+err.Error())
+			st.Errors = append(st.Errors, "source.yaml: "+err.Error())
 		}
 		if s, err := config.LoadSink(common.ConfigDir); err == nil {
-			state.SinkConfig = s
+			st.SinkConfig = s
 		} else {
-			state.Errors = append(state.Errors, "sink.yaml: "+err.Error())
+			st.Errors = append(st.Errors, "sink.yaml: "+err.Error())
 		}
 		if a, err := config.LoadAllowlist(common.ConfigDir); err == nil {
-			state.Allowlist = a
+			st.Allowlist = a
 		} else {
-			state.Errors = append(state.Errors, "allowlist.yaml: "+err.Error())
+			st.Errors = append(st.Errors, "allowlist.yaml: "+err.Error())
+		}
+		if ss, err := state.LoadSource(state.SourcePath(home)); err == nil && ss != nil {
+			st.SourceState = ss
+		}
+		if sk, err := state.LoadSink(state.SinkPath(home)); err == nil && sk != nil {
+			st.SinkState = sk
 		}
 
 		if common.JSON {
 			enc := json.NewEncoder(os.Stdout)
 			enc.SetIndent("", "  ")
-			return enc.Encode(state)
+			return enc.Encode(st)
 		}
 
-		fmt.Printf("agentcookie %s\n", state.Version)
-		fmt.Printf("config dir: %s\n", state.ConfigDir)
-		if state.SourceConfig != nil {
-			fmt.Printf("  source -> %s\n", state.SourceConfig.Sink.URL)
-			fmt.Printf("    chrome db: %s\n", state.SourceConfig.Chrome.DBPath)
+		fmt.Printf("agentcookie %s\n", st.Version)
+		fmt.Printf("config dir: %s\n", st.ConfigDir)
+		if st.SourceConfig != nil {
+			fmt.Printf("  source -> %s\n", st.SourceConfig.Sink.URL)
+			fmt.Printf("    chrome db: %s\n", st.SourceConfig.Chrome.DBPath)
 		} else {
 			fmt.Println("  source: not configured")
 		}
-		if state.SinkConfig != nil {
-			fmt.Printf("  sink listening on %s\n", state.SinkConfig.Listen.Addr)
-			fmt.Printf("    chrome db: %s\n", state.SinkConfig.Chrome.DBPath)
+		if st.SinkConfig != nil {
+			fmt.Printf("  sink listening on %s\n", st.SinkConfig.Listen.Addr)
+			if st.SinkConfig.CDP.Enabled && st.SinkConfig.CDP.Managed {
+				fmt.Printf("    managed Chrome profile: %s\n", st.SinkConfig.CDP.ProfileDir)
+			} else if st.SinkConfig.Chrome.DBPath != "" {
+				fmt.Printf("    chrome db: %s\n", st.SinkConfig.Chrome.DBPath)
+			}
 		} else {
 			fmt.Println("  sink: not configured")
 		}
-		if state.Allowlist != nil {
-			fmt.Printf("  allowlist v%d: %d domains\n", state.Allowlist.Version, len(state.Allowlist.Domains))
-			for _, d := range state.Allowlist.Domains {
+		if st.Allowlist != nil {
+			fmt.Printf("  allowlist v%d: %d domains\n", st.Allowlist.Version, len(st.Allowlist.Domains))
+			for _, d := range st.Allowlist.Domains {
 				if d.Description != "" {
 					fmt.Printf("    - %s  (%s)\n", d.Pattern, d.Description)
 				} else {
@@ -74,7 +89,23 @@ var statusCmd = &cobra.Command{
 		} else {
 			fmt.Println("  allowlist: not configured")
 		}
-		for _, e := range state.Errors {
+		if st.SourceState != nil {
+			ago := "never"
+			if !st.SourceState.LastPush.IsZero() {
+				ago = time.Since(st.SourceState.LastPush).Round(time.Second).String() + " ago"
+			}
+			fmt.Printf("  source daemon: %d pushes, %d failures, last push %s\n",
+				st.SourceState.TotalPushes, st.SourceState.TotalFailures, ago)
+		}
+		if st.SinkState != nil {
+			ago := "never"
+			if !st.SinkState.LastWrite.IsZero() {
+				ago = time.Since(st.SinkState.LastWrite).Round(time.Second).String() + " ago"
+			}
+			fmt.Printf("  sink daemon: %d writes via %s, %d rejected, last write %s\n",
+				st.SinkState.TotalWrites, st.SinkState.LastWriteMode, st.SinkState.TotalRejects, ago)
+		}
+		for _, e := range st.Errors {
 			fmt.Fprintf(os.Stderr, "  warning: %s\n", e)
 		}
 		return nil

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -1,0 +1,115 @@
+// Package state is the shared state-file format that the source watcher and
+// the sink daemon both write to ~/.agentcookie/. `agentcookie status` reads
+// both files to surface live health.
+package state
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// SourceState is the source watcher's observable state, written on every push.
+type SourceState struct {
+	Role           string    `json:"role"`
+	LastPush       time.Time `json:"last_push,omitempty"`
+	LastPushCount  int       `json:"last_push_count"`
+	TotalPushes    int       `json:"total_pushes"`
+	TotalFailures  int       `json:"total_failures"`
+	LastError      string    `json:"last_error,omitempty"`
+	LastErrorAt    time.Time `json:"last_error_at,omitempty"`
+	SinkURL        string    `json:"sink_url"`
+}
+
+// SinkState is the sink daemon's observable state, written on every accepted
+// /sync write.
+type SinkState struct {
+	Role           string    `json:"role"`
+	LastWrite      time.Time `json:"last_write,omitempty"`
+	LastWriteCount int       `json:"last_write_count"`
+	LastWriteMode  string    `json:"last_write_mode"`
+	TotalWrites    int       `json:"total_writes"`
+	TotalDropped   int       `json:"total_dropped"`
+	TotalRejects   int       `json:"total_rejects"`
+	LastError      string    `json:"last_error,omitempty"`
+	LastErrorAt    time.Time `json:"last_error_at,omitempty"`
+	ListenAddr     string    `json:"listen_addr"`
+	CDPManaged     bool      `json:"cdp_managed"`
+}
+
+// Paths under ~/.agentcookie/.
+func SourcePath(home string) string { return filepath.Join(home, ".agentcookie", "source-state.json") }
+func SinkPath(home string) string   { return filepath.Join(home, ".agentcookie", "sink-state.json") }
+
+// Writer serializes JSON state file writes from multiple goroutines.
+type Writer struct {
+	path string
+	mu   sync.Mutex
+}
+
+// NewWriter returns a Writer that targets path. The parent directory is
+// created on first Save.
+func NewWriter(path string) *Writer {
+	return &Writer{path: path}
+}
+
+// Save writes v as JSON to the writer's path atomically (write-then-rename).
+func (w *Writer) Save(v any) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if err := os.MkdirAll(filepath.Dir(w.path), 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(w.path), ".tmp-state-*.json")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	enc := json.NewEncoder(tmp)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(v); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return err
+	}
+	return os.Rename(tmpName, w.path)
+}
+
+// LoadSource reads source-state.json. Returns nil, nil when the file does not
+// exist (the daemon may not have written yet).
+func LoadSource(path string) (*SourceState, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var s SourceState
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, err
+	}
+	return &s, nil
+}
+
+// LoadSink reads sink-state.json. Returns nil, nil when missing.
+func LoadSink(path string) (*SinkState, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var s SinkState
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, err
+	}
+	return &s, nil
+}

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -1,0 +1,97 @@
+package state
+
+import (
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestWriterSaveLoadRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "source-state.json")
+	w := NewWriter(path)
+
+	want := &SourceState{
+		Role:          "source",
+		LastPush:      time.Now().UTC().Truncate(time.Second),
+		LastPushCount: 12,
+		TotalPushes:   42,
+		SinkURL:       "http://test:9999/sync",
+	}
+	if err := w.Save(want); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := LoadSource(path)
+	if err != nil {
+		t.Fatalf("LoadSource: %v", err)
+	}
+	if got == nil {
+		t.Fatal("LoadSource returned nil")
+	}
+	if got.Role != want.Role || got.LastPushCount != want.LastPushCount || got.TotalPushes != want.TotalPushes {
+		t.Errorf("round-trip mismatch: got %+v, want %+v", got, want)
+	}
+}
+
+func TestLoadSourceMissingFile(t *testing.T) {
+	got, err := LoadSource(filepath.Join(t.TempDir(), "no-such.json"))
+	if err != nil {
+		t.Errorf("LoadSource on missing file should not error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil for missing file, got %+v", got)
+	}
+}
+
+func TestLoadSinkRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sink-state.json")
+	w := NewWriter(path)
+
+	want := &SinkState{
+		Role:           "sink",
+		LastWrite:      time.Now().UTC().Truncate(time.Second),
+		LastWriteCount: 7,
+		LastWriteMode:  "cdp-managed",
+		TotalWrites:    99,
+		ListenAddr:     "100.x.y.z:9999",
+		CDPManaged:     true,
+	}
+	if err := w.Save(want); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := LoadSink(path)
+	if err != nil {
+		t.Fatalf("LoadSink: %v", err)
+	}
+	if got == nil || got.Role != "sink" || got.LastWriteMode != "cdp-managed" || got.TotalWrites != 99 {
+		t.Errorf("round-trip mismatch: %+v", got)
+	}
+}
+
+func TestWriterIsConcurrencySafe(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "source-state.json")
+	w := NewWriter(path)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			s := &SourceState{Role: "source", TotalPushes: i}
+			_ = w.Save(s)
+		}(i)
+	}
+	wg.Wait()
+
+	got, err := LoadSource(path)
+	if err != nil {
+		t.Fatalf("LoadSource after concurrent saves: %v", err)
+	}
+	if got == nil {
+		t.Fatal("LoadSource returned nil after writes")
+	}
+	// Any save's value is acceptable; just confirm the file is valid JSON.
+}


### PR DESCRIPTION
Final v0.2 phase. Makes \`agentcookie status\` answer \"is the sync working right now?\" instead of just \"is the config valid?\".

## What's here

\`internal/state\`: shared JSON state file format both source watcher and sink daemon write to \`~/.agentcookie/\`. Atomic write-then-rename under a mutex.

\`internal/cli/source.go\` writes \`~/.agentcookie/source-state.json\` after every push: counters, last-push timestamp, last error.

\`internal/cli/sink.go\` writes \`~/.agentcookie/sink-state.json\` after every accepted /sync (and on rejection): counters, last-write timestamp / count / mode, last error.

\`agentcookie status\` reads both files and prints:

\`\`\`
source daemon: 42 pushes, 0 failures, last push 3s ago
sink daemon: 38 writes via cdp-managed, 0 rejected, last write 4s ago
\`\`\`

\`agentcookie status --json\` returns the same shape machine-readable.

## Tests

\`go test ./...\` -> 80 pass in 15 packages. 4 new tests cover atomic round-trip, missing-file handling, concurrency safety (50 parallel saves), both Source/Sink shapes.

## What this completes

All of v0.2 (U1-U8) is now landed. Live cross-machine verification of the magical install path is the next-step gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)