### PR TITLE
feat(v0.8): sidecar cookies bridge for PP CLIs

### DIFF
--- a/cookiesource/cookiesource.go
+++ b/cookiesource/cookiesource.go
@@ -1,0 +1,90 @@
+// Package cookiesource is the importable PP-CLI integration point for the
+// agentcookie bridge. PP CLIs that read Chrome cookies via kooky (or any
+// other Chrome-cookies library) call cookiesource.Open to discover the
+// path they should read from. When agentcookie is installed and the
+// AGENTCOOKIE_PLAIN_COOKIES env var is set, Open returns the sidecar
+// path with PlainText=true. When not, Open returns the empty default
+// and PlainText=false, signaling the caller to fall back to its existing
+// kooky-discovery flow.
+//
+// The sidecar file is a plaintext Chrome-shaped SQLite at
+// ~/.agentcookie/cookies-plain.db. PP CLIs reading it skip both the
+// macOS Keychain handshake and Chrome 127+'s App-Bound encryption.
+//
+// Typical PP CLI integration:
+//
+//	src, err := cookiesource.Open()
+//	if err != nil {
+//	    // ...
+//	}
+//	if src.PlainText {
+//	    cookies = readSidecar(src.Path)
+//	} else {
+//	    cookies = kooky.FindAllCookieStores() // existing fallback
+//	}
+//
+// Or the one-line version via ReadCookies, which handles both paths
+// internally.
+package cookiesource
+
+import (
+	"errors"
+	"fmt"
+	"os"
+)
+
+// EnvVar is the environment variable PP CLIs and Hermes-style agents
+// set on a Mac mini to opt in to the agentcookie bridge. Its value is
+// the absolute path to the plaintext sidecar SQLite.
+const EnvVar = "AGENTCOOKIE_PLAIN_COOKIES"
+
+// ErrSidecarMissing is returned by Open when AGENTCOOKIE_PLAIN_COOKIES
+// is set but the file does not exist on disk. Callers can treat this as
+// "agentcookie not installed (or not yet synced)" and fall back to
+// their default Chrome path.
+var ErrSidecarMissing = errors.New("cookiesource: AGENTCOOKIE_PLAIN_COOKIES is set but the file does not exist (is agentcookie installed and has it run at least one sync?)")
+
+// Source describes the cookie store the PP CLI should read from.
+//
+// PlainText=true means the caller should read Path as a Chrome-shaped
+// SQLite whose `value` column holds plaintext cookies and whose
+// `encrypted_value` column is empty. No Keychain access required.
+//
+// PlainText=false (and empty Path) means the caller should fall back to
+// its existing kooky-discovery or hardcoded-Chrome-path flow.
+type Source struct {
+	Path      string
+	PlainText bool
+}
+
+// Open returns the Source the PP CLI should read cookies from.
+// Honors AGENTCOOKIE_PLAIN_COOKIES; falls back when unset.
+//
+// Returns ErrSidecarMissing if the env var is set but the file does
+// not exist; callers usually want to log and continue with fallback.
+func Open() (Source, error) {
+	path := os.Getenv(EnvVar)
+	if path == "" {
+		return Source{}, nil
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return Source{Path: path, PlainText: true}, ErrSidecarMissing
+		}
+		return Source{}, fmt.Errorf("cookiesource: stat %s: %w", path, err)
+	}
+	if info.IsDir() {
+		return Source{}, fmt.Errorf("cookiesource: %s is a directory, not a SQLite file", path)
+	}
+	return Source{Path: path, PlainText: true}, nil
+}
+
+// Available reports whether the agentcookie bridge is configured AND the
+// sidecar file exists. Cheap probe for tooling that wants to log
+// "using agentcookie bridge" without surfacing errors. Returns false
+// (with no error) for any reason the bridge is not usable.
+func Available() bool {
+	src, err := Open()
+	return err == nil && src.PlainText && src.Path != ""
+}

