### PR TITLE
fix(v0.5 chromeconn): land SameSite=None+Secure cookies via URL field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ go.work.sum
 
 # Built binaries (each cmd compiles to bin/<name>)
 /bin/
+hack/

--- a/internal/chromeconn/cookies.go
+++ b/internal/chromeconn/cookies.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"strings"
 	"time"
 
 	"github.com/chromedp/cdproto/cdp"
@@ -91,13 +92,24 @@ func cookieToParam(c chrome.Cookie) *network.CookieParam {
 		return nil
 	}
 	p := &network.CookieParam{
-		Name:     c.Name,
-		Value:    c.Value,
-		Domain:   c.HostKey,
-		Path:     c.Path,
-		Secure:   c.IsSecure != 0,
-		HTTPOnly: c.IsHTTPOnly != 0,
-		SameSite: sameSiteEnum(c.SameSite),
+		Name:         c.Name,
+		Value:        c.Value,
+		Domain:       c.HostKey,
+		Path:         c.Path,
+		Secure:       c.IsSecure != 0,
+		HTTPOnly:     c.IsHTTPOnly != 0,
+		SameSite:     sameSiteEnum(c.SameSite),
+		SourceScheme: sourceSchemeEnum(c.SourceScheme, c.IsSecure != 0),
+	}
+	if c.SourcePort > 0 {
+		p.SourcePort = int64(c.SourcePort)
+	}
+	// SameSite=None cookies are silently dropped unless Chrome can verify a
+	// secure source. Providing an explicit URL lets Chrome derive scheme and
+	// port; without it the cookie is rejected. Apply only when the cookie is
+	// Secure (the only case where SameSite=None is legal anyway).
+	if p.Secure {
+		p.URL = "https://" + strings.TrimPrefix(c.HostKey, ".") + c.Path
 	}
 	if c.HasExpires != 0 && c.ExpiresUTC > 0 {
 		expiresUnix := float64(c.ExpiresUTC)/1e6 - chromeEpochDeltaSeconds
@@ -121,6 +133,25 @@ func cdpTimeSinceEpoch(unixSeconds float64) cdp.TimeSinceEpoch {
 	whole := int64(unixSeconds)
 	frac := unixSeconds - float64(whole)
 	return cdp.TimeSinceEpoch(time.Unix(whole, int64(frac*1e9)).UTC())
+}
+
+// sourceSchemeEnum maps Chrome SQLite source_scheme int (0=unset, 1=non-secure,
+// 2=secure) to cdproto's enum. Chrome silently drops SameSite=None cookies
+// whose source scheme is Unset/NonSecure even when Secure=true; we infer
+// Secure source scheme from the IsSecure flag as a safety net for cookies
+// whose SQLite source_scheme field is empty.
+func sourceSchemeEnum(v int, isSecure bool) network.CookieSourceScheme {
+	switch v {
+	case 1:
+		return network.CookieSourceSchemeNonSecure
+	case 2:
+		return network.CookieSourceSchemeSecure
+	default:
+		if isSecure {
+			return network.CookieSourceSchemeSecure
+		}
+		return network.CookieSourceSchemeUnset
+	}
 }
 
 // sameSiteEnum maps Chrome SQLite samesite int to cdproto's enum.

--- a/internal/chromeconn/cookies_test.go
+++ b/internal/chromeconn/cookies_test.go
@@ -10,17 +10,19 @@ import (
 )
 
 func TestCookieToParam_Happy(t *testing.T) {
-	// instacart-shaped session cookie: SameSite=None, Secure, persistent expiry.
+	// instacart-shaped cookie: SameSite=None, Secure, persistent expiry.
 	c := chrome.Cookie{
-		HostKey:    ".instacart.com",
-		Name:       "_instacart_session_id",
-		Value:      "abc.def.ghi",
-		Path:       "/",
-		IsSecure:   1,
-		IsHTTPOnly: 1,
-		SameSite:   0, // None
-		HasExpires: 1,
-		ExpiresUTC: 13380163200000000, // 2025-01-01 UTC in WebKit microseconds (Unix 1735689600 + delta 11644473600, times 1e6)
+		HostKey:      ".instacart.com",
+		Name:         "_instacart_session_id",
+		Value:        "abc.def.ghi",
+		Path:         "/",
+		IsSecure:     1,
+		IsHTTPOnly:   1,
+		SameSite:     0, // None
+		SourceScheme: 2, // Secure
+		SourcePort:   443,
+		HasExpires:   1,
+		ExpiresUTC:   13380163200000000, // 2025-01-01 UTC in WebKit microseconds
 	}
 	p := cookieToParam(c)
 	if p == nil {
@@ -35,6 +37,15 @@ func TestCookieToParam_Happy(t *testing.T) {
 	if p.SameSite != network.CookieSameSiteNone {
 		t.Errorf("samesite: got %q want None", p.SameSite)
 	}
+	if p.SourceScheme != network.CookieSourceSchemeSecure {
+		t.Errorf("source scheme: got %q want Secure", p.SourceScheme)
+	}
+	if p.SourcePort != 443 {
+		t.Errorf("source port: got %d want 443", p.SourcePort)
+	}
+	if p.URL != "https://instacart.com/" {
+		t.Errorf("URL: got %q want https://instacart.com/", p.URL)
+	}
 	if p.Expires == nil {
 		t.Fatal("expected non-nil Expires for persistent cookie")
 	}
@@ -42,6 +53,27 @@ func TestCookieToParam_Happy(t *testing.T) {
 	want := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 	if !got.Equal(want) {
 		t.Errorf("Expires: got %s want %s", got, want)
+	}
+}
+
+func TestCookieToParam_SourceSchemeInferredFromSecure(t *testing.T) {
+	// Cookie with IsSecure=1 but SourceScheme=0 (unset in SQLite) should still
+	// get Secure inferred so Chrome doesn't reject SameSite=None cookies.
+	c := chrome.Cookie{HostKey: "x.com", Name: "n", IsSecure: 1, SourceScheme: 0}
+	p := cookieToParam(c)
+	if p.SourceScheme != network.CookieSourceSchemeSecure {
+		t.Errorf("inferred source scheme: got %q want Secure", p.SourceScheme)
+	}
+	if p.URL != "https://x.com" {
+		t.Errorf("URL: got %q want https://x.com", p.URL)
+	}
+}
+
+func TestCookieToParam_InsecureLeavesURLEmpty(t *testing.T) {
+	c := chrome.Cookie{HostKey: "x.com", Name: "n", IsSecure: 0}
+	p := cookieToParam(c)
+	if p.URL != "" {
+		t.Errorf("URL should be empty for non-secure cookie, got %q", p.URL)
 	}
 }
 


### PR DESCRIPTION
## Summary

Live verification on the Mac mini revealed that `SameSite=None+Secure` cookies (instacart class) were silently dropped by Chrome after `Network.SetCookies` reported success. chromedp's plain `CookieParam` omits `SourceScheme` and `URL`, so Chrome defaults to a non-secure source and rejects the cookie at storage time.

## Fix

- Propagate `source_scheme` + `source_port` from the chrome.Cookie SQLite shape into the CookieParam.
- When `Secure=true`, synthesize an `https://` URL field so Chrome can derive the secure scheme unambiguously.
- Infer `CookieSourceSchemeSecure` from the `IsSecure` flag when SQLite `source_scheme` is unset (back-compat with older Chrome databases).

## Verification

Empirical, against a vanilla Chrome 148 on the Mac mini with a 3-cookie batch:

- Before: 2/3 landed; the `SameSite=None+Secure` one was missing on read-back.
- After: 3/3 land.

Also added `hack/` to .gitignore (scratch dir for the live probe).

## Test plan

- [x] `go test ./internal/chromeconn/` 21 passed
- [x] Live attach test against headless Chrome on the Mac mini, all 3 batch cookies present after `storage.GetCookies` read-back