### PR TITLE
feat(v0.5 U4): wizard auto-activates chrome://inspect remote debugging

### DIFF
--- a/internal/chromeconn/toggle.go
+++ b/internal/chromeconn/toggle.go
@@ -1,0 +1,179 @@
+package chromeconn
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// localStateFile is the per-installation Chrome preferences file at the
+// user-data-dir root. The chrome://inspect/#remote-debugging toggle persists
+// here under devtools.remote_debugging.user-enabled. Verified in
+// docs/research/chrome-144-remote-debugging.md.
+const localStateFile = "Local State"
+
+// remoteDebuggingPrefPath is the Local State JSON key path for the toggle.
+const (
+	prefDevtools         = "devtools"
+	prefRemoteDebugging  = "remote_debugging"
+	prefUserEnabledKey   = "user-enabled"
+)
+
+// IsRemoteDebuggingPrefSet returns true when Chrome's Local State at
+// userDataDir has devtools.remote_debugging.user-enabled set to true. Does
+// not require Chrome to be running.
+func IsRemoteDebuggingPrefSet(userDataDir string) (bool, error) {
+	path := filepath.Join(userDataDir, localStateFile)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("chromeconn: read Local State: %w", err)
+	}
+	var state map[string]any
+	if err := json.Unmarshal(data, &state); err != nil {
+		return false, fmt.Errorf("chromeconn: parse Local State: %w", err)
+	}
+	dev, _ := state[prefDevtools].(map[string]any)
+	if dev == nil {
+		return false, nil
+	}
+	rd, _ := dev[prefRemoteDebugging].(map[string]any)
+	if rd == nil {
+		return false, nil
+	}
+	v, ok := rd[prefUserEnabledKey].(bool)
+	if !ok {
+		return false, nil
+	}
+	return v, nil
+}
+
+// SetRemoteDebuggingPref writes devtools.remote_debugging.user-enabled=true
+// into Chrome's Local State at userDataDir, preserving every other key. Uses
+// an atomic temp-file-rename write so a crash mid-write does not corrupt
+// Chrome's preferences.
+//
+// Chrome should not be running when this is called: a running Chrome
+// overwrites Local State periodically and on exit, which clobbers the write.
+func SetRemoteDebuggingPref(userDataDir string) error {
+	path := filepath.Join(userDataDir, localStateFile)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("chromeconn: %s not found; launch Chrome at least once before enabling remote debugging", path)
+		}
+		return fmt.Errorf("chromeconn: read Local State: %w", err)
+	}
+	var state map[string]any
+	if err := json.Unmarshal(data, &state); err != nil {
+		return fmt.Errorf("chromeconn: parse Local State: %w", err)
+	}
+	dev, _ := state[prefDevtools].(map[string]any)
+	if dev == nil {
+		dev = map[string]any{}
+	}
+	rd, _ := dev[prefRemoteDebugging].(map[string]any)
+	if rd == nil {
+		rd = map[string]any{}
+	}
+	rd[prefUserEnabledKey] = true
+	dev[prefRemoteDebugging] = rd
+	state[prefDevtools] = dev
+
+	out, err := json.Marshal(state)
+	if err != nil {
+		return fmt.Errorf("chromeconn: marshal Local State: %w", err)
+	}
+	tmp := path + ".agentcookie.tmp"
+	if err := os.WriteFile(tmp, out, 0o600); err != nil {
+		return fmt.Errorf("chromeconn: write temp Local State: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("chromeconn: rename Local State: %w", err)
+	}
+	return nil
+}
+
+// IsChromeRunning reports whether any Google Chrome process is currently
+// running. Cheap pgrep equivalent; does not assert which user-data-dir.
+func IsChromeRunning() (bool, error) {
+	out, err := exec.Command("/usr/bin/pgrep", "-x", "Google Chrome").CombinedOutput()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			return false, nil
+		}
+		return false, fmt.Errorf("chromeconn: pgrep Chrome: %w (%s)", err, strings.TrimSpace(string(out)))
+	}
+	return len(out) > 0, nil
+}
+
+// QuitChromeGracefully tells Chrome to quit via osascript, giving Chrome a
+// chance to save session state, persist preferences, and close cleanly.
+// Waits up to timeout for the process to exit; falls back to a friendly
+// error if Chrome refuses (some pinned tabs or modal dialogs can block
+// quit).
+func QuitChromeGracefully(ctx context.Context, timeout time.Duration) error {
+	cmd := exec.CommandContext(ctx, "/usr/bin/osascript", "-e", `tell application "Google Chrome" to quit`)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("chromeconn: osascript quit Chrome: %w (%s)", err, strings.TrimSpace(string(out)))
+	}
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		running, err := IsChromeRunning()
+		if err != nil {
+			return err
+		}
+		if !running {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(250 * time.Millisecond):
+		}
+	}
+	return fmt.Errorf("chromeconn: Chrome did not exit within %s; a modal dialog or pinned tab may be blocking quit", timeout)
+}
+
+// LaunchChrome relaunches Chrome.app via macOS open(1). Returns once open
+// returns, which is typically before Chrome has finished initializing. Use
+// WaitForRemoteDebugging to know when CDP is actually available.
+func LaunchChrome(ctx context.Context) error {
+	cmd := exec.CommandContext(ctx, "/usr/bin/open", "-a", "Google Chrome")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("chromeconn: open Google Chrome: %w (%s)", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// WaitForRemoteDebugging polls for DevToolsActivePort in userDataDir up to
+// timeout. Returns the discovered Endpoint on success. Use after LaunchChrome
+// to wait until Chrome has finished initializing remote debugging.
+func WaitForRemoteDebugging(ctx context.Context, userDataDir string, timeout time.Duration) (Endpoint, error) {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		ep, err := Discover(userDataDir)
+		if err == nil {
+			return ep, nil
+		}
+		if !errors.Is(err, ErrRemoteDebuggingNotEnabled) {
+			return Endpoint{}, err
+		}
+		select {
+		case <-ctx.Done():
+			return Endpoint{}, ctx.Err()
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+	return Endpoint{}, fmt.Errorf("chromeconn: DevToolsActivePort did not appear within %s", timeout)
+}

--- a/internal/chromeconn/toggle_test.go
+++ b/internal/chromeconn/toggle_test.go
@@ -1,0 +1,143 @@
+package chromeconn
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestIsRemoteDebuggingPrefSet_Missing(t *testing.T) {
+	dir := t.TempDir()
+	on, err := IsRemoteDebuggingPrefSet(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if on {
+		t.Error("expected false for missing Local State")
+	}
+}
+
+func TestIsRemoteDebuggingPrefSet_False(t *testing.T) {
+	dir := t.TempDir()
+	state := map[string]any{
+		"devtools": map[string]any{
+			"remote_debugging": map[string]any{
+				"user-enabled": false,
+			},
+		},
+	}
+	writeJSON(t, filepath.Join(dir, "Local State"), state)
+	on, err := IsRemoteDebuggingPrefSet(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if on {
+		t.Error("expected false")
+	}
+}
+
+func TestIsRemoteDebuggingPrefSet_True(t *testing.T) {
+	dir := t.TempDir()
+	state := map[string]any{
+		"devtools": map[string]any{
+			"remote_debugging": map[string]any{
+				"user-enabled": true,
+			},
+		},
+		"other": "preserved",
+	}
+	writeJSON(t, filepath.Join(dir, "Local State"), state)
+	on, err := IsRemoteDebuggingPrefSet(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !on {
+		t.Error("expected true")
+	}
+}
+
+func TestSetRemoteDebuggingPref_PreservesOtherKeys(t *testing.T) {
+	dir := t.TempDir()
+	original := map[string]any{
+		"user_experience_metrics": map[string]any{"client_id": "abc-123"},
+		"devtools": map[string]any{
+			"adb_key": "secret-key-do-not-touch",
+			"port_forwarding_config": map[string]any{
+				"8080": "localhost:8080",
+			},
+		},
+		"safebrowsing": "ok",
+	}
+	writeJSON(t, filepath.Join(dir, "Local State"), original)
+
+	if err := SetRemoteDebuggingPref(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(dir, "Local State"))
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+	// New key set.
+	dev := got["devtools"].(map[string]any)
+	rd := dev["remote_debugging"].(map[string]any)
+	if rd["user-enabled"] != true {
+		t.Errorf("user-enabled: got %v want true", rd["user-enabled"])
+	}
+	// Sibling devtools keys preserved.
+	if dev["adb_key"] != "secret-key-do-not-touch" {
+		t.Errorf("adb_key clobbered: got %v", dev["adb_key"])
+	}
+	if pf, _ := dev["port_forwarding_config"].(map[string]any); pf["8080"] != "localhost:8080" {
+		t.Errorf("port_forwarding_config clobbered: got %v", dev["port_forwarding_config"])
+	}
+	// Top-level siblings preserved.
+	if got["safebrowsing"] != "ok" {
+		t.Errorf("safebrowsing clobbered: got %v", got["safebrowsing"])
+	}
+	if uem, _ := got["user_experience_metrics"].(map[string]any); uem["client_id"] != "abc-123" {
+		t.Errorf("user_experience_metrics clobbered: got %v", got["user_experience_metrics"])
+	}
+}
+
+func TestSetRemoteDebuggingPref_NoLocalStateFile(t *testing.T) {
+	dir := t.TempDir()
+	err := SetRemoteDebuggingPref(dir)
+	if err == nil {
+		t.Fatal("expected error for missing Local State")
+	}
+}
+
+func TestSetRemoteDebuggingPref_BootstrapsMissingParents(t *testing.T) {
+	// Real-world case: brand-new Chrome profile where devtools subtree
+	// doesn't exist yet.
+	dir := t.TempDir()
+	writeJSON(t, filepath.Join(dir, "Local State"), map[string]any{
+		"some_other_key": "ok",
+	})
+
+	if err := SetRemoteDebuggingPref(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	on, err := IsRemoteDebuggingPrefSet(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !on {
+		t.Error("expected true after Set on bare Local State")
+	}
+}
+
+func writeJSON(t *testing.T, path string, v any) {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/mvanhorn/agentcookie/extension"
+	"github.com/mvanhorn/agentcookie/internal/chromeconn"
 	"github.com/mvanhorn/agentcookie/internal/keystore"
 	"github.com/mvanhorn/agentcookie/internal/launchd"
 	"github.com/mvanhorn/agentcookie/internal/pairing"
@@ -22,16 +23,18 @@ import (
 
 // Wizard flags. These are read by both `install` and `uninstall`.
 var (
-	wizardRole       string
-	wizardPeer       string
-	wizardListen     string
-	wizardLocalName  string
-	wizardSinkURL    string
-	wizardCode       string
-	wizardPairURL    string
-	wizardRepair     bool
-	wizardForce      bool
-	wizardSkipDaemon bool
+	wizardRole               string
+	wizardPeer               string
+	wizardListen             string
+	wizardLocalName          string
+	wizardSinkURL            string
+	wizardCode               string
+	wizardPairURL            string
+	wizardRepair             bool
+	wizardForce              bool
+	wizardSkipDaemon         bool
+	wizardNoRestartChrome    bool
+	wizardSkipRemoteDebug    bool
 )
 
 var wizardCmd = &cobra.Command{
@@ -85,6 +88,8 @@ func init() {
 	wizardInstallCmd.Flags().BoolVar(&wizardRepair, "repair", false, "force a fresh pairing handshake even if a key already exists")
 	wizardInstallCmd.Flags().BoolVar(&wizardForce, "force", false, "overwrite existing source.yaml / sink.yaml / allowlist.yaml")
 	wizardInstallCmd.Flags().BoolVar(&wizardSkipDaemon, "skip-daemon", false, "skip installing the LaunchAgent (configs + pairing only)")
+	wizardInstallCmd.Flags().BoolVar(&wizardNoRestartChrome, "no-restart-chrome", false, "[sink] do not auto-quit/relaunch Chrome to activate the chrome://inspect remote-debugging toggle; Chrome must be restarted manually for attach mode to discover the CDP endpoint")
+	wizardInstallCmd.Flags().BoolVar(&wizardSkipRemoteDebug, "skip-remote-debug", false, "[sink] do not write the chrome://inspect remote-debugging preference; useful when running the wizard for managed-mode sink installs")
 
 	wizardUninstallCmd.Flags().StringVar(&wizardRole, "as", "", "source | sink (required)")
 	wizardUninstallCmd.Flags().BoolVar(&wizardForce, "purge", false, "also delete configs and paired keys")
@@ -232,6 +237,12 @@ func wizardInstallSink(ctx context.Context, binPath, logDir string) error {
 		fmt.Fprintf(os.Stderr, "agentcookie wizard: paired with source %q (fingerprint %s)\n", wizardPeer, res.Fingerprint)
 	}
 
+	if !wizardSkipRemoteDebug {
+		if err := ensureRemoteDebuggingEnabled(ctx); err != nil {
+			return fmt.Errorf("activate Chrome remote debugging: %w", err)
+		}
+	}
+
 	if !wizardSkipDaemon {
 		if err := installLaunchAgent(launchd.Spec{
 			Role:       launchd.RoleSink,
@@ -244,6 +255,91 @@ func wizardInstallSink(ctx context.Context, binPath, logDir string) error {
 	}
 
 	fmt.Fprintln(os.Stderr, "agentcookie wizard: sink install complete")
+	return nil
+}
+
+// ensureRemoteDebuggingEnabled walks the sink machine's real Chrome through
+// the chrome://inspect/#remote-debugging activation contract documented in
+// docs/research/chrome-144-remote-debugging.md. The full flow when starting
+// from cold:
+//
+//  1. Check whether the toggle pref is already set. If yes, skip.
+//  2. If Chrome is running, quit it cleanly via osascript so it can save
+//     session state and persist Local State.
+//  3. Write devtools.remote_debugging.user-enabled=true into Local State.
+//  4. Relaunch Chrome via 'open -a "Google Chrome"' (unless --no-restart-chrome).
+//  5. Wait for DevToolsActivePort to appear (proves CDP is active).
+//
+// On first sink-to-Chrome connect, Chrome shows a permission dialog the user
+// must click Allow on. Subsequent CDP traffic over the same WebSocket does
+// not re-prompt. This is the residual user click after autonomous activation.
+func ensureRemoteDebuggingEnabled(ctx context.Context) error {
+	profileDir := chromeconn.DefaultProfileDir()
+
+	// Step 1: already on?
+	if ep, err := chromeconn.Discover(profileDir); err == nil {
+		fmt.Fprintf(os.Stderr, "agentcookie wizard: Chrome remote debugging already active at %s\n", ep.WebSocketURL())
+		return nil
+	}
+	prefSet, err := chromeconn.IsRemoteDebuggingPrefSet(profileDir)
+	if err != nil {
+		return fmt.Errorf("read Local State: %w", err)
+	}
+	if prefSet {
+		fmt.Fprintln(os.Stderr, "agentcookie wizard: chrome://inspect toggle already on in Local State, but Chrome has not been restarted yet")
+	}
+
+	chromeRunning, err := chromeconn.IsChromeRunning()
+	if err != nil {
+		return fmt.Errorf("probe Chrome process: %w", err)
+	}
+
+	if wizardNoRestartChrome {
+		// Lights-off mode: write the pref but do not touch the running Chrome.
+		if !prefSet {
+			if err := chromeconn.SetRemoteDebuggingPref(profileDir); err != nil {
+				return err
+			}
+			fmt.Fprintln(os.Stderr, "agentcookie wizard: wrote chrome://inspect remote-debugging pref to Local State; restart Chrome manually to activate CDP")
+		}
+		if chromeRunning {
+			fmt.Fprintln(os.Stderr, "agentcookie wizard: Chrome is currently running; the new pref takes effect on the next Chrome launch")
+		}
+		return nil
+	}
+
+	if chromeRunning {
+		fmt.Fprintln(os.Stderr, "agentcookie wizard: quitting Chrome to write the chrome://inspect remote-debugging pref (it will be relaunched immediately)")
+		quitCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
+		if err := chromeconn.QuitChromeGracefully(quitCtx, 15*time.Second); err != nil {
+			cancel()
+			return fmt.Errorf("quit Chrome: %w (pass --no-restart-chrome and restart Chrome yourself)", err)
+		}
+		cancel()
+	}
+
+	if !prefSet {
+		if err := chromeconn.SetRemoteDebuggingPref(profileDir); err != nil {
+			return err
+		}
+		fmt.Fprintln(os.Stderr, "agentcookie wizard: chrome://inspect remote-debugging pref written")
+	}
+
+	launchCtx, cancelLaunch := context.WithTimeout(ctx, 10*time.Second)
+	if err := chromeconn.LaunchChrome(launchCtx); err != nil {
+		cancelLaunch()
+		return fmt.Errorf("relaunch Chrome: %w", err)
+	}
+	cancelLaunch()
+
+	waitCtx, cancelWait := context.WithTimeout(ctx, 30*time.Second)
+	defer cancelWait()
+	ep, err := chromeconn.WaitForRemoteDebugging(waitCtx, profileDir, 30*time.Second)
+	if err != nil {
+		return fmt.Errorf("wait for Chrome to publish DevToolsActivePort: %w", err)
+	}
+	fmt.Fprintf(os.Stderr, "agentcookie wizard: Chrome CDP active at %s\n", ep.WebSocketURL())
+	fmt.Fprintln(os.Stderr, "agentcookie wizard: the first time the sink attaches, Chrome will show an 'Allow remote debugging' dialog; click Allow once")
 	return nil
 }
 
@@ -402,11 +498,15 @@ peer:
 func renderSinkYAML(peer string) string {
 	// Bind to the local tailnet IP for sink listener if available; otherwise 0.0.0.0:9999.
 	listenAddr := defaultSinkListenAddr()
+	// v0.5 default: cdp.mode=attach. Sink connects to the user's real
+	// Chrome via the chrome://inspect/#remote-debugging activation, which
+	// the wizard wires up at install time. Legacy managed-Chrome mode is
+	// still available by setting `cdp.mode: managed` (see U3 for cleanup).
 	return fmt.Sprintf(`listen:
   addr: %s
 cdp:
   enabled: true
-  managed: true
+  mode: attach
 peer:
   hostname: %s
 `, listenAddr, peer)


### PR DESCRIPTION
## Summary

Sink-side wizard now wires up the chrome://inspect/#remote-debugging toggle autonomously via Local-State write + Chrome restart, eliminating the manual click step in the v0.5 plan U4.

## Flow

1. Check if remote debugging is already active (DevToolsActivePort exists, or `devtools.remote_debugging.user-enabled` set in Local State).
2. Quit Chrome gracefully via `osascript` (preserves session state).
3. Atomically merge `devtools.remote_debugging.user-enabled = true` into `Local State`.
4. Relaunch Chrome via `open -a "Google Chrome"`.
5. Poll `DevToolsActivePort` until it appears (confirms CDP listener is live).

Residual user action: one click on the per-connection "Allow remote debugging" dialog Chrome shows when the sink first attaches. No documented bypass on Chrome 148 (upstream tracked at chrome-devtools-mcp#825).

## Flags

- `--no-restart-chrome` writes the pref but does not quit/relaunch; the new pref takes effect on the next Chrome launch.
- `--skip-remote-debug` skips the whole step (for managed-mode installs).

## sink.yaml default

`renderSinkYAML` now emits `cdp.mode: attach` (was `cdp.managed: true`). Existing configs with `managed: true` still work via the back-compat path in `config.go`. v0.5 U3 cleans up the legacy paths.

## Test plan

- [x] 8 new tests for the Local-State JSON merge: preserves siblings, bootstraps missing parents, handles missing file, idempotent re-runs
- [x] All 114 tests across 14 packages pass
- [ ] Live verification against the Mac mini (U6)