--- a/cookiesource/cookiesource_test.go
+++ b/cookiesource/cookiesource_test.go
@@ -1,0 +1,70 @@
+package cookiesource
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestOpen_EnvUnset(t *testing.T) {
+	t.Setenv(EnvVar, "")
+	src, err := Open()
+	if err != nil {
+		t.Errorf("unset env: got err %v, want nil", err)
+	}
+	if src.PlainText {
+		t.Error("unset env: PlainText should be false")
+	}
+	if src.Path != "" {
+		t.Errorf("unset env: Path should be empty, got %q", src.Path)
+	}
+	if Available() {
+		t.Error("Available should be false when env unset")
+	}
+}
+
+func TestOpen_EnvSetFileExists(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cookies-plain.db")
+	if err := os.WriteFile(path, []byte("sqlite3-bytes-here"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(EnvVar, path)
+
+	src, err := Open()
+	if err != nil {
+		t.Errorf("happy path: got err %v, want nil", err)
+	}
+	if !src.PlainText {
+		t.Error("happy path: PlainText should be true")
+	}
+	if src.Path != path {
+		t.Errorf("happy path: Path %q, want %q", src.Path, path)
+	}
+	if !Available() {
+		t.Error("Available should be true when env set + file exists")
+	}
+}
+
+func TestOpen_EnvSetFileMissing(t *testing.T) {
+	t.Setenv(EnvVar, "/tmp/this-does-not-exist-agentcookie-test-1234")
+	src, err := Open()
+	if !errors.Is(err, ErrSidecarMissing) {
+		t.Errorf("missing-file: got err %v, want ErrSidecarMissing", err)
+	}
+	if !src.PlainText {
+		t.Error("missing-file should still report PlainText=true so caller knows the bridge was meant to be used")
+	}
+	if Available() {
+		t.Error("Available should be false when sidecar missing")
+	}
+}
+
+func TestOpen_EnvSetPointsAtDirectory(t *testing.T) {
+	t.Setenv(EnvVar, t.TempDir())
+	_, err := Open()
+	if err == nil {
+		t.Error("dir path: expected error, got nil")
+	}
+}

--- a/internal/chrome/sidecar.go
+++ b/internal/chrome/sidecar.go
@@ -1,0 +1,188 @@
+package chrome
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// sidecarSchema is the cookies-table schema we create in the sidecar SQLite.
+// Matches Chrome's modern (134+) schema exactly so kooky and other Chrome-
+// cookie libraries read it as if it were Chrome's own Cookies file. The
+// `value` column is text (plaintext); `encrypted_value` is a zero-byte
+// blob. Libraries that check `encrypted_value` first and fall back to
+// `value` when empty (kooky, lite-chrome, others) work transparently.
+const sidecarSchema = `
+CREATE TABLE IF NOT EXISTS cookies(
+	creation_utc INTEGER NOT NULL,
+	host_key TEXT NOT NULL,
+	top_frame_site_key TEXT NOT NULL,
+	name TEXT NOT NULL,
+	value TEXT NOT NULL,
+	encrypted_value BLOB NOT NULL,
+	path TEXT NOT NULL,
+	expires_utc INTEGER NOT NULL,
+	is_secure INTEGER NOT NULL,
+	is_httponly INTEGER NOT NULL,
+	last_access_utc INTEGER NOT NULL,
+	has_expires INTEGER NOT NULL,
+	is_persistent INTEGER NOT NULL,
+	priority INTEGER NOT NULL,
+	samesite INTEGER NOT NULL,
+	source_scheme INTEGER NOT NULL,
+	source_port INTEGER NOT NULL,
+	last_update_utc INTEGER NOT NULL,
+	source_type INTEGER NOT NULL,
+	has_cross_site_ancestor INTEGER NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS cookies_unique_index ON cookies(
+	host_key, top_frame_site_key, has_cross_site_ancestor, name, path, source_scheme, source_port
+);
+`
+
+// WriteCookiesSidecar writes cookies as plaintext into a Chrome-shaped
+// SQLite at targetPath. Used by agentcookie to publish a kooky-readable
+// cookies file that PP CLIs (and any cookie-reading library) can use
+// without Keychain access. See docs/plans/2026-05-17-001 for the bridge
+// architecture.
+//
+// The write is atomic: we write to a temp file in the same directory and
+// rename it into place once the transaction commits. Readers either see
+// the previous file or the new file, never a half-state.
+//
+// Returns the number of cookies written.
+func WriteCookiesSidecar(targetPath string, cookies []Cookie) (int, error) {
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o700); err != nil {
+		return 0, fmt.Errorf("mkdir sidecar parent: %w", err)
+	}
+	tmpPath := targetPath + ".agentcookie.tmp"
+	_ = os.Remove(tmpPath)
+
+	db, err := sql.Open("sqlite3", "file:"+tmpPath+"?_journal=WAL")
+	if err != nil {
+		return 0, fmt.Errorf("open sidecar tmp: %w", err)
+	}
+	if _, err := db.Exec(sidecarSchema); err != nil {
+		db.Close()
+		_ = os.Remove(tmpPath)
+		return 0, fmt.Errorf("create sidecar schema: %w", err)
+	}
+
+	cols := sidecarColumnSet()
+	insertSQL, args := buildUpsert(cols)
+
+	tx, err := db.Begin()
+	if err != nil {
+		db.Close()
+		_ = os.Remove(tmpPath)
+		return 0, fmt.Errorf("begin sidecar tx: %w", err)
+	}
+	stmt, err := tx.Prepare(insertSQL)
+	if err != nil {
+		tx.Rollback()
+		db.Close()
+		_ = os.Remove(tmpPath)
+		return 0, fmt.Errorf("prepare sidecar upsert: %w", err)
+	}
+
+	nowChrome := time.Now().UnixMicro() + chromeEpochDeltaMicros
+	written := 0
+	for _, c := range cookies {
+		row := args(rowInput{
+			cookie:        c,
+			encrypted:     []byte{},
+			creationUTC:   nowChrome,
+			lastUpdateUTC: nowChrome,
+		})
+		patchPlaintextValue(row, cols, c.Value)
+		if _, err := stmt.Exec(row...); err != nil {
+			if isUniqueConstraintError(err) {
+				continue
+			}
+			stmt.Close()
+			tx.Rollback()
+			db.Close()
+			_ = os.Remove(tmpPath)
+			return written, fmt.Errorf("upsert sidecar %s/%s: %w", c.HostKey, c.Name, err)
+		}
+		written++
+	}
+	stmt.Close()
+	if err := tx.Commit(); err != nil {
+		db.Close()
+		_ = os.Remove(tmpPath)
+		return written, fmt.Errorf("commit sidecar tx: %w", err)
+	}
+	if err := db.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return written, fmt.Errorf("close sidecar db: %w", err)
+	}
+	if err := os.Chmod(tmpPath, 0o600); err != nil {
+		_ = os.Remove(tmpPath)
+		return written, fmt.Errorf("chmod sidecar: %w", err)
+	}
+	if err := os.Rename(tmpPath, targetPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return written, fmt.Errorf("rename sidecar into place: %w", err)
+	}
+	return written, nil
+}
+
+// sidecarColumnSet returns the column set buildUpsert needs. Sidecar
+// always uses the full modern Chrome schema (we control the table).
+func sidecarColumnSet() map[string]bool {
+	return map[string]bool{
+		"creation_utc": true, "host_key": true, "top_frame_site_key": true,
+		"name": true, "value": true, "encrypted_value": true, "path": true,
+		"expires_utc": true, "is_secure": true, "is_httponly": true,
+		"last_access_utc": true, "has_expires": true, "is_persistent": true,
+		"priority": true, "samesite": true, "source_scheme": true,
+		"source_port": true, "last_update_utc": true, "source_type": true,
+		"has_cross_site_ancestor": true,
+	}
+}
+
+// patchPlaintextValue overwrites the `value` column slot with the plaintext
+// cookie value before stmt.Exec. buildUpsert's default `get` returns ""
+// for `value` (matching Chrome's encrypted-mode behavior). For the sidecar
+// we want the actual value there.
+func patchPlaintextValue(row []any, cols map[string]bool, plaintext string) {
+	idx := 0
+	for _, name := range orderedSidecarColumns() {
+		if !cols[name] {
+			continue
+		}
+		if name == "value" {
+			row[idx] = plaintext
+			return
+		}
+		idx++
+	}
+}
+
+// orderedSidecarColumns must match the candidate order in buildUpsert
+// so positional indexing into the row slice lines up.
+func orderedSidecarColumns() []string {
+	return []string{
+		"creation_utc", "host_key", "top_frame_site_key", "name", "value",
+		"encrypted_value", "path", "expires_utc", "is_secure", "is_httponly",
+		"last_access_utc", "has_expires", "is_persistent", "priority",
+		"samesite", "source_scheme", "source_port", "last_update_utc",
+		"source_type", "has_cross_site_ancestor",
+	}
+}
+
+// isUniqueConstraintError reports whether the SQLite error is a unique-
+// index violation. Source cookies sometimes have duplicate (host, name,
+// path, scheme, port) tuples after the source-side blocklist filter; we
+// silently skip later duplicates rather than failing the whole batch.
+func isUniqueConstraintError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "UNIQUE constraint failed")
+}

