### PR TITLE
fix(v0.7): prepend Chrome 127+ App-Bound prefix on cookie write

### DIFF
--- a/internal/chrome/appbound.go
+++ b/internal/chrome/appbound.go
@@ -26,3 +26,16 @@ func stripAppBoundPrefix(plaintext []byte, hostKey string) []byte {
 	}
 	return plaintext[sha256.Size:]
 }
+
+// prependAppBoundPrefix is the inverse of stripAppBoundPrefix: prepends the
+// SHA256(host_key) prefix before v10 encryption so Chrome 127+ accepts the
+// cookie on decrypt. Without the prefix, Chrome silently drops the cookie
+// on the next launch (cookie passes SQLite write but doesn't survive the
+// in-memory load).
+func prependAppBoundPrefix(plaintext []byte, hostKey string) []byte {
+	prefix := sha256.Sum256([]byte(hostKey))
+	out := make([]byte, sha256.Size+len(plaintext))
+	copy(out, prefix[:])
+	copy(out[sha256.Size:], plaintext)
+	return out
+}

--- a/internal/chrome/sqlitecount.go
+++ b/internal/chrome/sqlitecount.go
@@ -1,0 +1,22 @@
+package chrome
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+// SqliteRowCount returns the row count of a table at dbPath. Used by the
+// sink to verify writes immediately after commit, separately from any
+// later state changes Chrome may apply on relaunch.
+func SqliteRowCount(dbPath, table string) (int, error) {
+	db, err := sql.Open("sqlite3", "file:"+dbPath+"?mode=ro")
+	if err != nil {
+		return 0, fmt.Errorf("open %s: %w", dbPath, err)
+	}
+	defer db.Close()
+	var n int
+	if err := db.QueryRow(fmt.Sprintf("select count(*) from %s", table)).Scan(&n); err != nil {
+		return 0, fmt.Errorf("count %s: %w", table, err)
+	}
+	return n, nil
+}

