### PR TITLE
feat(v0.5 U5): wizard prints Tailscale exit-node setup hint

### DIFF
--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -18,6 +18,7 @@ import (
 	"github.com/mvanhorn/agentcookie/internal/keystore"
 	"github.com/mvanhorn/agentcookie/internal/launchd"
 	"github.com/mvanhorn/agentcookie/internal/pairing"
+	"github.com/mvanhorn/agentcookie/internal/tsclient"
 )
 
 // Wizard flags. These are read by both `install` and `uninstall`.
@@ -34,6 +35,7 @@ var (
 	wizardSkipDaemon         bool
 	wizardNoRestartChrome    bool
 	wizardSkipRemoteDebug    bool
+	wizardSkipExitNode       bool
 )
 
 var wizardCmd = &cobra.Command{
@@ -89,6 +91,7 @@ func init() {
 	wizardInstallCmd.Flags().BoolVar(&wizardSkipDaemon, "skip-daemon", false, "skip installing the LaunchAgent (configs + pairing only)")
 	wizardInstallCmd.Flags().BoolVar(&wizardNoRestartChrome, "no-restart-chrome", false, "[sink] do not auto-quit/relaunch Chrome to activate the chrome://inspect remote-debugging toggle; Chrome must be restarted manually for attach mode to discover the CDP endpoint")
 	wizardInstallCmd.Flags().BoolVar(&wizardSkipRemoteDebug, "skip-remote-debug", false, "[sink] do not write the chrome://inspect remote-debugging preference; useful when running the wizard for managed-mode sink installs")
+	wizardInstallCmd.Flags().BoolVar(&wizardSkipExitNode, "skip-exit-node-hint", false, "do not detect Tailscale or print the sudo commands that route the sink's outbound traffic through the source machine")
 
 	wizardUninstallCmd.Flags().StringVar(&wizardRole, "as", "", "source | sink (required)")
 	wizardUninstallCmd.Flags().BoolVar(&wizardForce, "purge", false, "also delete configs and paired keys")
@@ -178,6 +181,10 @@ func wizardInstallSource(ctx context.Context, binPath, logDir string) error {
 		fmt.Fprintln(os.Stderr, "agentcookie wizard: source LaunchAgent installed and started")
 	}
 
+	if !wizardSkipExitNode {
+		printExitNodeHint(ctx, "source", wizardPeer)
+	}
+
 	fmt.Fprintln(os.Stderr, "agentcookie wizard: source install complete")
 	return nil
 }
@@ -243,8 +250,69 @@ func wizardInstallSink(ctx context.Context, binPath, logDir string) error {
 		fmt.Fprintln(os.Stderr, "agentcookie wizard: sink LaunchAgent installed and started")
 	}
 
+	if !wizardSkipExitNode {
+		printExitNodeHint(ctx, "sink", wizardPeer)
+	}
+
 	fmt.Fprintln(os.Stderr, "agentcookie wizard: sink install complete")
 	return nil
+}
+
+// printExitNodeHint inspects Tailscale state and emits sudo command lines
+// the user can run once to align the sink machine's outbound IP with the
+// source machine's. It never executes sudo itself; that is intentionally
+// left to the human since it changes routing for the entire machine.
+//
+// role: "source" or "sink", determines which side of the relationship we
+// are configuring. peerHost is the OTHER machine's tailnet hostname.
+func printExitNodeHint(ctx context.Context, role, peerHost string) {
+	cli, err := tsclient.FindCLI()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "agentcookie wizard: Tailscale not detected; skipping exit-node hint")
+		fmt.Fprintln(os.Stderr, "agentcookie wizard: sites that bind sessions to the source machine's IP (instacart class) will not work without an exit-node hop")
+		return
+	}
+	st, err := tsclient.Get(ctx, cli)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "agentcookie wizard: Tailscale CLI errored (%v); skipping exit-node hint\n", err)
+		return
+	}
+
+	switch role {
+	case "source":
+		if st.SelfAdvertisesExitNode() {
+			fmt.Fprintln(os.Stderr, "agentcookie wizard: this machine already advertises as a Tailscale exit node")
+			return
+		}
+		fmt.Fprintln(os.Stderr, "agentcookie wizard: optional next step on this machine (source):")
+		fmt.Fprintln(os.Stderr, "  sudo tailscale set --advertise-exit-node")
+		fmt.Fprintln(os.Stderr, "  # then approve the exit-node offer in the Tailscale admin console")
+		fmt.Fprintln(os.Stderr, "  # routes the sink machine's outbound traffic through this machine's public IP")
+		fmt.Fprintln(os.Stderr, "  # keeps session-bound sites (instacart class) working when the sink hits them")
+	case "sink":
+		peer := st.FindPeer(peerHost)
+		if peer == nil {
+			fmt.Fprintf(os.Stderr, "agentcookie wizard: tailnet peer %q not found in Tailscale status; cannot suggest an exit-node command\n", peerHost)
+			fmt.Fprintln(os.Stderr, "agentcookie wizard: confirm both machines are on the same tailnet and the source advertises as exit node, then re-run the wizard")
+			return
+		}
+		if st.SelfUsesExitNode() {
+			fmt.Fprintln(os.Stderr, "agentcookie wizard: this machine already routes through a Tailscale exit node")
+			return
+		}
+		if !peer.ExitNodeOption {
+			fmt.Fprintf(os.Stderr, "agentcookie wizard: peer %q is on the tailnet but is NOT advertising as exit node\n", peerHost)
+			fmt.Fprintln(os.Stderr, "agentcookie wizard: run this on the source machine first:")
+			fmt.Fprintln(os.Stderr, "  sudo tailscale set --advertise-exit-node")
+			fmt.Fprintln(os.Stderr, "agentcookie wizard: then approve the exit-node offer at https://login.tailscale.com/admin/machines")
+			return
+		}
+		fmt.Fprintln(os.Stderr, "agentcookie wizard: optional next step on this machine (sink):")
+		fmt.Fprintf(os.Stderr, "  sudo tailscale set --exit-node=%s --exit-node-allow-lan-access=true\n", peerHost)
+		fmt.Fprintln(os.Stderr, "  # routes this machine's outbound traffic through the source's public IP")
+		fmt.Fprintln(os.Stderr, "  # verify with: curl -s https://api.ipify.org && echo")
+		fmt.Fprintln(os.Stderr, "  # to undo: sudo tailscale set --exit-node=")
+	}
 }
 
 // ensureRemoteDebuggingEnabled walks the sink machine's real Chrome through

