### PR TITLE
feat(v0.9): plain v10 cookie write so kooky v0.2.2 readers just work on the Mac mini

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 ## [Unreleased]
 
+### v0.9: plain v10 sink writes for headless kooky readers
+
+agentcookie's sink-side write now emits Chrome cookies in plain v10
+format with no App-Bound 32-byte plaintext prefix, and pins
+`meta.version = 18` in the cookies SQLite. The effect: PP CLIs and any
+other kooky v0.2.2 caller on the Mac mini can read the file directly
+without per-CLI cooperation, App-Bound knowledge, or paste-from-laptop
+ceremony. See `docs/plans/2026-05-17-003-feat-agentcookie-v10-mode-soup-to-nuts-plan.md`.
+
+Precondition: Mac mini Chrome stays quit during agent operation.
+Launching it would migrate `meta.version` to 24 and rewrite cookies in
+App-Bound v20, breaking every kooky v0.2.2 reader. The sink uses
+`chromectl.WithChromeDown` (not WithChromeQuit) so writes never trigger
+a relaunch.
+
+The install wizard now expands the Chrome Safe Storage Keychain
+partition list during sink install so Apple-tool callers read the
+password without GUI prompts. Ad-hoc-signed Go binaries (most PP CLIs)
+still need a one-time "Always Allow" click on first read; the partition
+list is groundwork.
+
+Each sink write runs a post-commit probe that decrypts a few cookies the
+way kooky v0.2.2 would and logs `probe ok` or `probe FAIL` with
+diagnostic counts. A regression of either the App-Bound write or the
+meta.version pin surfaces in stderr immediately instead of corrupting
+agent runs silently.
+
+Deferred for a future coordinated bump: switch back to App-Bound v20
+mode once PP CLIs and the printing-press meta-library move from kooky
+v0.2.2 to v0.2.9+ (which strips the 32-byte prefix when `dbVersion >= 24`).
+Until that bump, v0.9 plain-v10 mode is the bridge.
+
+End-to-end runbook: `docs/runbook-v0.9-soup-to-nuts.md`.
+
+## [Unreleased pre-v0.9]
+
 Tag v0.1.0 to cut the first release. See [docs/quickstart.md](docs/quickstart.md) to install and try it.
 
 ### Added (since project start)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Pre-release. v0.1 in active development. Watch the repo for the launch announcem
 - Unified `agentcookie` CLI: `source`, `sink`, `pair`, `status`, `version`. All support `--json` for agent callers.
 - Pairing handshake: X25519 + HKDF-SHA256 salted with a one-time code. Derived 32-byte keys land at `~/.config/agentcookie/keys/<peer>.json` mode 0600.
 - Cookie acquisition on macOS: read Chrome cookies SQLite read-only with `immutable=1`, decrypt v10 ciphertext using the Keychain Safe Storage key.
-- Cookie write: schema-aware INSERT ... ON CONFLICT that adapts to Chrome's evolving column set (`top_frame_site_key`, `source_type`, `has_cross_site_ancestor`).
+- Cookie write (v0.9): plain v10 mode + `meta.version=18` pin so any kooky v0.2.2 caller on the Mac mini sink reads cookies directly without paste-from-laptop ceremony. Schema-aware INSERT ... ON CONFLICT adapts to Chrome's evolving column set (`top_frame_site_key`, `source_type`, `has_cross_site_ancestor`). Sink stays Chrome-quit so the version migration never fires.
 - Live-Chrome injection: sink probes Chrome's DevTools port and uses `Storage.setCookies` for instant in-memory visibility. Falls back to SQLite write if Chrome isn't debuggable.
 - Wire protocol v1: versioned `SyncEnvelope` with monotonic Sequence (replay defense), source hostname, cookies. Documented in `docs/protocol.md`.
 - Sink-side allowlist enforcement: defense in depth even if the source is compromised.