--- a/internal/chrome/write.go
+++ b/internal/chrome/write.go
@@ -56,7 +56,12 @@ func WriteCookies(dbPath string, cookies []Cookie, key []byte) (int, error) {
 
 	written := 0
 	for _, c := range cookies {
-		encrypted, err := encryptValue(c.Value, key)
+		// Chrome 127+ App-Bound Encryption: the decrypted plaintext Chrome
+		// expects is `SHA256(host_key) || actual_value`. Without the
+		// 32-byte prefix Chrome silently drops the cookie on next launch.
+		// stripAppBoundPrefix on read undoes this; prepend on write.
+		appBoundPlaintext := prependAppBoundPrefix([]byte(c.Value), c.HostKey)
+		encrypted, err := encryptValueBytes(appBoundPlaintext, key)
 		if err != nil {
 			return written, fmt.Errorf("encrypt %s/%s: %w", c.HostKey, c.Name, err)
 		}
@@ -79,6 +84,10 @@ func WriteCookies(dbPath string, cookies []Cookie, key []byte) (int, error) {
 }
 
 func encryptValue(plaintext string, key []byte) ([]byte, error) {
+	return encryptValueBytes([]byte(plaintext), key)
+}
+
+func encryptValueBytes(plaintext, key []byte) ([]byte, error) {
 	block, err := aes.NewCipher(key)
 	if err != nil {
 		return nil, err
@@ -171,15 +180,17 @@ func buildUpsert(cols map[string]bool) (string, func(rowInput) []any) {
 		placeholders = append(placeholders, "?")
 		// Skip primary-key columns and creation_utc from the UPDATE clause.
 		switch f.name {
-		case "host_key", "top_frame_site_key", "name", "path", "source_scheme", "source_port", "creation_utc":
+		case "host_key", "top_frame_site_key", "has_cross_site_ancestor", "name", "path", "source_scheme", "source_port", "creation_utc":
 			continue
 		}
 		updates = append(updates, fmt.Sprintf("%s=excluded.%s", f.name, f.name))
 	}
 
 	// Build conflict target from the columns that are actually present and form
-	// the unique key on every modern Chromium schema.
-	conflictCandidates := []string{"host_key", "top_frame_site_key", "name", "path", "source_scheme", "source_port"}
+	// the unique key on every modern Chromium schema. Chrome 134+ added
+	// has_cross_site_ancestor to the unique index; older Chromes don't have it
+	// in the schema at all and the present-filter below drops it.
+	conflictCandidates := []string{"host_key", "top_frame_site_key", "has_cross_site_ancestor", "name", "path", "source_scheme", "source_port"}
 	var conflictCols []string
 	for _, c := range conflictCandidates {
 		if cols[c] {

--- a/internal/chromectl/chromectl.go
+++ b/internal/chromectl/chromectl.go
@@ -55,6 +55,13 @@ func IsRunning() (bool, error) {
 // QuitAndWait sends Chrome a graceful AppleEvent quit and polls until the
 // process is gone. Returns nil immediately if Chrome was not running.
 // Use this before any write to Chrome's on-disk state.
+//
+// "quit saving no" tells Chrome to skip any beforeunload prompts. Chrome's
+// Cmd+Q-confirmation setting is also bypassed. If AppleScript still gets
+// canceled (-128, "User canceled" — happens when Chrome's quit-on-Cmd+Q
+// warning is on AND a page has beforeunload AND Chrome decides to
+// suppress the AppleEvent), the function falls back to SIGTERM via pkill,
+// then SIGKILL if SIGTERM doesn't take.
 func QuitAndWait(ctx context.Context, timeout time.Duration) error {
 	running, err := IsRunning()
 	if err != nil {
@@ -63,10 +70,15 @@ func QuitAndWait(ctx context.Context, timeout time.Duration) error {
 	if !running {
 		return nil
 	}
-	cmd := exec.CommandContext(ctx, "/usr/bin/osascript", "-e", `tell application "Google Chrome" to quit`)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("chromectl: osascript quit: %w (%s)", err, strings.TrimSpace(string(out)))
-	}
+
+	// First try: AppleScript with "saving no" to bypass beforeunload prompts.
+	cmd := exec.CommandContext(ctx, "/usr/bin/osascript", "-e", `tell application "Google Chrome" to quit saving no`)
+	out, err := cmd.CombinedOutput()
+	stderr := strings.TrimSpace(string(out))
+	appleScriptFailed := err != nil
+
+	// Even if AppleScript reported success, poll briefly to confirm. Chrome
+	// can swallow the quit AppleEvent and stay running.
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		select {
@@ -81,6 +93,49 @@ func QuitAndWait(ctx context.Context, timeout time.Duration) error {
 		if !running {
 			return nil
 		}
+		// If the AppleScript reported "user canceled" and Chrome is still up,
+		// bail out of the polite path early and use signals.
+		if appleScriptFailed && strings.Contains(stderr, "-128") {
+			break
+		}
+	}
+
+	// Fallback: SIGTERM the Chrome processes directly.
+	_ = exec.CommandContext(ctx, "/usr/bin/pkill", "-TERM", "-x", "Google Chrome").Run()
+	for time.Now().Before(deadline) {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(200 * time.Millisecond):
+		}
+		running, err := IsRunning()
+		if err != nil {
+			return err
+		}
+		if !running {
+			return nil
+		}
+	}
+
+	// Last resort: SIGKILL.
+	_ = exec.CommandContext(ctx, "/usr/bin/pkill", "-KILL", "-x", "Google Chrome").Run()
+	hardDeadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(hardDeadline) {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(200 * time.Millisecond):
+		}
+		running, err := IsRunning()
+		if err != nil {
+			return err
+		}
+		if !running {
+			return nil
+		}
+	}
+	if appleScriptFailed {
+		return fmt.Errorf("chromectl: %w (osascript: %s; signals did not stop Chrome)", ErrQuitTimeout, stderr)
 	}
 	return ErrQuitTimeout
 }

--- a/internal/cli/sink.go
+++ b/internal/cli/sink.go
@@ -214,6 +214,9 @@ func applyEnvelopeToSink(
 			if err != nil {
 				return fmt.Errorf("cookies: %w", err)
 			}
+			if rowCount, qerr := chrome.SqliteRowCount(cfg.Chrome.DBPath, "cookies"); qerr == nil {
+				fmt.Fprintf(os.Stderr, "agentcookie sink: post-commit verify: %d rows in cookies table (just wrote %d)\n", rowCount, n)
+			}
 		}
 		if len(env.LocalStorageTarball) > 0 {
 			n, err := replaceLevelDBDir(env.LocalStorageTarball, chromepaths.LocalStorageLevelDB())

--- a/internal/cli/source.go
+++ b/internal/cli/source.go
@@ -193,11 +193,18 @@ func pushOnce(
 	} else if !errors.Is(err, chromedirsync.ErrSourceMissing) {
 		fmt.Fprintf(os.Stderr, "agentcookie source: localStorage pack failed (%v); continuing without it\n", err)
 	}
-	if it, sk, err := chromedirsync.Pack(chromepaths.IndexedDBDir(), 50*1024*1024); err == nil {
-		idbTarball = it
-		idbSkipped = sk
-	} else if !errors.Is(err, chromedirsync.ErrSourceMissing) {
-		fmt.Fprintf(os.Stderr, "agentcookie source: indexedDB pack failed (%v); continuing without it\n", err)
+	// IndexedDB is opt-in for v0.7: typical user dirs are 400MB+ (Gmail caches,
+	// Slack message history) and inlining that in the JSON envelope blows
+	// past the source-side POST timeout. Most PP CLIs auth via localStorage
+	// or cookies; IndexedDB is rarely an auth-state surface in practice.
+	// Set AGENTCOOKIE_SYNC_INDEXEDDB=1 to opt in.
+	if os.Getenv("AGENTCOOKIE_SYNC_INDEXEDDB") == "1" {
+		if it, sk, err := chromedirsync.Pack(chromepaths.IndexedDBDir(), 5*1024*1024); err == nil {
+			idbTarball = it
+			idbSkipped = sk
+		} else if !errors.Is(err, chromedirsync.ErrSourceMissing) {
+			fmt.Fprintf(os.Stderr, "agentcookie source: indexedDB pack failed (%v); continuing without it\n", err)
+		}
 	}
 
 	envelope := protocol.SyncEnvelope{


### PR DESCRIPTION
## Summary

Without the SHA256(host_key) prefix on the plaintext before v10 encryption, Chrome silently drops 99% of cookies on relaunch. The prefix was discovered in v0.5 research and applied to reads, but never to writes.

## Live verify

Mac mini Chrome 148, both before and after the fix:

| | Cookies written | Survived Chrome relaunch | instacart_sid present |
|---|---|---|---|
| Before | 7188 | 42 | no |
| After | 7196 | 7127 | yes |

## Other fixes from live verify on Matt's hardware

- `chromectl.QuitAndWait` falls back from "tell app to quit saving no" to SIGTERM then SIGKILL when AppleEvent quit returns -128 ("user canceled", which fires when Chrome's Cmd+Q-confirmation setting is on AND a page has beforeunload).
- Chrome 134+ added `has_cross_site_ancestor` to `cookies_unique_index`; updated `buildUpsert`'s conflict list.
- IndexedDB sync now opt-in via `AGENTCOOKIE_SYNC_INDEXEDDB=1`; default off because user dirs are typically 400MB+ and inline JSON envelopes hit source-side POST timeout.
- Internal helper `chrome.SqliteRowCount` for post-commit verification logging.

## State after merge

Cookies AND localStorage are syncing from laptop Chrome Default profile to Mac mini Chrome Default profile. PP CLIs reading the real profile (Superhuman, Instacart) now see the auth artifacts. Whether the sites actually authenticate also depends on IP-binding (Tailscale exit-node from v0.5 U5) and User-Agent matching.

## Test plan

- [x] `go test ./internal/chrome/` 10 passed
- [x] `go test ./internal/chromectl/` 3 passed
- [x] Live verify on Mac mini Chrome 148: 7127/7196 cookies persist (vs 42/7188 before)
- [x] instacart `__Host-instacart_sid` byte-length matches laptop