--- a/internal/tsclient/tsclient.go
+++ b/internal/tsclient/tsclient.go
@@ -1,0 +1,128 @@
+// Package tsclient probes Tailscale state on the local machine. agentcookie
+// uses it during wizard install to detect whether Tailscale is available and
+// to advise the user on the exit-node setup that keeps the sink machine's
+// outbound IP aligned with the source machine.
+package tsclient
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// macAppCLI is the canonical Tailscale CLI path on a macOS install of
+// Tailscale.app. The standalone CLI install drops a tailscale binary on PATH
+// instead, which we probe first.
+const macAppCLI = "/Applications/Tailscale.app/Contents/MacOS/Tailscale"
+
+// ErrNotInstalled is returned by FindCLI when no Tailscale binary is on PATH
+// or under /Applications/.
+var ErrNotInstalled = errors.New("tsclient: Tailscale CLI not found")
+
+// Status is a thin JSON view over `tailscale status --json` containing only
+// the fields agentcookie cares about. The real JSON has many more fields.
+type Status struct {
+	Version string         `json:"Version"`
+	Self    *PeerStatus    `json:"Self"`
+	Peer    map[string]*PeerStatus `json:"Peer"`
+}
+
+// PeerStatus mirrors the per-peer object Tailscale's status JSON emits.
+type PeerStatus struct {
+	HostName       string   `json:"HostName"`
+	DNSName        string   `json:"DNSName"`
+	TailscaleIPs   []string `json:"TailscaleIPs"`
+	ExitNodeOption bool     `json:"ExitNodeOption"`
+	ExitNode       bool     `json:"ExitNode"`
+	Online         bool     `json:"Online"`
+}
+
+// FindCLI returns the path to the local Tailscale CLI. Checks PATH first,
+// then the macOS app bundle path. Returns ErrNotInstalled when neither
+// exists.
+func FindCLI() (string, error) {
+	if p, err := exec.LookPath("tailscale"); err == nil {
+		return p, nil
+	}
+	if _, err := os.Stat(macAppCLI); err == nil {
+		return macAppCLI, nil
+	}
+	return "", ErrNotInstalled
+}
+
+// Get runs `tailscale status --json` and parses the result. Caller must
+// pass a non-empty cliPath (use FindCLI).
+func Get(ctx context.Context, cliPath string) (*Status, error) {
+	if cliPath == "" {
+		return nil, errors.New("tsclient: cliPath is required")
+	}
+	runCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(runCtx, cliPath, "status", "--json").Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return nil, fmt.Errorf("tsclient: %s status: %w (%s)", cliPath, err, strings.TrimSpace(string(exitErr.Stderr)))
+		}
+		return nil, fmt.Errorf("tsclient: %s status: %w", cliPath, err)
+	}
+	var st Status
+	if err := json.Unmarshal(out, &st); err != nil {
+		return nil, fmt.Errorf("tsclient: parse status JSON: %w", err)
+	}
+	return &st, nil
+}
+
+// FindPeer returns the PeerStatus for the named hostname. Matches against
+// HostName and the DNS-name's first label (Tailscale's "magic DNS" form).
+// Returns nil when no peer matches.
+func (s *Status) FindPeer(hostname string) *PeerStatus {
+	if s == nil {
+		return nil
+	}
+	target := strings.ToLower(strings.TrimSpace(hostname))
+	for _, p := range s.Peer {
+		if p == nil {
+			continue
+		}
+		if strings.EqualFold(p.HostName, target) {
+			return p
+		}
+		if label, _, ok := strings.Cut(p.DNSName, "."); ok && strings.EqualFold(label, target) {
+			return p
+		}
+	}
+	return nil
+}
+
+// SelfAdvertisesExitNode reports whether the local machine is configured to
+// advertise itself as a Tailscale exit node.
+func (s *Status) SelfAdvertisesExitNode() bool {
+	if s == nil || s.Self == nil {
+		return false
+	}
+	return s.Self.ExitNodeOption
+}
+
+// SelfUsesExitNode reports whether the local machine is currently routing
+// its outbound traffic through a Tailscale exit node.
+func (s *Status) SelfUsesExitNode() bool {
+	if s == nil || s.Self == nil {
+		return false
+	}
+	return s.Self.ExitNode
+}
+
+// SelfHostname returns the local machine's tailnet hostname, or empty when
+// status is not available.
+func (s *Status) SelfHostname() string {
+	if s == nil || s.Self == nil {
+		return ""
+	}
+	return s.Self.HostName
+}