--- a/internal/chrome/sidecar_test.go
+++ b/internal/chrome/sidecar_test.go
@@ -1,0 +1,158 @@
+package chrome
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteCookiesSidecar_HappyPath(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "cookies-plain.db")
+	cookies := []Cookie{
+		{HostKey: ".instacart.com", Name: "_session", Value: "plain-text-session-token", Path: "/", IsSecure: 1, SameSite: 0, HasExpires: 1, ExpiresUTC: 13380163200000000},
+		{HostKey: "github.com", Name: "user_session", Value: "github-token-12345", Path: "/", IsSecure: 1},
+		{HostKey: ".claude.ai", Name: "csrf", Value: "csrf-token", SameSite: 1},
+	}
+	n, err := WriteCookiesSidecar(target, cookies)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 3 {
+		t.Errorf("wrote %d, want 3", n)
+	}
+
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("sidecar mode: got %o, want 0600", info.Mode().Perm())
+	}
+
+	db, err := sql.Open("sqlite3", "file:"+target+"?mode=ro")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	var count int
+	if err := db.QueryRow("select count(*) from cookies").Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 3 {
+		t.Errorf("sqlite count: got %d, want 3", count)
+	}
+
+	rows, _ := db.Query("select host_key, name, value, length(encrypted_value) from cookies where name = '_session'")
+	defer rows.Close()
+	if !rows.Next() {
+		t.Fatal("expected at least one row for _session")
+	}
+	var host, name, value string
+	var encLen int
+	if err := rows.Scan(&host, &name, &value, &encLen); err != nil {
+		t.Fatal(err)
+	}
+	if host != ".instacart.com" || name != "_session" {
+		t.Errorf("row identity wrong: %s/%s", host, name)
+	}
+	if value != "plain-text-session-token" {
+		t.Errorf("value not plaintext: %q", value)
+	}
+	if encLen != 0 {
+		t.Errorf("encrypted_value should be empty, got %d bytes", encLen)
+	}
+}
+
+func TestWriteCookiesSidecar_AtomicReplace(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "cookies-plain.db")
+	if _, err := WriteCookiesSidecar(target, []Cookie{
+		{HostKey: "a.com", Name: "first", Value: "old"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := WriteCookiesSidecar(target, []Cookie{
+		{HostKey: "b.com", Name: "second", Value: "new"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	db, _ := sql.Open("sqlite3", "file:"+target+"?mode=ro")
+	defer db.Close()
+	rows, _ := db.Query("select host_key, name, value from cookies")
+	defer rows.Close()
+	count := 0
+	for rows.Next() {
+		var h, n, v string
+		rows.Scan(&h, &n, &v)
+		if h != "b.com" {
+			t.Errorf("expected only b.com row after replace, got %s", h)
+		}
+		count++
+	}
+	if count != 1 {
+		t.Errorf("expected 1 row after replace, got %d", count)
+	}
+}
+
+func TestWriteCookiesSidecar_ParentDirCreated(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "nested", "sub", "cookies.db")
+	if _, err := WriteCookiesSidecar(target, []Cookie{{HostKey: "x.com", Name: "n"}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(target); err != nil {
+		t.Errorf("sidecar not created: %v", err)
+	}
+	info, _ := os.Stat(filepath.Dir(target))
+	if info.Mode().Perm() != 0o700 {
+		t.Errorf("parent dir mode: got %o, want 0700", info.Mode().Perm())
+	}
+}
+
+func TestWriteCookiesSidecar_EmptyValuesAllowed(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "cookies.db")
+	cookies := []Cookie{
+		{HostKey: ".example.com", Name: "consent_flag", Value: ""},
+		{HostKey: ".example.com", Name: "with_value", Value: "actual-value"},
+	}
+	n, err := WriteCookiesSidecar(target, cookies)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 2 {
+		t.Errorf("wrote %d, want 2", n)
+	}
+	db, _ := sql.Open("sqlite3", "file:"+target+"?mode=ro")
+	defer db.Close()
+	var emptyCount, nonEmptyCount int
+	db.QueryRow("select count(*) from cookies where value = ''").Scan(&emptyCount)
+	db.QueryRow("select count(*) from cookies where value != ''").Scan(&nonEmptyCount)
+	if emptyCount != 1 || nonEmptyCount != 1 {
+		t.Errorf("empty/non-empty counts: %d/%d, want 1/1", emptyCount, nonEmptyCount)
+	}
+}
+
+func TestWriteCookiesSidecar_DuplicateRowsTolerated(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "cookies.db")
+	// Same (host, name, path, scheme, port, has_cross_site_ancestor) tuple
+	// twice. The ON CONFLICT clause makes the second upsert overwrite the
+	// first; one row ends up in the table, second value wins.
+	cookies := []Cookie{
+		{HostKey: "x.com", Name: "dup", Path: "/", Value: "first"},
+		{HostKey: "x.com", Name: "dup", Path: "/", Value: "second"},
+	}
+	if _, err := WriteCookiesSidecar(target, cookies); err != nil {
+		t.Fatal(err)
+	}
+	db, _ := sql.Open("sqlite3", "file:"+target+"?mode=ro")
+	defer db.Close()
+	var count int
+	var lastValue string
+	db.QueryRow("select count(*), max(value) from cookies").Scan(&count, &lastValue)
+	if count != 1 {
+		t.Errorf("expected 1 deduped row, got %d", count)
+	}
+	if lastValue != "second" {
+		t.Errorf("expected upsert to land 'second', got %q", lastValue)
+	}
+}

--- a/internal/chromepaths/chromepaths.go
+++ b/internal/chromepaths/chromepaths.go
@@ -38,3 +38,13 @@ func LocalStorageLevelDB() string {
 func IndexedDBDir() string {
 	return filepath.Join(DefaultProfileDir(), "IndexedDB")
 }
+
+// SidecarCookiesDB returns the agentcookie bridge sidecar path. PP CLIs
+// read from this file (or honor the AGENTCOOKIE_PLAIN_COOKIES env var
+// pointing at it) to get cookies without Keychain access. Plaintext
+// values, Chrome-shaped schema. Default location is
+// ~/.agentcookie/cookies-plain.db, mode 0600.
+func SidecarCookiesDB() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".agentcookie", "cookies-plain.db")
+}

--- a/internal/cli/sink.go
+++ b/internal/cli/sink.go
@@ -168,14 +168,14 @@ func runSink(cmd *cobra.Command, args []string) error {
 			http.Error(w, fmt.Sprintf("apply envelope: %v", err), http.StatusInternalServerError)
 			return
 		}
-		fmt.Fprintf(os.Stderr, "agentcookie sink: wrote %d cookies + %d localStorage origins + %d indexedDB origins (dropped %d non-allowlisted cookies)\n", result.Cookies, result.LocalStorage, result.IndexedDB, dropped)
+		fmt.Fprintf(os.Stderr, "agentcookie sink: wrote %d cookies (+ %d sidecar) + %d localStorage origins + %d indexedDB origins (dropped %d non-allowlisted cookies)\n", result.Cookies, result.SidecarCookies, result.LocalStorage, result.IndexedDB, dropped)
 		sinkState.LastWrite = time.Now().UTC()
 		sinkState.LastWriteCount = result.Cookies
 		sinkState.LastWriteMode = "sqlite+leveldb"
 		sinkState.TotalWrites++
 		sinkState.TotalDropped += dropped
 		_ = stateWriter.Save(sinkState)
-		_, _ = fmt.Fprintf(w, "ok: wrote %d cookies, %d localStorage origins, %d indexedDB origins; dropped %d non-allowlisted cookies\n", result.Cookies, result.LocalStorage, result.IndexedDB, dropped)
+		_, _ = fmt.Fprintf(w, "ok: wrote %d cookies (%d sidecar), %d localStorage origins, %d indexedDB origins; dropped %d non-allowlisted cookies\n", result.Cookies, result.SidecarCookies, result.LocalStorage, result.IndexedDB, dropped)
 	})
 
 	srv := &http.Server{Addr: cfg.Listen.Addr, Handler: mux}
@@ -189,9 +189,10 @@ func runSink(cmd *cobra.Command, args []string) error {
 
 // writeResult counts what landed on the sink during one /sync.
 type writeResult struct {
-	Cookies      int
-	LocalStorage int // top-level origin subdirs in the live leveldb after the write
-	IndexedDB    int // origin subdirs in the live IndexedDB dir after the write
+	Cookies        int
+	SidecarCookies int // plaintext cookies written to ~/.agentcookie/cookies-plain.db
+	LocalStorage   int // top-level origin subdirs in the live leveldb after the write
+	IndexedDB      int // origin subdirs in the live IndexedDB dir after the write
 }
 
 // applyEnvelopeToSink wraps the three on-disk Chrome writes in a single
@@ -216,6 +217,16 @@ func applyEnvelopeToSink(
 			}
 			if rowCount, qerr := chrome.SqliteRowCount(cfg.Chrome.DBPath, "cookies"); qerr == nil {
 				fmt.Fprintf(os.Stderr, "agentcookie sink: post-commit verify: %d rows in cookies table (just wrote %d)\n", rowCount, n)
+			}
+			// v0.8 bridge: also write a plaintext-value sidecar at
+			// ~/.agentcookie/cookies-plain.db. PP CLIs reading this path
+			// get cookies without Keychain prompts and without kooky's
+			// App-Bound-decryption complaint. Sidecar errors are logged
+			// but non-fatal: the real Chrome write is the source of truth.
+			if sidecarN, sidecarErr := chrome.WriteCookiesSidecar(chromepaths.SidecarCookiesDB(), cookies); sidecarErr != nil {
+				fmt.Fprintf(os.Stderr, "agentcookie sink: sidecar write failed (%v); PP CLIs will fall back to Chrome's encrypted store\n", sidecarErr)
+			} else {
+				result.SidecarCookies = sidecarN
 			}
 		}
 		if len(env.LocalStorageTarball) > 0 {

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -35,6 +35,7 @@ var (
 	wizardSkipDaemon         bool
 	wizardSkipExitNode       bool
 	wizardSkipKeychainPrompt bool
+	wizardSkipBridgeHint     bool
 )
 
 var wizardCmd = &cobra.Command{
@@ -90,6 +91,7 @@ func init() {
 	wizardInstallCmd.Flags().BoolVar(&wizardSkipDaemon, "skip-daemon", false, "skip installing the LaunchAgent (configs + pairing only)")
 	wizardInstallCmd.Flags().BoolVar(&wizardSkipExitNode, "skip-exit-node-hint", false, "do not detect Tailscale or print the sudo commands that route the sink's outbound traffic through the source machine")
 	wizardInstallCmd.Flags().BoolVar(&wizardSkipKeychainPrompt, "skip-keychain-prompt", false, "[sink] do not trigger the Chrome Safe Storage Keychain prompt during install; the sink daemon will prompt on first sync instead")
+	wizardInstallCmd.Flags().BoolVar(&wizardSkipBridgeHint, "skip-bridge-hint", false, "[sink] do not print the cookie-bridge env-var integration hint at install end")
 
 	wizardUninstallCmd.Flags().StringVar(&wizardRole, "as", "", "source | sink (required)")
 	wizardUninstallCmd.Flags().BoolVar(&wizardForce, "purge", false, "also delete configs and paired keys")
@@ -258,8 +260,23 @@ func wizardInstallSink(ctx context.Context, binPath, logDir string) error {
 		printExitNodeHint(ctx, "sink", wizardPeer)
 	}
 
+	if !wizardSkipBridgeHint {
+		printBridgeHint()
+	}
+
 	fmt.Fprintln(os.Stderr, "agentcookie wizard: sink install complete")
 	return nil
+}
+
+// printBridgeHint tells the operator how PP CLIs use the v0.8 sidecar
+// cookies bridge. Sidecar lives at ~/.agentcookie/cookies-plain.db
+// (plaintext, mode 0600). PP CLIs read it via the AGENTCOOKIE_PLAIN_COOKIES
+// env var or by importing the cookiesource Go module.
+func printBridgeHint() {
+	fmt.Fprintln(os.Stderr, "agentcookie wizard: PP CLIs and headless agents can use the cookie bridge:")
+	fmt.Fprintln(os.Stderr, "  echo 'export AGENTCOOKIE_PLAIN_COOKIES=~/.agentcookie/cookies-plain.db' >> ~/.zshenv")
+	fmt.Fprintln(os.Stderr, "  # Existing PP CLI: one-line patch to read from the env var via the cookiesource Go module")
+	fmt.Fprintln(os.Stderr, "  # See README 'Using cookies with PP CLIs' for the import snippet")
 }
 
 // printExitNodeHint inspects Tailscale state and emits sudo command lines


### PR DESCRIPTION
## Summary

Closes the headless-agent gap from v0.7. PP CLIs reading Chrome cookies hit two walls:
1. Per-binary macOS Keychain prompts (hard block for headless Hermes/agents).
2. The `kooky` library does not handle Chrome 127+ App-Bound decryption.

v0.8 ships the bridge: agentcookie publishes plaintext cookies in a Chrome-shaped SQLite at `~/.agentcookie/cookies-plain.db`. PP CLIs read it without Keychain access and without decryption.

Plan: `docs/plans/2026-05-17-001-feat-pp-cli-bridge-sidecar-cookies-plan.md`.

## What's in this PR

- `internal/chrome/sidecar.go`: `WriteCookiesSidecar` writes a plaintext-value, empty-encrypted_value SQLite with the Chrome 134+ schema. Atomic write via temp + rename, mode 0600.
- `internal/chromepaths.SidecarCookiesDB()` returns the canonical path.
- Sink's `applyEnvelopeToSink` writes the sidecar inside the existing chromectl-quit ceremony. Errors logged but non-fatal.
- `cookiesource/` Go package (top-level, separate module) for PP CLI integration. `cookiesource.Open()` honors `AGENTCOOKIE_PLAIN_COOKIES`. PP CLIs replace `kooky.FindAllCookieStores` with a two-line env-var check.
- Wizard prints a one-time install hint pointing at the env var pattern.

## Test plan

- [x] `go test ./internal/...` 82 passed
- [x] `go test ./cookiesource/` 4 passed
- [x] Sidecar atomic-replace, parent-dir-creation, empty-values, duplicate-tuple-tolerance scenarios
- [x] cookiesource env-unset, env-set-with-file, env-set-with-missing-file, env-set-with-directory scenarios
- [ ] U5: live verify on Mac mini, Hermes runs instacart-pp-cli headless via the bridge