--- a/docs/runbook-v0.9-soup-to-nuts.md
+++ b/docs/runbook-v0.9-soup-to-nuts.md
@@ -1,0 +1,110 @@
+# Runbook: v0.9 soup-to-nuts on a Mac mini sink
+
+End-to-end verification that an agent (Hermes, or a plain SSH session) on
+the Mac mini can act as you on a kooky-using PP CLI with no manual paste
+step. This is the v0.9 shipping signal.
+
+## Pre-state
+
+- MBP (source) and Mac mini (sink) both paired and running agentcookie
+  v0.9+.
+- Mac mini Chrome has been launched at least once so the Chrome Safe
+  Storage Keychain item exists.
+- Mac mini Chrome is currently QUIT. (`pgrep -x 'Google Chrome'` returns
+  nothing.)
+- instacart-pp-cli installed on the Mac mini.
+
+## Steps
+
+### 1. Re-run the wizard sink install on Mac mini
+
+This expands the partition list and triggers the Always Allow prompt.
+You may be asked for your login keychain password once.
+
+```
+agentcookie wizard install --as sink --peer <source-host> \
+  --code <pair-code> --pair-url http://<source-host>:9998/pair
+```
+
+If pairing already exists, the wizard skips that and just runs the
+partition-list step. Look for:
+
+```
+agentcookie wizard: partition list granted (Apple-tool callers can now read Safe Storage silently)
+```
+
+### 2. Push a fresh sync from MBP
+
+```
+agentcookie source --once
+```
+
+On Mac mini's sink stderr (or `~/.agentcookie/logs/sink.err`), confirm:
+
+```
+agentcookie sink: wrote N cookies (+ N sidecar) + ...
+agentcookie sink: probe ok: 3 cookies round-tripped, meta.version=18
+```
+
+A `probe FAIL` line here is a stop-the-line: the bridge is unhealthy
+and the soup-to-nuts run will not work. See the probe diagnostic for
+which check failed (app-bound-leaks > 0 means U1 regressed;
+meta.version != 18 means U2 regressed or Chrome rewrote the file).
+
+### 3. SSH to Mac mini and run instacart-pp-cli directly
+
+```
+ssh mac-mini 'instacart doctor'
+```
+
+Expected output:
+
+```
+[ok ] api: logged in as <Matt's display name>
+[ok ] cookies: read N cookies from Chrome
+...
+```
+
+If instacart prompts for a Keychain decision (or errors with "User
+interaction is not allowed"), the partition list grant did not cover
+this binary. Workaround: SSH into Mac mini interactively, run
+`instacart doctor` once at the desktop console, click "Always Allow"
+on the prompt. Second run from SSH should succeed silently.
+
+### 4. Confirm zero manual paste in the session
+
+Inspect the SSH session output: no `auth paste`, no `dump-instacart`,
+no manual clipboard step. The CLI talked to Chrome Safe Storage and
+the Cookies SQLite directly via kooky v0.2.2.
+
+This is the shipping signal for v0.9.
+
+## What "soup to nuts" excludes from this runbook
+
+- Third-party kooky callers (bird CLI from last30days, etc.). Try one
+  after the instacart run succeeds; same mechanism applies.
+- CLIs that use chromedp / DevTools instead of kooky. Out of scope for
+  v0.9; they read from a running Chrome's memory and need a different
+  path.
+- Hermes-driven flows that wrap the CLI in other automation. The
+  bridge is shared; success here means Hermes succeeds.
+
+## Rollback
+
+If the bridge breaks and you need cookies on the Mac mini today:
+
+```
+# On MBP (source machine):
+~/agentcookie/hack/dump-instacart | ssh mac-mini 'instacart auth paste'
+```
+
+This is the manual ceremony that worked before v0.9. The v0.9 plan
+exists to eliminate it; this is the rollback if v0.9 itself is broken.
+
+## What to capture if the runbook fails
+
+- The exact `agentcookie sink: probe ...` line from `~/.agentcookie/logs/sink.err`
+- `sqlite3 ~/Library/Application\ Support/Google/Chrome/Default/Cookies "SELECT value FROM meta WHERE key='version'"`
+- `pgrep -x 'Google Chrome'` on Mac mini (must return empty)
+- `security find-generic-password -s "Chrome Safe Storage" -a "Chrome"` on Mac mini (the attributes line shows partition list)
+- The error text instacart-pp-cli emitted

--- a/internal/chrome/appbound.go
+++ b/internal/chrome/appbound.go
@@ -32,6 +32,13 @@ func stripAppBoundPrefix(plaintext []byte, hostKey string) []byte {
 // cookie on decrypt. Without the prefix, Chrome silently drops the cookie
 // on the next launch (cookie passes SQLite write but doesn't survive the
 // in-memory load).
+//
+// Currently unreferenced: v0.9 dropped the App-Bound prefix from the write
+// path because PP CLIs on the Mac mini sink read via kooky v0.2.2, which
+// does not strip the prefix. See plan 2026-05-17-003. Kept exported for the
+// eventual coordinated bump (kooky v0.2.9+ in PP, agentcookie back to v20
+// mode); call sites re-enable it then. stripAppBoundPrefix on the read side
+// stays active and defensive.
 func prependAppBoundPrefix(plaintext []byte, hostKey string) []byte {
 	prefix := sha256.Sum256([]byte(hostKey))
 	out := make([]byte, sha256.Size+len(plaintext))

--- a/internal/chrome/keychain.go
+++ b/internal/chrome/keychain.go
@@ -6,6 +6,7 @@ import (
 	"crypto/pbkdf2"
 	"crypto/sha1"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 )
@@ -44,4 +45,50 @@ func DeriveAESKey(password string) ([]byte, error) {
 		return nil, fmt.Errorf("pbkdf2: %w", err)
 	}
 	return key, nil
+}
+
+// DefaultPartitionList is the partition string SetSafeStoragePartitionList
+// uses when its argument is empty. Apple-signed binaries and Apple-tool
+// callers (like the `security` CLI) read Chrome Safe Storage without a GUI
+// prompt under this list. Ad-hoc-signed Go binaries (most PP CLIs) still
+// need a one-time "Always Allow" click on first read; the partition list
+// is groundwork, not a complete grant.
+const DefaultPartitionList = "apple-tool:,apple:"
+
+// buildPartitionListArgv returns the argv for the `security` command that
+// updates the Chrome Safe Storage partition list. Split out from
+// SetSafeStoragePartitionList so the argv shape is unit-testable without
+// shelling out.
+func buildPartitionListArgv(partitions string) []string {
+	if partitions == "" {
+		partitions = DefaultPartitionList
+	}
+	return []string{
+		"set-generic-password-partition-list",
+		"-S", partitions,
+		"-s", keychainService,
+		"-a", keychainAccount,
+	}
+}
+
+// SetSafeStoragePartitionList expands the partition list on the Chrome
+// Safe Storage Keychain item so headless callers can read it with no GUI
+// prompt. macOS prompts the user for their login keychain password the
+// first time this runs; subsequent runs with the same list are no-ops.
+// Idempotent.
+//
+// Passing partitions = "" uses DefaultPartitionList. Ad-hoc-signed
+// binaries (most Go CLIs) are NOT covered by the default and still need
+// their own one-time Always Allow click on first read; the partition list
+// covers Apple-tool intermediaries (e.g., the `security` CLI itself).
+func SetSafeStoragePartitionList(partitions string) error {
+	argv := buildPartitionListArgv(partitions)
+	cmd := exec.Command("security", argv...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("set Chrome Safe Storage partition list (login keychain password required): %w", err)
+	}
+	return nil
 }

--- a/internal/chrome/keychain_test.go
+++ b/internal/chrome/keychain_test.go
@@ -1,0 +1,43 @@
+package chrome
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestBuildPartitionListArgv_DefaultsToDefaultPartitionList(t *testing.T) {
+	got := buildPartitionListArgv("")
+	want := []string{
+		"set-generic-password-partition-list",
+		"-S", DefaultPartitionList,
+		"-s", "Chrome Safe Storage",
+		"-a", "Chrome",
+	}
+	if !slices.Equal(got, want) {
+		t.Errorf("default argv: got %v, want %v", got, want)
+	}
+}
+
+func TestBuildPartitionListArgv_CustomPartitionsPassthrough(t *testing.T) {
+	custom := "apple-tool:,apple:,teamid:ABC1234"
+	got := buildPartitionListArgv(custom)
+	if got[2] != custom {
+		t.Errorf("partition list arg: got %q, want %q", got[2], custom)
+	}
+	// Service and account stay pinned regardless of partition input.
+	if got[4] != "Chrome Safe Storage" {
+		t.Errorf("service arg: got %q", got[4])
+	}
+	if got[6] != "Chrome" {
+		t.Errorf("account arg: got %q", got[6])
+	}
+}
+
+func TestBuildPartitionListArgv_SubcommandIsFirst(t *testing.T) {
+	// The `security` CLI dispatches on argv[0]. Mis-ordering here would
+	// silently hit the wrong subcommand.
+	got := buildPartitionListArgv("")
+	if got[0] != "set-generic-password-partition-list" {
+		t.Errorf("subcommand arg[0]: got %q, want set-generic-password-partition-list", got[0])
+	}
+}

--- a/internal/chrome/probe.go
+++ b/internal/chrome/probe.go
@@ -1,0 +1,103 @@
+package chrome
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"database/sql"
+	"fmt"
+)
+
+// ProbeResult is the post-write sink-side health check against a freshly
+// written Cookies SQLite. The check exercises the same v10 + AES-CBC path
+// kooky v0.2.2 uses, so a green probe means the bridge is actually readable
+// to PP CLIs on this machine, not just internally round-tripping.
+type ProbeResult struct {
+	Path string
+
+	// RowsChecked is the number of cookies the probe successfully decrypted.
+	// Zero is suspicious -- either the file is empty or all decrypts failed.
+	RowsChecked int
+
+	// AppBoundLeaks is the count of cookies whose decrypted plaintext starts
+	// with SHA256(host_key). Non-zero means the App-Bound prefix is still
+	// being emitted on write -- a U1 regression that would silently corrupt
+	// every kooky v0.2.2 read.
+	AppBoundLeaks int
+
+	// MetaVersion is the value of meta.version in the SQLite. v0.9 expects
+	// "18" (the U2 pin); anything else means the meta write regressed or
+	// Chrome rewrote the file.
+	MetaVersion string
+}
+
+// OK reports whether the bridge is healthy from a kooky-v0.2.2 reader's
+// point of view: at least one row decrypted, no App-Bound prefix leaks,
+// and meta.version pinned to "18".
+func (r ProbeResult) OK() bool {
+	return r.RowsChecked > 0 && r.AppBoundLeaks == 0 && r.MetaVersion == "18"
+}
+
+// Summary returns a one-line description of the probe result suitable for
+// sink stderr.
+func (r ProbeResult) Summary() string {
+	if r.OK() {
+		return fmt.Sprintf("probe ok: %d cookies round-tripped, meta.version=%s", r.RowsChecked, r.MetaVersion)
+	}
+	return fmt.Sprintf("probe FAIL: rows=%d app-bound-leaks=%d meta.version=%q", r.RowsChecked, r.AppBoundLeaks, r.MetaVersion)
+}
+
+// ProbeCookiesFile decrypts up to maxRows cookies from path using the same
+// v10 + AES-CBC + macOS Keychain key path kooky v0.2.2 uses, then reads
+// meta.version. Reports any App-Bound prefix leakage from the write path
+// and the meta.version pin. Read-only; never modifies path.
+//
+// The bridge has multiple ways to silently break (Chrome rewrites cookies on
+// launch, agentcookie write path regresses, the Keychain key changes between
+// install and run). A failed probe in sink stderr exposes the break
+// immediately instead of letting an agent run fail an hour later with no
+// breadcrumb.
+func ProbeCookiesFile(path string, key []byte, maxRows int) (ProbeResult, error) {
+	result := ProbeResult{Path: path}
+	if maxRows <= 0 {
+		maxRows = 3
+	}
+
+	dsn := fmt.Sprintf("file:%s?mode=ro&immutable=1", path)
+	db, err := sql.Open("sqlite3", dsn)
+	if err != nil {
+		return result, fmt.Errorf("probe open: %w", err)
+	}
+	defer db.Close()
+
+	rows, err := db.Query(`SELECT host_key, encrypted_value FROM cookies WHERE LENGTH(encrypted_value) > 0 LIMIT ?`, maxRows)
+	if err != nil {
+		return result, fmt.Errorf("probe query cookies: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var host string
+		var enc []byte
+		if err := rows.Scan(&host, &enc); err != nil {
+			return result, fmt.Errorf("probe scan: %w", err)
+		}
+		plain, err := decryptValue(enc, key)
+		if err != nil {
+			return result, fmt.Errorf("probe decrypt %s: %w", host, err)
+		}
+		result.RowsChecked++
+		hostHash := sha256.Sum256([]byte(host))
+		if len(plain) >= sha256.Size && bytes.Equal([]byte(plain)[:sha256.Size], hostHash[:]) {
+			result.AppBoundLeaks++
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return result, fmt.Errorf("probe iterate: %w", err)
+	}
+
+	// meta.version is best-effort; an empty result means the meta table or
+	// row is missing, which surfaces in result.MetaVersion=="" rather than
+	// as an error. The caller's OK() check fails in that case anyway.
+	_ = db.QueryRow(`SELECT value FROM meta WHERE key='version'`).Scan(&result.MetaVersion)
+
+	return result, nil
+}

--- a/internal/chrome/probe_test.go
+++ b/internal/chrome/probe_test.go
@@ -1,0 +1,155 @@
+package chrome
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+)
+
+func TestProbeCookiesFile_HealthyV10Bridge(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "Cookies")
+	seedEmptyCookiesDB(t, path)
+
+	in := []Cookie{
+		{HostKey: ".instacart.com", Name: "session", Value: "real-session-token", Path: "/"},
+		{HostKey: ".github.com", Name: "user_session", Value: "github-token", Path: "/"},
+		{HostKey: ".claude.ai", Name: "csrf", Value: "csrf-value", Path: "/"},
+	}
+	if _, err := WriteCookies(path, in, testKey); err != nil {
+		t.Fatalf("WriteCookies: %v", err)
+	}
+
+	probe, err := ProbeCookiesFile(path, testKey, 3)
+	if err != nil {
+		t.Fatalf("ProbeCookiesFile: %v", err)
+	}
+	if !probe.OK() {
+		t.Errorf("expected probe.OK()=true, got %#v (summary=%q)", probe, probe.Summary())
+	}
+	if probe.RowsChecked != 3 {
+		t.Errorf("RowsChecked: got %d, want 3", probe.RowsChecked)
+	}
+	if probe.AppBoundLeaks != 0 {
+		t.Errorf("AppBoundLeaks: got %d, want 0", probe.AppBoundLeaks)
+	}
+	if probe.MetaVersion != "18" {
+		t.Errorf("MetaVersion: got %q, want 18", probe.MetaVersion)
+	}
+}
+
+func TestProbeCookiesFile_DetectsAppBoundPrefixRegression(t *testing.T) {
+	// Simulate the v0.8 (pre-v0.9) write path: encrypted_value carries the
+	// App-Bound SHA256(host_key) prefix in its plaintext. The probe must
+	// catch this because PP CLIs on kooky v0.2.2 would silently corrupt
+	// every cookie they read.
+	path := filepath.Join(t.TempDir(), "Cookies")
+	seedEmptyCookiesDB(t, path)
+
+	host := ".instacart.com"
+	value := "real-session-token"
+	withPrefix := prependAppBoundPrefix([]byte(value), host)
+	enc, err := encryptValueBytes(withPrefix, testKey)
+	if err != nil {
+		t.Fatalf("encryptValueBytes: %v", err)
+	}
+
+	db, _ := sql.Open("sqlite3", "file:"+path)
+	defer db.Close()
+	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS meta (key LONGVARCHAR NOT NULL UNIQUE PRIMARY KEY, value LONGVARCHAR)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO meta(key, value) VALUES ('version', '18')`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO cookies (creation_utc, host_key, top_frame_site_key, name, value, encrypted_value, path, expires_utc, is_secure, is_httponly, last_access_utc, has_expires, is_persistent, priority, samesite, source_scheme, source_port, last_update_utc, source_type, has_cross_site_ancestor) VALUES (0, ?, '', 'session', '', ?, '/', 0, 1, 0, 0, 0, 0, 1, 0, 2, 443, 0, 0, 1)`, host, enc); err != nil {
+		t.Fatal(err)
+	}
+
+	probe, err := ProbeCookiesFile(path, testKey, 3)
+	if err != nil {
+		t.Fatalf("ProbeCookiesFile: %v", err)
+	}
+	if probe.OK() {
+		t.Errorf("expected probe.OK()=false (App-Bound regression), got %#v", probe)
+	}
+	if probe.AppBoundLeaks != 1 {
+		t.Errorf("AppBoundLeaks: got %d, want 1", probe.AppBoundLeaks)
+	}
+	if probe.RowsChecked != 1 {
+		t.Errorf("RowsChecked: got %d, want 1", probe.RowsChecked)
+	}
+}
+
+func TestProbeCookiesFile_ReportsMissingMetaVersion(t *testing.T) {
+	// File has cookies but no meta table. probe.MetaVersion should be empty
+	// so the caller can distinguish "meta intentionally not set" from "we
+	// did write meta.version=18".
+	path := filepath.Join(t.TempDir(), "Cookies")
+	seedEmptyCookiesDB(t, path)
+
+	enc, _ := encryptValueBytes([]byte("v"), testKey)
+	db, _ := sql.Open("sqlite3", "file:"+path)
+	defer db.Close()
+	if _, err := db.Exec(`INSERT INTO cookies (creation_utc, host_key, top_frame_site_key, name, value, encrypted_value, path, expires_utc, is_secure, is_httponly, last_access_utc, has_expires, is_persistent, priority, samesite, source_scheme, source_port, last_update_utc, source_type, has_cross_site_ancestor) VALUES (0, '.a.com', '', 'n', '', ?, '/', 0, 0, 0, 0, 0, 0, 1, 0, 2, 443, 0, 0, 1)`, enc); err != nil {
+		t.Fatal(err)
+	}
+
+	probe, err := ProbeCookiesFile(path, testKey, 3)
+	if err != nil {
+		t.Fatalf("ProbeCookiesFile: %v", err)
+	}
+	if probe.MetaVersion != "" {
+		t.Errorf("MetaVersion with missing meta: got %q, want empty", probe.MetaVersion)
+	}
+	if probe.OK() {
+		t.Errorf("OK() with missing meta should be false")
+	}
+}
+
+func TestProbeCookiesFile_EmptyDBReturnsZeroRows(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "Cookies")
+	seedEmptyCookiesDB(t, path)
+	probe, err := ProbeCookiesFile(path, testKey, 3)
+	if err != nil {
+		t.Fatalf("ProbeCookiesFile: %v", err)
+	}
+	if probe.RowsChecked != 0 {
+		t.Errorf("RowsChecked on empty db: got %d, want 0", probe.RowsChecked)
+	}
+	if probe.OK() {
+		t.Errorf("OK() on empty db should be false")
+	}
+}
+
+func TestProbeCookiesFile_FileMissingReturnsError(t *testing.T) {
+	_, err := ProbeCookiesFile(filepath.Join(t.TempDir(), "does-not-exist"), testKey, 3)
+	if err == nil {
+		t.Error("expected error for missing file, got nil")
+	}
+}
+
+func TestProbeResult_SummaryShape(t *testing.T) {
+	ok := ProbeResult{RowsChecked: 5, AppBoundLeaks: 0, MetaVersion: "18"}
+	if got := ok.Summary(); got == "" {
+		t.Error("ok Summary empty")
+	}
+	bad := ProbeResult{RowsChecked: 5, AppBoundLeaks: 3, MetaVersion: "24"}
+	got := bad.Summary()
+	if got == "" {
+		t.Error("bad Summary empty")
+	}
+	// Should include the leak count and meta.version explicitly so a sink
+	// log line is actionable without rerunning the probe.
+	if !contains(got, "3") || !contains(got, "24") {
+		t.Errorf("bad Summary missing details: %q", got)
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/chrome/write.go
+++ b/internal/chrome/write.go
@@ -56,12 +56,14 @@ func WriteCookies(dbPath string, cookies []Cookie, key []byte) (int, error) {
 
 	written := 0
 	for _, c := range cookies {
-		// Chrome 127+ App-Bound Encryption: the decrypted plaintext Chrome
-		// expects is `SHA256(host_key) || actual_value`. Without the
-		// 32-byte prefix Chrome silently drops the cookie on next launch.
-		// stripAppBoundPrefix on read undoes this; prepend on write.
-		appBoundPlaintext := prependAppBoundPrefix([]byte(c.Value), c.HostKey)
-		encrypted, err := encryptValueBytes(appBoundPlaintext, key)
+		// Plain v10 mode (v0.9): no App-Bound SHA256(host_key) prefix.
+		// PP CLIs on the sink read via kooky v0.2.2, which does not strip
+		// the prefix; emitting it here corrupts every cookie they read.
+		// The companion writeMetaVersion call below pins meta.version=18 so
+		// future kooky v0.2.9+ readers also skip the 32-byte strip. When the
+		// deferred PP/kooky bump lands, flip both: re-enable
+		// prependAppBoundPrefix and drop the meta.version=18 write.
+		encrypted, err := encryptValueBytes([]byte(c.Value), key)
 		if err != nil {
 			return written, fmt.Errorf("encrypt %s/%s: %w", c.HostKey, c.Name, err)
 		}
@@ -77,10 +79,31 @@ func WriteCookies(dbPath string, cookies []Cookie, key []byte) (int, error) {
 		written++
 	}
 
+	if err := writeMetaVersion(tx, "18"); err != nil {
+		return written, err
+	}
+
 	if err := tx.Commit(); err != nil {
 		return written, fmt.Errorf("commit tx: %w", err)
 	}
 	return written, nil
+}
+
+// writeMetaVersion pins the cookies SQLite's meta.version to v. v0.9 writes
+// "18" (pre-App-Bound). kooky v0.2.9+ strips a 32-byte prefix from decrypted
+// AES-CBC plaintext when dbVersion >= 24 (Chrome 134+'s App-Bound migration).
+// Plain v10 cookies (no SHA256(host_key) prefix) would be corrupted by that
+// strip; pinning meta.version=18 keeps both v0.2.2 and v0.2.9+ readers
+// correct against the same file. Safe because Mac mini Chrome stays quit
+// during agent operation, so Chrome's own version migration never fires.
+func writeMetaVersion(tx *sql.Tx, v string) error {
+	if _, err := tx.Exec(`CREATE TABLE IF NOT EXISTS meta (key LONGVARCHAR NOT NULL UNIQUE PRIMARY KEY, value LONGVARCHAR)`); err != nil {
+		return fmt.Errorf("ensure meta table: %w", err)
+	}
+	if _, err := tx.Exec(`INSERT INTO meta(key, value) VALUES ('version', ?) ON CONFLICT(key) DO UPDATE SET value=excluded.value`, v); err != nil {
+		return fmt.Errorf("write meta.version=%s: %w", v, err)
+	}
+	return nil
 }
 
 func encryptValue(plaintext string, key []byte) ([]byte, error) {

--- a/internal/chrome/write_test.go
+++ b/internal/chrome/write_test.go
@@ -1,0 +1,200 @@
+package chrome
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"database/sql"
+	"path/filepath"
+	"testing"
+)
+
+// testKey is a fixed 16-byte AES key for write/read round-trip tests.
+// Real keys come from PBKDF2(SafeStoragePassword, "saltysalt", 1003, 16).
+var testKey = []byte("0123456789abcdef")
+
+// seedEmptyCookiesDB creates a Chrome-shaped Cookies SQLite at path with the
+// modern (Chrome 134+) cookies table and no rows. Returns the path. Used as a
+// fixture for WriteCookies tests; mirrors what Chrome creates on first launch.
+func seedEmptyCookiesDB(t *testing.T, path string) {
+	t.Helper()
+	db, err := sql.Open("sqlite3", "file:"+path)
+	if err != nil {
+		t.Fatalf("open seed db: %v", err)
+	}
+	defer db.Close()
+	if _, err := db.Exec(sidecarSchema); err != nil {
+		t.Fatalf("seed schema: %v", err)
+	}
+}
+
+func TestWriteCookies_PlainV10RoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "Cookies")
+	seedEmptyCookiesDB(t, path)
+
+	in := []Cookie{
+		{HostKey: ".instacart.com", Name: "_session", Value: "instacart-session-token", Path: "/", IsSecure: 1, IsPersistent: 1, HasExpires: 1, ExpiresUTC: 13380163200000000},
+		{HostKey: ".github.com", Name: "user_session", Value: "github-token-xyz", Path: "/", IsSecure: 1},
+	}
+	n, err := WriteCookies(path, in, testKey)
+	if err != nil {
+		t.Fatalf("WriteCookies: %v", err)
+	}
+	if n != len(in) {
+		t.Fatalf("wrote %d, want %d", n, len(in))
+	}
+
+	got, err := ReadCookiesForHost(path, "%instacart%", testKey)
+	if err != nil {
+		t.Fatalf("ReadCookiesForHost(instacart): %v", err)
+	}
+	if len(got) != 1 || got[0].Value != "instacart-session-token" {
+		t.Errorf("instacart cookie value: got %#v", got)
+	}
+
+	got2, err := ReadCookiesForHost(path, "%github.com", testKey)
+	if err != nil {
+		t.Fatalf("ReadCookiesForHost(github): %v", err)
+	}
+	if len(got2) != 1 || got2[0].Value != "github-token-xyz" {
+		t.Errorf("github cookie value: got %#v", got2)
+	}
+}
+
+func TestWriteCookies_NoAppBoundPrefixInPlaintext(t *testing.T) {
+	// The whole point of v0.9: decrypted plaintext is the raw cookie value,
+	// not SHA256(host_key) || value. PP CLIs on kooky v0.2.2 read this file
+	// without stripping the prefix; if we ship the prefix here, they get
+	// garbage.
+	path := filepath.Join(t.TempDir(), "Cookies")
+	seedEmptyCookiesDB(t, path)
+
+	host := ".instacart.com"
+	value := "session-token-payload"
+	if _, err := WriteCookies(path, []Cookie{{HostKey: host, Name: "n", Value: value, Path: "/"}}, testKey); err != nil {
+		t.Fatalf("WriteCookies: %v", err)
+	}
+
+	// Read the raw encrypted_value blob, decrypt without the App-Bound
+	// strip, and assert the result is exactly the value (not 32-bytes-of-
+	// SHA + value).
+	db, err := sql.Open("sqlite3", "file:"+path+"?mode=ro")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+	var enc []byte
+	if err := db.QueryRow(`SELECT encrypted_value FROM cookies WHERE host_key = ?`, host).Scan(&enc); err != nil {
+		t.Fatalf("scan encrypted: %v", err)
+	}
+	plain, err := decryptValue(enc, testKey)
+	if err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	if plain != value {
+		t.Errorf("plaintext: got %q, want %q (likely still carries App-Bound prefix)", plain, value)
+	}
+
+	// Stronger: assert SHA256(host) is not the first 32 bytes.
+	hostHash := sha256.Sum256([]byte(host))
+	if len(plain) >= sha256.Size && bytes.Equal([]byte(plain)[:sha256.Size], hostHash[:]) {
+		t.Errorf("decrypted plaintext starts with SHA256(host_key); App-Bound prefix is still being emitted")
+	}
+}
+
+func TestWriteCookies_EmptyValueRoundTrips(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "Cookies")
+	seedEmptyCookiesDB(t, path)
+
+	if _, err := WriteCookies(path, []Cookie{{HostKey: ".example.com", Name: "consent", Value: "", Path: "/"}}, testKey); err != nil {
+		t.Fatalf("WriteCookies: %v", err)
+	}
+	got, err := ReadCookiesForHost(path, "%example.com", testKey)
+	if err != nil {
+		t.Fatalf("ReadCookiesForHost: %v", err)
+	}
+	if len(got) != 1 || got[0].Value != "" {
+		t.Errorf("empty value round-trip: got %#v", got)
+	}
+}
+
+func TestWriteCookies_MetaVersion18Written(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "Cookies")
+	seedEmptyCookiesDB(t, path)
+
+	if _, err := WriteCookies(path, []Cookie{{HostKey: ".a.com", Name: "n", Value: "v", Path: "/"}}, testKey); err != nil {
+		t.Fatalf("WriteCookies: %v", err)
+	}
+
+	db, _ := sql.Open("sqlite3", "file:"+path+"?mode=ro")
+	defer db.Close()
+	var version string
+	if err := db.QueryRow(`SELECT value FROM meta WHERE key='version'`).Scan(&version); err != nil {
+		t.Fatalf("read meta.version: %v", err)
+	}
+	if version != "18" {
+		t.Errorf("meta.version: got %q, want 18", version)
+	}
+}
+
+func TestWriteCookies_MetaVersionOverwritesExisting(t *testing.T) {
+	// Simulate the realistic case: Chrome 134+ created the file with
+	// meta.version=24. agentcookie's write should pin it back to 18.
+	path := filepath.Join(t.TempDir(), "Cookies")
+	seedEmptyCookiesDB(t, path)
+
+	// Pre-seed meta with version=24 the way Chrome 134+ would.
+	db, _ := sql.Open("sqlite3", "file:"+path)
+	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS meta (key LONGVARCHAR NOT NULL UNIQUE PRIMARY KEY, value LONGVARCHAR)`); err != nil {
+		t.Fatalf("pre-seed meta table: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO meta(key, value) VALUES ('version', '24')`); err != nil {
+		t.Fatalf("pre-seed meta row: %v", err)
+	}
+	db.Close()
+
+	if _, err := WriteCookies(path, []Cookie{{HostKey: ".a.com", Name: "n", Value: "v", Path: "/"}}, testKey); err != nil {
+		t.Fatalf("WriteCookies: %v", err)
+	}
+
+	db2, _ := sql.Open("sqlite3", "file:"+path+"?mode=ro")
+	defer db2.Close()
+	var version string
+	if err := db2.QueryRow(`SELECT value FROM meta WHERE key='version'`).Scan(&version); err != nil {
+		t.Fatalf("read meta.version: %v", err)
+	}
+	if version != "18" {
+		t.Errorf("meta.version after overwrite: got %q, want 18", version)
+	}
+	var count int
+	if err := db2.QueryRow(`SELECT COUNT(*) FROM meta WHERE key='version'`).Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 meta.version row, got %d (UPSERT created a duplicate)", count)
+	}
+}
+
+func TestWriteCookies_MetaVersionIdempotent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "Cookies")
+	seedEmptyCookiesDB(t, path)
+
+	for i := 0; i < 3; i++ {
+		if _, err := WriteCookies(path, []Cookie{{HostKey: ".a.com", Name: "n", Value: "v", Path: "/"}}, testKey); err != nil {
+			t.Fatalf("WriteCookies pass %d: %v", i, err)
+		}
+	}
+
+	db, _ := sql.Open("sqlite3", "file:"+path+"?mode=ro")
+	defer db.Close()
+	var version string
+	var rowCount int
+	if err := db.QueryRow(`SELECT value FROM meta WHERE key='version'`).Scan(&version); err != nil {
+		t.Fatalf("read meta.version: %v", err)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM meta`).Scan(&rowCount); err != nil {
+		t.Fatalf("count meta rows: %v", err)
+	}
+	if version != "18" || rowCount != 1 {
+		t.Errorf("idempotency: version=%q (want 18) rowCount=%d (want 1)", version, rowCount)
+	}
+}

--- a/internal/chromectl/chromectl.go
+++ b/internal/chromectl/chromectl.go
@@ -185,6 +185,11 @@ func LaunchAndWait(ctx context.Context, timeout time.Duration) error {
 // quitTimeout and launchTimeout cap the two boundary phases.
 // fn runs with no time limit; the caller's context cancellation handles
 // abort.
+//
+// Use this on the source machine where Chrome is the user's interactive
+// browser and must come back up after writes. On the Mac mini sink, use
+// WithChromeDown -- Chrome must stay quit so its meta.version=24
+// migration does not rewrite the v0.9 plain-v10 cookies into v20.
 func WithChromeQuit(ctx context.Context, quitTimeout, launchTimeout time.Duration, fn func() error) error {
 	if err := QuitAndWait(ctx, quitTimeout); err != nil {
 		return err
@@ -198,4 +203,25 @@ func WithChromeQuit(ctx context.Context, quitTimeout, launchTimeout time.Duratio
 		return launchErr
 	}
 	return nil
+}
+
+// WithChromeDown quits Chrome, runs fn, and leaves Chrome quit. Used on
+// the Mac mini sink: Chrome must not run interactively because launching
+// it would trigger the version-24 schema migration that rewrites the
+// v0.9 plain-v10 cookies into App-Bound v20, breaking every kooky v0.2.2
+// reader on the box.
+//
+// If Chrome was already running when this is called, it gets quit. The
+// caller has no way to know whether to re-launch later; the sink-mini
+// premise is that Chrome stays down. If a user manually launches Chrome
+// on the sink after this returns, they will silently break the bridge
+// until the next sync.
+//
+// fn runs with no time limit; the caller's context cancellation handles
+// abort.
+func WithChromeDown(ctx context.Context, quitTimeout time.Duration, fn func() error) error {
+	if err := QuitAndWait(ctx, quitTimeout); err != nil {
+		return err
+	}
+	return fn()
 }

--- a/internal/chromectl/chromectl_test.go
+++ b/internal/chromectl/chromectl_test.go
@@ -67,3 +67,55 @@ func TestLaunchAndWait_NoOpWhenRunning(t *testing.T) {
 		t.Errorf("expected nil when Chrome already running, got %v", err)
 	}
 }
+
+// TestWithChromeDown_RunsFnAndDoesNotRelaunch verifies WithChromeDown
+// runs fn and, crucially, never calls LaunchAndWait. Runs only when
+// Chrome is not currently running so the test does not disturb the
+// developer's session.
+func TestWithChromeDown_RunsFnAndDoesNotRelaunch(t *testing.T) {
+	running, err := IsRunning()
+	if err != nil {
+		t.Skipf("IsRunning errored: %v", err)
+	}
+	if running {
+		t.Skip("Chrome is running on this machine; test would disturb it")
+	}
+	called := false
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := WithChromeDown(ctx, 500*time.Millisecond, func() error {
+		called = true
+		return nil
+	}); err != nil {
+		t.Errorf("WithChromeDown returned error: %v", err)
+	}
+	if !called {
+		t.Error("fn was not invoked")
+	}
+	// Confirm WithChromeDown did NOT launch Chrome behind our back.
+	stillNotRunning, _ := IsRunning()
+	if stillNotRunning {
+		t.Error("WithChromeDown launched Chrome; it must leave Chrome quit")
+	}
+}
+
+// TestWithChromeDown_PropagatesFnError ensures fn errors surface as the
+// returned error and are not swallowed.
+func TestWithChromeDown_PropagatesFnError(t *testing.T) {
+	running, err := IsRunning()
+	if err != nil {
+		t.Skipf("IsRunning errored: %v", err)
+	}
+	if running {
+		t.Skip("Chrome is running on this machine; test would disturb it")
+	}
+	want := errors.New("fn boom")
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	got := WithChromeDown(ctx, 500*time.Millisecond, func() error {
+		return want
+	})
+	if !errors.Is(got, want) {
+		t.Errorf("expected fn error to propagate, got %v", got)
+	}
+}

--- a/internal/cli/sink.go
+++ b/internal/cli/sink.go
@@ -218,6 +218,15 @@ func applyEnvelopeToSink(
 			if rowCount, qerr := chrome.SqliteRowCount(cfg.Chrome.DBPath, "cookies"); qerr == nil {
 				fmt.Fprintf(os.Stderr, "agentcookie sink: post-commit verify: %d rows in cookies table (just wrote %d)\n", rowCount, n)
 			}
+			// v0.9 probe: decrypt a few rows the way kooky v0.2.2 would and
+			// confirm no App-Bound prefix leakage + meta.version=18 pin.
+			// Fails loud in sink stderr so a regression is visible before
+			// any agent run hits broken cookies.
+			if probe, perr := chrome.ProbeCookiesFile(cfg.Chrome.DBPath, key, 3); perr != nil {
+				fmt.Fprintf(os.Stderr, "agentcookie sink: %s (error: %v)\n", "probe error", perr)
+			} else {
+				fmt.Fprintf(os.Stderr, "agentcookie sink: %s\n", probe.Summary())
+			}
 			// v0.8 bridge: also write a plaintext-value sidecar at
 			// ~/.agentcookie/cookies-plain.db. PP CLIs reading this path
 			// get cookies without Keychain prompts and without kooky's

--- a/internal/cli/sink.go
+++ b/internal/cli/sink.go
@@ -208,7 +208,11 @@ func applyEnvelopeToSink(
 	key []byte,
 ) (writeResult, error) {
 	var result writeResult
-	err := chromectl.WithChromeQuit(ctx, 20*time.Second, 30*time.Second, func() error {
+	// v0.9: WithChromeDown (not WithChromeQuit) -- on the Mac mini sink
+	// Chrome stays quit. Launching Chrome would trigger the meta.version
+	// migration from 18 to 24 and rewrite cookies into App-Bound v20,
+	// breaking every kooky v0.2.2 reader. See plan 2026-05-17-003 U5.
+	err := chromectl.WithChromeDown(ctx, 20*time.Second, func() error {
 		if len(cookies) > 0 {
 			n, err := chrome.WriteCookies(cfg.Chrome.DBPath, cookies, key)
 			result.Cookies = n

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -285,15 +285,25 @@ func wizardInstallSink(ctx context.Context, binPath, logDir string) error {
 	return nil
 }
 
-// printBridgeHint tells the operator how PP CLIs use the v0.8 sidecar
-// cookies bridge. Sidecar lives at ~/.agentcookie/cookies-plain.db
-// (plaintext, mode 0600). PP CLIs read it via the AGENTCOOKIE_PLAIN_COOKIES
-// env var or by importing the cookiesource Go module.
+// printBridgeHint tells the operator how PP CLIs use the cookie bridge.
+// v0.9 ships two paths:
+//
+//   1. Primary: Mac mini's actual Chrome Cookies file is written in plain
+//      v10 mode (no App-Bound prefix) with meta.version=18. Any kooky
+//      v0.2.2 caller reads it via the macOS Keychain Safe Storage key.
+//      No env var, no cookiesource integration required.
+//   2. Backstop: ~/.agentcookie/cookies-plain.db sidecar (mode 0600,
+//      plaintext values, empty encrypted_value). cookiesource-aware
+//      callers honor AGENTCOOKIE_PLAIN_COOKIES.
+//
+// Precondition for path 1: Mac mini Chrome stays quit. The wizard says so;
+// the user keeps it that way.
 func printBridgeHint() {
-	fmt.Fprintln(os.Stderr, "agentcookie wizard: PP CLIs and headless agents can use the cookie bridge:")
-	fmt.Fprintln(os.Stderr, "  echo 'export AGENTCOOKIE_PLAIN_COOKIES=~/.agentcookie/cookies-plain.db' >> ~/.zshenv")
-	fmt.Fprintln(os.Stderr, "  # Existing PP CLI: one-line patch to read from the env var via the cookiesource Go module")
-	fmt.Fprintln(os.Stderr, "  # See README 'Using cookies with PP CLIs' for the import snippet")
+	fmt.Fprintln(os.Stderr, "agentcookie wizard: PP CLIs and headless agents read cookies two ways on this sink:")
+	fmt.Fprintln(os.Stderr, "  1. Direct: any kooky v0.2.2 caller reads Mac mini's Chrome Cookies file (v0.9 plain-v10 mode).")
+	fmt.Fprintln(os.Stderr, "     Keep Chrome QUIT on this machine: launching it migrates meta.version and breaks the bridge.")
+	fmt.Fprintln(os.Stderr, "  2. Sidecar: cookiesource-aware callers honor:")
+	fmt.Fprintln(os.Stderr, "       export AGENTCOOKIE_PLAIN_COOKIES=~/.agentcookie/cookies-plain.db")
 }
 
 // printExitNodeHint inspects Tailscale state and emits sudo command lines

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -35,6 +35,7 @@ var (
 	wizardSkipDaemon         bool
 	wizardSkipExitNode       bool
 	wizardSkipKeychainPrompt bool
+	wizardSkipPartitionList  bool
 	wizardSkipBridgeHint     bool
 )
 
@@ -91,6 +92,7 @@ func init() {
 	wizardInstallCmd.Flags().BoolVar(&wizardSkipDaemon, "skip-daemon", false, "skip installing the LaunchAgent (configs + pairing only)")
 	wizardInstallCmd.Flags().BoolVar(&wizardSkipExitNode, "skip-exit-node-hint", false, "do not detect Tailscale or print the sudo commands that route the sink's outbound traffic through the source machine")
 	wizardInstallCmd.Flags().BoolVar(&wizardSkipKeychainPrompt, "skip-keychain-prompt", false, "[sink] do not trigger the Chrome Safe Storage Keychain prompt during install; the sink daemon will prompt on first sync instead")
+	wizardInstallCmd.Flags().BoolVar(&wizardSkipPartitionList, "skip-partition-list", false, "[sink] do not expand the Chrome Safe Storage Keychain partition list; PP CLIs using Apple-tool callers may then prompt on first read")
 	wizardInstallCmd.Flags().BoolVar(&wizardSkipBridgeHint, "skip-bridge-hint", false, "[sink] do not print the cookie-bridge env-var integration hint at install end")
 
 	wizardUninstallCmd.Flags().StringVar(&wizardRole, "as", "", "source | sink (required)")
@@ -243,6 +245,21 @@ func wizardInstallSink(ctx context.Context, binPath, logDir string) error {
 			return fmt.Errorf("Keychain access: %w (re-run after granting Always Allow, or pass --skip-keychain-prompt)", err)
 		}
 		fmt.Fprintln(os.Stderr, "agentcookie wizard: Keychain access granted; sink daemon can run unattended")
+	}
+
+	// v0.9: expand the Chrome Safe Storage partition list so Apple-tool
+	// callers (e.g., the `security` CLI used by various PP-CLI side scripts)
+	// can read the password without a GUI prompt. macOS prompts once for
+	// the user's login keychain password to authorize the change. Ad-hoc-
+	// signed Go binaries (most PP CLIs) still need their own one-time
+	// Always Allow click on first read; the partition list is groundwork,
+	// not a blanket grant. See plan 2026-05-17-003.
+	if !wizardSkipPartitionList {
+		fmt.Fprintln(os.Stderr, "agentcookie wizard: expanding Chrome Safe Storage partition list (you may be prompted for your login keychain password)")
+		if err := chrome.SetSafeStoragePartitionList(""); err != nil {
+			return fmt.Errorf("partition list grant: %w (re-run after granting, or pass --skip-partition-list)", err)
+		}
+		fmt.Fprintln(os.Stderr, "agentcookie wizard: partition list granted (Apple-tool callers can now read Safe Storage silently)")
 	}
 
 	if !wizardSkipDaemon {


### PR DESCRIPTION
## Summary

Soup-to-nuts agentcookie: PP CLIs and any other kooky v0.2.2 caller on the Mac mini read Chrome cookies directly without paste-from-laptop ceremony.

- **U1+U2**: sink emits cookies as plain v10 (no App-Bound 32-byte plaintext prefix) and pins `meta.version=18` in the Cookies SQLite. Both kooky v0.2.2 and a future kooky v0.2.9+ read this file correctly because the 32-byte strip is gated on `dbVersion >= 24`.
- **U3**: install wizard expands the Chrome Safe Storage Keychain partition list so Apple-tool callers read silently. Ad-hoc-signed Go binaries still need a one-time Always Allow click; this is groundwork.
- **U4**: post-write probe decrypts a few cookies the kooky-v0.2.2 way and logs `probe ok` / `probe FAIL` in sink stderr so regressions surface immediately.
- **U5**: sink switches from `chromectl.WithChromeQuit` to `chromectl.WithChromeDown`. Mac mini Chrome stays quit; launching it would migrate meta.version to 24 and rewrite cookies as App-Bound v20, silently breaking every kooky v0.2.2 reader.
- **U6+U7**: end-to-end runbook (`docs/runbook-v0.9-soup-to-nuts.md`), CHANGELOG entry, README update, refreshed wizard bridge hint.

Plan: `docs/plans/2026-05-17-003-feat-agentcookie-v10-mode-soup-to-nuts-plan.md`. Supersedes the deferred kooky-fork plan at `docs/plans/2026-05-17-002-feat-kooky-fork-app-bound-bridge-plan.md`.

Deferred (post-100%-working polish): bump kooky from v0.2.2 to v0.2.9+ across PP CLIs and the printing-press meta-library. When that lands, flip agentcookie back to v20 (App-Bound) mode.

## Test plan

- [ ] On Mac mini: re-run `agentcookie wizard install --as sink ...`. Look for `partition list granted`.
- [ ] On MBP: `agentcookie source --once`. Mac mini sink stderr shows `probe ok: N cookies round-tripped, meta.version=18`.
- [ ] `sqlite3 ~/Library/Application\ Support/Google/Chrome/Default/Cookies "SELECT value FROM meta WHERE key='version'"` returns `18` on Mac mini.
- [ ] `pgrep -x 'Google Chrome'` on Mac mini returns empty after the sink write.
- [ ] `ssh mac-mini 'instacart doctor'` returns `[ok] api: logged in as <Matt>` with zero manual paste in the session.
- [ ] Try a third-party kooky CLI on Mac mini (bird from last30days) and confirm same behavior.

If any step fails, capture the diagnostic per the runbook's "What to capture" section.