--- a/internal/tsclient/tsclient_test.go
+++ b/internal/tsclient/tsclient_test.go
@@ -1,0 +1,68 @@
+package tsclient
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestStatus_ParseSampleJSON(t *testing.T) {
+	// Sample shape from `tailscale status --json` on a real tailnet,
+	// trimmed to the fields tsclient consumes.
+	raw := `{
+	  "Version": "1.96.5",
+	  "Self": {
+	    "HostName": "matts-mac-mini",
+	    "DNSName": "matts-mac-mini.tail-xxxx.ts.net.",
+	    "TailscaleIPs": ["100.80.229.80"],
+	    "ExitNodeOption": false,
+	    "ExitNode": false,
+	    "Online": true
+	  },
+	  "Peer": {
+	    "abc123": {
+	      "HostName": "MacBook Pro (44)",
+	      "DNSName": "macbook-pro-44.tail-xxxx.ts.net.",
+	      "TailscaleIPs": ["100.98.176.68"],
+	      "ExitNodeOption": true,
+	      "ExitNode": false,
+	      "Online": true
+	    }
+	  }
+	}`
+	var st Status
+	if err := json.Unmarshal([]byte(raw), &st); err != nil {
+		t.Fatal(err)
+	}
+	if st.SelfHostname() != "matts-mac-mini" {
+		t.Errorf("self hostname: got %q", st.SelfHostname())
+	}
+	if st.SelfAdvertisesExitNode() {
+		t.Error("self should not advertise exit-node")
+	}
+	if st.SelfUsesExitNode() {
+		t.Error("self should not be using exit-node")
+	}
+
+	p := st.FindPeer("macbook-pro-44")
+	if p == nil {
+		t.Fatal("expected to find peer by DNS label")
+	}
+	if !p.ExitNodeOption {
+		t.Error("peer should advertise exit-node")
+	}
+	if p.TailscaleIPs[0] != "100.98.176.68" {
+		t.Errorf("peer IP: got %v", p.TailscaleIPs)
+	}
+}
+
+func TestFindPeer_Misses(t *testing.T) {
+	st := &Status{Peer: map[string]*PeerStatus{
+		"a": {HostName: "alpha", DNSName: "alpha.example.ts.net."},
+	}}
+	if got := st.FindPeer("zulu"); got != nil {
+		t.Errorf("expected nil for missing peer, got %v", got)
+	}
+	if got := (*Status)(nil).FindPeer("alpha"); got != nil {
+		t.Errorf("nil receiver should return nil, got %v", got)
+	}
+}


### PR DESCRIPTION
## Summary

Sites that bind sessions to the IP the session was minted on (instacart class) refuse to load if the sink machine hits them from a different public IP than the source. Tailscale's exit-node feature routes the sink machine's outbound traffic through the source so both sides share an IP.

This unit adds a wizard step that detects Tailscale on the local machine, inspects its tailnet state, and emits the exact sudo commands the user runs for the appropriate role.

## What the wizard prints

Source side:
```
sudo tailscale set --advertise-exit-node
```

Sink side:
```
sudo tailscale set --exit-node=<source-host> --exit-node-allow-lan-access=true
```

The wizard never executes sudo itself; exit-node routing changes outbound behavior for the entire machine and stays a deliberate user action.

## Behavior

- Tailscale missing: one-line note that session-bound sites may not work; continue.
- Already advertising / using exit-node: skip the hint.
- Peer not on tailnet: explain the missing prerequisite.
- Peer on tailnet but not advertising as exit-node: print source-side command first.

`--skip-exit-node-hint` opts out.

## What's new

- `internal/tsclient` package: `FindCLI`, `Get`, `FindPeer`, helpers around `tailscale status --json`.
- Hint function wired into both source and sink install flows.

## Test plan

- [x] `go test ./internal/...` 112 passed in 14 packages
- [x] Tailscale JSON parsing test against a real-tailnet shape
- [x] Status helpers handle nil receivers