### PR TITLE
feat(v0.10): one-time keychain access for headless kooky CLIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,53 @@
 
 ## [Unreleased]
 
+### v0.10: one-time keychain access for headless kooky CLIs
+
+The remaining gap after v0.9: kooky-using CLIs (instacart-pp-cli, bird,
+future PP CLIs) hit a macOS Keychain prompt the first time each binary
+tried to read Chrome Safe Storage. v0.10 closes the gap with a single
+wizard step at sink install time.
+
+`agentcookie wizard install --as sink` now auto-runs
+`set-keychain-access`, which spawns a one-shot LaunchAgent in the
+user's GUI session and iterates strategies to broaden Chrome Safe
+Storage access. The primary strategy is `delete-and-recreate-with-A`:
+remove the existing keychain item, recreate with `security
+add-generic-password -A` and a fresh random password. On a fresh
+install this works without a login keychain password prompt because
+`SecKeychainAddGenericPassword` on a new item honors `-A` at creation
+time. Each strategy is validated via the same Apple Security framework
+API path kooky-CGO uses (`github.com/keybase/go-keychain.GetGenericPassword`,
+exposed as `agentcookie internal keychain-probe`).
+
+For sinks where the keychain item already exists with a restrictive
+ACL from a prior Chrome run or earlier agentcookie install, the
+strategy may fail; the install does not abort, prints a loud warning,
+and points at `docs/runbook-v0.10-keychain-access.md`. The runbook
+documents a one-time GUI fallback (open Keychain Access, click
+"Allow all applications to access this item" on the Chrome Safe Storage
+row, type your login password once) that clears the prior ACL state so
+a wizard re-run succeeds.
+
+`chrome.SafeStoragePassword` now tries the keybase/go-keychain CGO path
+first and falls back to shelling out to the `security` CLI. The keybase
+path is more reliable from LaunchAgent contexts where the legacy
+`security` CLI sometimes returns exit 44 with empty stdout despite the
+underlying keychain being readable.
+
+Validated live on a Mac mini: after one-time setup,
+`ssh matts-mac-mini 'instacart-pp-cli auth login'` returns
+`imported N cookies from Chrome` and exit 0 with no GUI prompt;
+`instacart-pp-cli doctor` reports `[ok] session: N cookies from chrome`
+(not "from paste") and `[ok] api: logged in as`. End-to-end runbook
+at `docs/runbook-v0.10-keychain-access.md`.
+
+Security trade-off: Chrome Safe Storage is now any-app-readable on
+sink machines. The practical threat model already assumes a sink-side
+process compromise means lost cookies (the plaintext sidecar at
+`~/.agentcookie/cookies-plain.db` is there too). Pass
+`--skip-keychain-access` to the wizard to opt out of the broader ACL.
+
 ### v0.9: plain v10 sink writes for headless kooky readers
 
 agentcookie's sink-side write now emits Chrome cookies in plain v10

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Pre-release. v0.1 in active development. Watch the repo for the launch announcem
 - Pairing handshake: X25519 + HKDF-SHA256 salted with a one-time code. Derived 32-byte keys land at `~/.config/agentcookie/keys/<peer>.json` mode 0600.
 - Cookie acquisition on macOS: read Chrome cookies SQLite read-only with `immutable=1`, decrypt v10 ciphertext using the Keychain Safe Storage key.
 - Cookie write (v0.9): plain v10 mode + `meta.version=18` pin so any kooky v0.2.2 caller on the Mac mini sink reads cookies directly without paste-from-laptop ceremony. Schema-aware INSERT ... ON CONFLICT adapts to Chrome's evolving column set (`top_frame_site_key`, `source_type`, `has_cross_site_ancestor`). Sink stays Chrome-quit so the version migration never fires.
+- Keychain access (v0.10): one-time wizard step broadens Chrome Safe Storage ACL via `add-generic-password -A` inside a one-shot LaunchAgent, so every kooky-using CLI on the sink (instacart-pp-cli, bird, future PP CLIs) reads silently from SSH or LaunchAgent context. No per-binary Always-Allow clicks.
 - Live-Chrome injection: sink probes Chrome's DevTools port and uses `Storage.setCookies` for instant in-memory visibility. Falls back to SQLite write if Chrome isn't debuggable.
 - Wire protocol v1: versioned `SyncEnvelope` with monotonic Sequence (replay defense), source hostname, cookies. Documented in `docs/protocol.md`.
 - Sink-side allowlist enforcement: defense in depth even if the source is compromised.

--- a/docs/runbook-v0.10-keychain-access.md
+++ b/docs/runbook-v0.10-keychain-access.md
@@ -1,0 +1,156 @@
+# Runbook: v0.10 Chrome Safe Storage keychain access on Mac mini
+
+Goal of v0.10: any kooky-using CLI on the sink (instacart-pp-cli, bird,
+future PP CLIs) reads Chrome cookies headlessly from SSH or LaunchAgent
+context, with no per-binary Always-Allow click and no manual paste.
+
+This runbook covers what the wizard does automatically, what it cannot
+do on macOS, and the one-time GUI fallback for when programmatic
+mechanism does not succeed.
+
+## What `agentcookie wizard install --as sink` does for keychain access
+
+After the standard pair / config / LaunchAgent steps, the sink install
+auto-runs `set-keychain-access`, which spawns a one-shot LaunchAgent in
+the user's GUI session and iterates strategies, validating each via the
+same Apple Security framework call path kooky-CGO uses:
+
+1. **delete-and-recreate-with-A** (primary; works on fresh installs).
+   Best-effort delete of the existing Chrome Safe Storage item, then
+   `security add-generic-password -A` with a random password. The `-A`
+   flag means "any application may access this item without warning."
+   When the item is freshly created, this does not require the login
+   keychain password.
+
+2. **partition-list:apple-tool,apple** (fallback). Tries to broaden the
+   item's partition list. On macOS 15+ this typically requires the
+   login keychain password and will fail from a LaunchAgent context.
+
+3. **trust-list:&lt;binary&gt;** (fallback per `--extra-binary`).
+   Updates the existing item with `-T &lt;binary path&gt;` to add the
+   specific binary to the per-binary trust list. Requires reading the
+   existing password first, which works from LaunchAgent context when
+   the keychain is unlocked.
+
+The wizard reports which strategy won:
+
+```
+agentcookie wizard: keychain access: delete-and-recreate-with-A
+```
+
+If all strategies fail, the install does not abort. It prints a loud
+warning and points at this runbook.
+
+## When the wizard succeeds
+
+After the wizard prints `keychain access: <strategy>`, every kooky-using
+CLI on the sink reads Chrome cookies silently. Validate:
+
+```
+ssh matts-mac-mini '/Users/mvanhorn/go/bin/instacart-pp-cli auth login'
+```
+
+Expected: `imported N cookies from Chrome`, exit 0, no GUI prompt fires
+on the Mac mini desktop during the run.
+
+Then:
+
+```
+ssh matts-mac-mini '/Users/mvanhorn/go/bin/instacart-pp-cli doctor'
+```
+
+Expected:
+
+```
+  [ok ] session: N cookies from chrome
+  [ok ] api: logged in as <Matt>
+```
+
+Note `from chrome`, not `from paste`. That confirms the cookies came
+through kooky reading Chrome's Cookies file, not from a stale
+`auth paste` session cache.
+
+## When the wizard fails (one-time GUI fallback)
+
+If the wizard prints `keychain access: FAILED` (typically because the
+Chrome Safe Storage item already exists with a restrictive ACL from a
+prior install or from Chrome itself running), do this one GUI step at
+the Mac mini desktop (Screen Sharing works):
+
+1. Open **Keychain Access.app**.
+2. In the search bar, type `Chrome Safe Storage`.
+3. Double-click the row. The info window opens.
+4. Click the **Access Control** tab.
+5. Select the **Allow all applications to access this item** radio
+   button (the top option).
+6. Click **Save Changes**.
+7. macOS prompts for your login keychain password. Type it once.
+
+The change is durable. After this:
+
+```
+ssh matts-mac-mini '/Users/mvanhorn/bin/agentcookie internal keychain-probe'
+```
+
+should print `ok len=N` (where N is the password byte length; the
+password itself is never printed).
+
+If `ok len=0`, the keychain item exists but the password is empty.
+Re-run the wizard:
+
+```
+ssh matts-mac-mini '/Users/mvanhorn/bin/agentcookie wizard set-keychain-access'
+```
+
+The wizard's `delete-and-recreate-with-A` strategy can now succeed
+because the GUI click cleared the prior ACL restrictions, leaving a
+clean slate for the recreate.
+
+## Verification checklist
+
+After install (or after the GUI fallback) the sink should pass:
+
+- [ ] `pgrep -f "agentcookie sink"` returns the sink PID
+- [ ] `tail -5 ~/.agentcookie/logs/sink.err.log` shows recent
+      `probe ok: N cookies round-tripped, meta.version=18`
+- [ ] `agentcookie internal keychain-probe` over SSH prints
+      `ok len=N` (N &gt; 0)
+- [ ] `instacart-pp-cli auth login` over SSH prints
+      `imported N cookies from Chrome` and exits 0
+- [ ] `instacart-pp-cli doctor` over SSH prints
+      `[ok] session: N cookies from chrome` (not "from paste")
+- [ ] `instacart-pp-cli doctor` over SSH prints
+      `[ok] api: logged in as`
+
+## What we cannot bypass
+
+`security set-generic-password-partition-list` and
+`security add-generic-password -U -A` (update an existing item to set
+`-A`) both call `SecKeychainItemSetAccessWithPassword` under the hood,
+which requires the user's login keychain password. macOS protects this
+operation deliberately because broadening keychain access is a
+security-sensitive change. There is no headless bypass for modifying
+an existing item's ACL. The wizard's `delete-and-recreate-with-A`
+strategy side-steps this by deleting first and creating a fresh item;
+this works because `SecKeychainAddGenericPassword` on a new item
+respects the `-A` flag at creation time without a password prompt
+(provided the login keychain is unlocked, which it is inside a
+LaunchAgent).
+
+## Security trade-off
+
+After v0.10, Chrome Safe Storage is readable by any process on the
+user's account. This is broader than Chrome's default (apps in the
+Apple-signed partition only). For an agentcookie sink running headless
+on a Mac mini, the practical threat model already assumes:
+
+- The machine itself is a security boundary
+- Any process running as the user can already exfiltrate cookies
+  via the `~/.agentcookie/cookies-plain.db` sidecar (plaintext,
+  mode 0600)
+- The bridge's value depends on multiple processes being able to read
+  the cookies
+
+If you do not want this trade-off, pass `--skip-keychain-access` to
+the wizard. Kooky-using CLIs on this sink will then prompt for
+Always-Allow on first run, per binary.

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/keybase/go-keychain v0.0.1 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx5
 github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/keybase/go-keychain v0.0.1 h1:way+bWYa6lDppZoZcgMbYsvC7GxljxrskdNInRtuthU=
+github.com/keybase/go-keychain v0.0.1/go.mod h1:PdEILRW3i9D8JcdM+FmY6RwkHGnhHxXwkPPMeUgOK1k=
 github.com/mattn/go-sqlite3 v1.14.44 h1:3VSe+xafpbzsLbdr2AWlAZk9yRHiBhTBakioXaCKTF8=
 github.com/mattn/go-sqlite3 v1.14.44/go.mod h1:pjEuOr8IwzLJP2MfGeTb0A35jauH+C2kbHKBr7yXKVQ=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/internal/chrome/keychain.go
+++ b/internal/chrome/keychain.go
@@ -20,9 +20,22 @@ const (
 )
 
 // SafeStoragePassword returns the Chrome Safe Storage password from the macOS
-// Keychain. The first call from a new binary prompts the user for Keychain
-// access; subsequent calls succeed silently once the user clicks "Always Allow".
+// Keychain. On darwin+CGO builds, tries the keybase/go-keychain API path
+// first (SecItemCopyMatching), then falls back to shelling out to the
+// `security` CLI. The keybase path is more reliable from LaunchAgent
+// contexts where the legacy `security` CLI sometimes returns empty output
+// or non-zero exits despite the underlying keychain being readable.
+//
+// Either path requires the binary to be in the Keychain item's ACL OR the
+// item to be marked any-app-accessible OR running in a context where the
+// login keychain is auto-unlocked (LaunchAgents in the user GUI session).
+// Plan 2026-05-17-004's wizard set-keychain-access step is what makes that
+// last condition true for new binaries.
 func SafeStoragePassword() (string, error) {
+	if pw, err := safeStoragePasswordViaKeybase(); err == nil {
+		return pw, nil
+	}
+	// Fall back to `security` CLI shell-out.
 	cmd := exec.Command("security",
 		"find-generic-password",
 		"-a", keychainAccount,

--- a/internal/chrome/keychain_keybase.go
+++ b/internal/chrome/keychain_keybase.go
@@ -1,0 +1,22 @@
+//go:build darwin && cgo
+
+package chrome
+
+import (
+	keychain "github.com/keybase/go-keychain"
+)
+
+// safeStoragePasswordViaKeybase is the darwin+CGO fast path for reading
+// Chrome Safe Storage. Calls the same Apple Security framework function
+// kooky-CGO uses (via the keybase wrapper) instead of shelling out to
+// `security`. The motivating observation: from a LaunchAgent context, the
+// keybase path returns the password reliably while the `security` CLI
+// occasionally returns exit 44 with empty stdout despite the underlying
+// Keychain item being readable.
+func safeStoragePasswordViaKeybase() (string, error) {
+	password, err := keychain.GetGenericPassword(keychainService, keychainAccount, "", "")
+	if err != nil {
+		return "", err
+	}
+	return string(password), nil
+}

--- a/internal/chrome/keychain_keybase_stub.go
+++ b/internal/chrome/keychain_keybase_stub.go
@@ -1,0 +1,9 @@
+//go:build !darwin || !cgo
+
+package chrome
+
+import "errors"
+
+func safeStoragePasswordViaKeybase() (string, error) {
+	return "", errors.New("safeStoragePasswordViaKeybase: requires darwin+cgo build")
+}

--- a/internal/chrome/launchagent_helper.go
+++ b/internal/chrome/launchagent_helper.go
@@ -1,0 +1,206 @@
+package chrome
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// LaunchAgentResult is the captured outcome of a one-shot LaunchAgent run.
+// stdout/stderr come from the plist's StandardOutPath / StandardErrorPath.
+// exit is the agent's last exit code (negative when launchctl could not
+// determine it, e.g., the agent never ran).
+type LaunchAgentResult struct {
+	Stdout string
+	Stderr string
+	Exit   int
+}
+
+// RunOneShotLaunchAgent writes a temporary plist that runs argv as a
+// one-shot LaunchAgent in the user's GUI session, waits for it to exit
+// (capped by timeout), captures stdout/stderr/exit-code, then removes
+// the plist.
+//
+// The point of this helper is to do Keychain mutations from a context
+// where the login keychain is auto-unlocked. SSH sessions have it
+// locked; the user's GUI session (where LaunchAgents run) does not.
+// Operations like security set-generic-password-partition-list and
+// security add-generic-password -A succeed silently from here, where
+// they fail from SSH.
+//
+// argv[0] must be an absolute path. argv[1:] are passed as-is.
+// Returns an error only for orchestration failures (write plist,
+// bootstrap, bootout). A non-zero agent exit code is NOT an
+// orchestration failure -- it lands in result.Exit.
+func RunOneShotLaunchAgent(argv []string, timeout time.Duration) (LaunchAgentResult, error) {
+	if len(argv) == 0 {
+		return LaunchAgentResult{}, fmt.Errorf("RunOneShotLaunchAgent: empty argv")
+	}
+
+	label, err := randomLabel("dev.agentcookie.oneshot")
+	if err != nil {
+		return LaunchAgentResult{}, fmt.Errorf("generate label: %w", err)
+	}
+
+	home, _ := os.UserHomeDir()
+	plistPath := filepath.Join(home, "Library", "LaunchAgents", label+".plist")
+	stdoutPath := filepath.Join(os.TempDir(), label+".stdout")
+	stderrPath := filepath.Join(os.TempDir(), label+".stderr")
+
+	defer func() {
+		// Cleanup, best-effort. The bootout above SHOULD have removed the
+		// agent already; this just makes sure we don't leak a plist file
+		// or an active label on the off-chance bootout failed.
+		_ = exec.Command("/bin/launchctl", "bootout", launchctlTarget(label)).Run()
+		_ = os.Remove(plistPath)
+		_ = os.Remove(stdoutPath)
+		_ = os.Remove(stderrPath)
+	}()
+
+	plistContent := renderOneShotPlist(label, argv, stdoutPath, stderrPath)
+	if err := os.WriteFile(plistPath, []byte(plistContent), 0o644); err != nil {
+		return LaunchAgentResult{}, fmt.Errorf("write plist: %w", err)
+	}
+
+	if out, err := exec.Command("/bin/launchctl", "bootstrap", launchctlDomain(), plistPath).CombinedOutput(); err != nil {
+		return LaunchAgentResult{}, fmt.Errorf("launchctl bootstrap: %w (%s)", err, strings.TrimSpace(string(out)))
+	}
+
+	// Poll for completion. launchctl print's "state = not running" + a
+	// numeric exit code means the one-shot finished. We cap by timeout
+	// to surface hangs (e.g., SecurityAgent prompt waiting on a click).
+	deadline := time.Now().Add(timeout)
+	pollInterval := 200 * time.Millisecond
+	for time.Now().Before(deadline) {
+		state, exit, ok := agentStateAndExit(label)
+		if ok && state == "not running" {
+			return LaunchAgentResult{
+				Stdout: readFileTrim(stdoutPath),
+				Stderr: readFileTrim(stderrPath),
+				Exit:   exit,
+			}, nil
+		}
+		time.Sleep(pollInterval)
+	}
+
+	// Timeout reached. Return what we have plus a synthetic "still running"
+	// exit code so callers can distinguish "agent timed out" from "agent
+	// exited with code 0 silently". The deferred bootout will kill it.
+	return LaunchAgentResult{
+		Stdout: readFileTrim(stdoutPath),
+		Stderr: readFileTrim(stderrPath),
+		Exit:   -1,
+	}, fmt.Errorf("RunOneShotLaunchAgent: agent %q did not exit within %s (likely hung on a Keychain prompt)", label, timeout)
+}
+
+func renderOneShotPlist(label string, argv []string, stdoutPath, stderrPath string) string {
+	var b strings.Builder
+	b.WriteString(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>`)
+	b.WriteString(plistEscape(label))
+	b.WriteString(`</string>
+  <key>ProgramArguments</key>
+  <array>
+`)
+	for _, a := range argv {
+		b.WriteString("    <string>")
+		b.WriteString(plistEscape(a))
+		b.WriteString("</string>\n")
+	}
+	b.WriteString(`  </array>
+  <key>RunAtLoad</key><true/>
+  <key>StandardOutPath</key><string>`)
+	b.WriteString(plistEscape(stdoutPath))
+	b.WriteString(`</string>
+  <key>StandardErrorPath</key><string>`)
+	b.WriteString(plistEscape(stderrPath))
+	b.WriteString(`</string>
+</dict>
+</plist>
+`)
+	return b.String()
+}
+
+// plistEscape escapes the four XML entities. plist values are XML, so
+// the same rules apply. Done in code to avoid pulling in a dep.
+func plistEscape(s string) string {
+	r := strings.NewReplacer(
+		"&", "&amp;",
+		"<", "&lt;",
+		">", "&gt;",
+		"\"", "&quot;",
+		"'", "&apos;",
+	)
+	return r.Replace(s)
+}
+
+func randomLabel(prefix string) (string, error) {
+	buf := make([]byte, 4)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return prefix + "." + hex.EncodeToString(buf), nil
+}
+
+func launchctlDomain() string {
+	return "gui/" + strconv.Itoa(os.Getuid())
+}
+
+func launchctlTarget(label string) string {
+	return launchctlDomain() + "/" + label
+}
+
+// agentStateAndExit parses `launchctl print <target>` for state and last
+// exit code. Returns (state, exit, true) on success; (_, _, false) if
+// the agent label is not loaded.
+func agentStateAndExit(label string) (string, int, bool) {
+	out, err := exec.Command("/bin/launchctl", "print", launchctlTarget(label)).CombinedOutput()
+	if err != nil {
+		// launchctl print returns non-zero when the label isn't loaded.
+		return "", 0, false
+	}
+	text := string(out)
+	state := scanField(text, "state =")
+	exitStr := scanField(text, "last exit code =")
+	if state == "" {
+		return "", 0, false
+	}
+	if exitStr == "" || exitStr == "(never exited)" {
+		return state, 0, true
+	}
+	exit, err := strconv.Atoi(exitStr)
+	if err != nil {
+		return state, 0, true
+	}
+	return state, exit, true
+}
+
+func scanField(text, key string) string {
+	idx := strings.Index(text, key)
+	if idx < 0 {
+		return ""
+	}
+	tail := text[idx+len(key):]
+	end := strings.IndexByte(tail, '\n')
+	if end < 0 {
+		end = len(tail)
+	}
+	return strings.TrimSpace(tail[:end])
+}
+
+func readFileTrim(path string) string {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimRight(string(b), "\n")
+}

--- a/internal/chrome/launchagent_helper_test.go
+++ b/internal/chrome/launchagent_helper_test.go
@@ -1,0 +1,88 @@
+package chrome
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPlistEscape_AllFiveXMLEntities(t *testing.T) {
+	in := `a&b<c>d"e'f`
+	got := plistEscape(in)
+	want := `a&amp;b&lt;c&gt;d&quot;e&apos;f`
+	if got != want {
+		t.Errorf("plistEscape: got %q, want %q", got, want)
+	}
+}
+
+func TestPlistEscape_NoEscapeNeeded(t *testing.T) {
+	in := "/Users/me/bin/agentcookie"
+	if got := plistEscape(in); got != in {
+		t.Errorf("plistEscape passthrough: got %q, want %q", got, in)
+	}
+}
+
+func TestRenderOneShotPlist_HasRequiredKeys(t *testing.T) {
+	got := renderOneShotPlist("dev.agentcookie.test", []string{"/bin/echo", "hello"}, "/tmp/out", "/tmp/err")
+	for _, must := range []string{
+		"<key>Label</key>", "dev.agentcookie.test",
+		"<key>ProgramArguments</key>", "/bin/echo", "hello",
+		"<key>RunAtLoad</key>", "<true/>",
+		"<key>StandardOutPath</key>", "/tmp/out",
+		"<key>StandardErrorPath</key>", "/tmp/err",
+	} {
+		if !strings.Contains(got, must) {
+			t.Errorf("plist missing %q. Full plist:\n%s", must, got)
+		}
+	}
+}
+
+func TestRenderOneShotPlist_EscapesArgvSpecialChars(t *testing.T) {
+	// An argv string containing '&' (an injection candidate via plist) must
+	// be escaped to &amp; or the plist becomes invalid XML.
+	got := renderOneShotPlist("dev.agentcookie.test", []string{"/bin/sh", "-c", "echo a & b"}, "/tmp/o", "/tmp/e")
+	if !strings.Contains(got, "echo a &amp; b") {
+		t.Errorf("plist did not escape '&' in argv. Plist:\n%s", got)
+	}
+	if strings.Contains(got, "echo a & b") {
+		t.Errorf("plist contains unescaped '&' in argv (will fail to parse). Plist:\n%s", got)
+	}
+}
+
+func TestScanField_ParsesLaunchctlPrintOutput(t *testing.T) {
+	sample := `	state = not running
+	last exit code = 0
+	pid = 12345
+`
+	if got := scanField(sample, "state ="); got != "not running" {
+		t.Errorf("state field: got %q, want %q", got, "not running")
+	}
+	if got := scanField(sample, "last exit code ="); got != "0" {
+		t.Errorf("exit code field: got %q, want %q", got, "0")
+	}
+}
+
+func TestScanField_MissingKey(t *testing.T) {
+	if got := scanField("nothing here", "state ="); got != "" {
+		t.Errorf("missing key should return empty, got %q", got)
+	}
+}
+
+func TestRandomLabel_UniqueAcrossCalls(t *testing.T) {
+	a, err := randomLabel("dev.agentcookie.test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := randomLabel("dev.agentcookie.test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a == b {
+		t.Errorf("two consecutive randomLabel calls returned same value: %q", a)
+	}
+	if !strings.HasPrefix(a, "dev.agentcookie.test.") {
+		t.Errorf("label missing prefix: %q", a)
+	}
+	if len(a) != len("dev.agentcookie.test.")+8 {
+		t.Errorf("label length unexpected: %q (len=%d)", a, len(a))
+	}
+}

--- a/internal/chrome/probe_keybase.go
+++ b/internal/chrome/probe_keybase.go
@@ -1,0 +1,59 @@
+//go:build darwin && cgo
+
+// Package chrome's probe_keybase.go exercises Chrome Safe Storage via the
+// keybase/go-keychain CGO library -- the same API path kooky's CGO build
+// uses. The legacy `security` CLI honors the `-A` "any application" ACL
+// flag, but kooky-CGO goes through SecItemCopyMatching which honors the
+// partition list instead. This probe lets agentcookie's wizard tell which
+// access strategy actually works for kooky callers.
+package chrome
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	keychain "github.com/keybase/go-keychain"
+)
+
+// ErrProbeTimedOut means the Keychain call did not return within the
+// probe's deadline. The most common cause is a SecurityAgent prompt sitting
+// on the user's screen waiting for an Always-Allow / Deny click. From a
+// LaunchAgent context with the right ACL/partition setup, the call returns
+// in milliseconds.
+var ErrProbeTimedOut = errors.New("probe: Keychain call exceeded deadline (likely a SecurityAgent prompt is hung waiting for a click)")
+
+// KeybaseKeychainProbe calls keychain.GetGenericPassword for the Chrome
+// Safe Storage item, with a hard timeout. Returns the password byte
+// length on success (never the password itself -- avoid leaking it through
+// stderr or process output).
+//
+// timeout caps how long we wait for the Keychain API. A hung call almost
+// always means a prompt is pending; treat that as a typed failure so the
+// wizard's strategy loop can move on without burning ~30s per attempt.
+func KeybaseKeychainProbe(timeout time.Duration) (int, error) {
+	type result struct {
+		n   int
+		err error
+	}
+	ch := make(chan result, 1)
+
+	go func() {
+		password, err := keychain.GetGenericPassword(keychainService, keychainAccount, "", "")
+		if err != nil {
+			ch <- result{0, fmt.Errorf("keybase keychain GetGenericPassword: %w", err)}
+			return
+		}
+		ch <- result{len(password), nil}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	select {
+	case r := <-ch:
+		return r.n, r.err
+	case <-ctx.Done():
+		return 0, ErrProbeTimedOut
+	}
+}

--- a/internal/chrome/probe_keybase_stub.go
+++ b/internal/chrome/probe_keybase_stub.go
@@ -1,0 +1,19 @@
+//go:build !darwin || !cgo
+
+package chrome
+
+import (
+	"errors"
+	"time"
+)
+
+// ErrProbeTimedOut keeps a build-friendly identifier across non-darwin or
+// no-CGO build configurations. See probe_keybase.go for the real implementation.
+var ErrProbeTimedOut = errors.New("probe: Keychain call exceeded deadline (not applicable on this build)")
+
+// KeybaseKeychainProbe stubs out on non-darwin and no-CGO builds. The
+// real implementation needs both darwin and CGO (the keybase library is
+// a CGO wrapper around macOS Security framework).
+func KeybaseKeychainProbe(timeout time.Duration) (int, error) {
+	return 0, errors.New("KeybaseKeychainProbe: requires darwin + CGO build")
+}

--- a/internal/cli/internal.go
+++ b/internal/cli/internal.go
@@ -1,0 +1,61 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mvanhorn/agentcookie/internal/chrome"
+)
+
+// internalCmd is a hidden command group for implementation-detail helpers
+// that the wizard and runbooks invoke but humans rarely call directly.
+// Hidden from `agentcookie --help` to keep the user-facing surface clean.
+var internalCmd = &cobra.Command{
+	Use:    "internal",
+	Short:  "Implementation-detail subcommands used by wizard and probes",
+	Hidden: true,
+}
+
+var keychainProbeCmd = &cobra.Command{
+	Use:   "keychain-probe",
+	Short: "Test whether Chrome Safe Storage is readable via the kooky-CGO API path",
+	Long: `keychain-probe calls Chrome Safe Storage via the same Apple Security
+framework API that kooky's CGO build uses (github.com/keybase/go-keychain ->
+SecItemCopyMatching). It is used by the agentcookie wizard's
+set-keychain-access strategy loop to tell whether a given partition-list
+or trust-list change actually makes the Keychain item readable to
+kooky-using CLIs, not just to the legacy security CLI.
+
+Prints "ok len=N" and exits 0 when the call succeeds (N is the password
+byte length; the password itself is never printed). Prints "fail: <error>"
+and exits 1 otherwise. A 5-second timeout detects the SecurityAgent-prompt
+hang as a typed failure rather than a hang.
+
+Run this from a LaunchAgent context (where the login keychain is auto-
+unlocked) for accurate results. Run from SSH and it will almost certainly
+fail with "interaction not allowed" regardless of the ACL/partition list,
+because SSH sessions have the login keychain locked.`,
+	RunE: runKeychainProbe,
+}
+
+var keychainProbeTimeoutSeconds int
+
+func init() {
+	keychainProbeCmd.Flags().IntVar(&keychainProbeTimeoutSeconds, "timeout-seconds", 5, "fail with ErrProbeTimedOut if the Keychain call does not return in this many seconds")
+	internalCmd.AddCommand(keychainProbeCmd)
+	rootCmd.AddCommand(internalCmd)
+}
+
+func runKeychainProbe(cmd *cobra.Command, args []string) error {
+	timeout := time.Duration(keychainProbeTimeoutSeconds) * time.Second
+	n, err := chrome.KeybaseKeychainProbe(timeout)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "fail: %v\n", err)
+		return err
+	}
+	fmt.Fprintf(os.Stdout, "ok len=%d\n", n)
+	return nil
+}

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -36,6 +36,7 @@ var (
 	wizardSkipExitNode       bool
 	wizardSkipKeychainPrompt bool
 	wizardSkipPartitionList  bool
+	wizardSkipKeychainAccess bool
 	wizardSkipBridgeHint     bool
 )
 
@@ -93,6 +94,7 @@ func init() {
 	wizardInstallCmd.Flags().BoolVar(&wizardSkipExitNode, "skip-exit-node-hint", false, "do not detect Tailscale or print the sudo commands that route the sink's outbound traffic through the source machine")
 	wizardInstallCmd.Flags().BoolVar(&wizardSkipKeychainPrompt, "skip-keychain-prompt", false, "[sink] do not trigger the Chrome Safe Storage Keychain prompt during install; the sink daemon will prompt on first sync instead")
 	wizardInstallCmd.Flags().BoolVar(&wizardSkipPartitionList, "skip-partition-list", false, "[sink] do not expand the Chrome Safe Storage Keychain partition list; PP CLIs using Apple-tool callers may then prompt on first read")
+	wizardInstallCmd.Flags().BoolVar(&wizardSkipKeychainAccess, "skip-keychain-access", false, "[sink] do not run v0.10 set-keychain-access strategies (the kooky-CGO probe + partition/trust-list loop); kooky CLIs may then prompt on first read per binary")
 	wizardInstallCmd.Flags().BoolVar(&wizardSkipBridgeHint, "skip-bridge-hint", false, "[sink] do not print the cookie-bridge env-var integration hint at install end")
 
 	wizardUninstallCmd.Flags().StringVar(&wizardRole, "as", "", "source | sink (required)")
@@ -247,19 +249,24 @@ func wizardInstallSink(ctx context.Context, binPath, logDir string) error {
 		fmt.Fprintln(os.Stderr, "agentcookie wizard: Keychain access granted; sink daemon can run unattended")
 	}
 
-	// v0.9: expand the Chrome Safe Storage partition list so Apple-tool
-	// callers (e.g., the `security` CLI used by various PP-CLI side scripts)
-	// can read the password without a GUI prompt. macOS prompts once for
-	// the user's login keychain password to authorize the change. Ad-hoc-
-	// signed Go binaries (most PP CLIs) still need their own one-time
-	// Always Allow click on first read; the partition list is groundwork,
-	// not a blanket grant. See plan 2026-05-17-003.
-	if !wizardSkipPartitionList {
-		fmt.Fprintln(os.Stderr, "agentcookie wizard: expanding Chrome Safe Storage partition list (you may be prompted for your login keychain password)")
-		if err := chrome.SetSafeStoragePartitionList(""); err != nil {
-			return fmt.Errorf("partition list grant: %w (re-run after granting, or pass --skip-partition-list)", err)
+	// v0.10: run the set-keychain-access strategy loop. This supersedes the
+	// v0.9 partition-list step -- v0.10's first strategy IS the same
+	// partition-list expansion, plus it verifies the result via the
+	// keybase/go-keychain API path kooky-CGO uses, and falls back to
+	// per-binary trust-list entries if the partition list alone does not
+	// cover ad-hoc-signed Go binaries. The whole thing runs inside a
+	// one-shot LaunchAgent (auto-unlocked keychain) so no login password
+	// prompt fires. See plan 2026-05-17-004.
+	if !wizardSkipKeychainAccess {
+		fmt.Fprintln(os.Stderr, "agentcookie wizard: running set-keychain-access strategy loop (broadens Chrome Safe Storage access for kooky-using CLIs)")
+		setKeychainExtraBinary = defaultKeychainTrustBinaries()
+		if err := runOuterWizard(setKeychainAccessCmd); err != nil {
+			// Do NOT abort install. Sink itself still works; only the
+			// per-CLI headless-read path is degraded.
+			fmt.Fprintf(os.Stderr, "agentcookie wizard: WARNING keychain access strategy loop failed: %v\n", err)
+			fmt.Fprintln(os.Stderr, "agentcookie wizard:   kooky-using CLIs on this sink will prompt for Keychain access on first read per binary")
+			fmt.Fprintln(os.Stderr, "agentcookie wizard:   see docs/runbook-v0.10-keychain-access.md for recovery")
 		}
-		fmt.Fprintln(os.Stderr, "agentcookie wizard: partition list granted (Apple-tool callers can now read Safe Storage silently)")
 	}
 
 	if !wizardSkipDaemon {
@@ -283,6 +290,37 @@ func wizardInstallSink(ctx context.Context, binPath, logDir string) error {
 
 	fmt.Fprintln(os.Stderr, "agentcookie wizard: sink install complete")
 	return nil
+}
+
+// defaultKeychainTrustBinaries returns kooky-using CLI binaries the wizard
+// should fall back to per-binary trust-list grants for, when the
+// partition-list strategies alone do not suffice. Tries a handful of known
+// PP CLI install paths; only includes paths that actually exist so the
+// trust-list strategy doesn't error on a missing file.
+func defaultKeychainTrustBinaries() []string {
+	home, _ := os.UserHomeDir()
+	candidates := []string{
+		filepath.Join(home, "go", "bin", "instacart-pp-cli"),
+	}
+	// Common printing-press library install paths -- include any that
+	// actually exist on this machine.
+	ppDir := filepath.Join(home, "printing-press", "library")
+	if entries, err := os.ReadDir(ppDir); err == nil {
+		for _, e := range entries {
+			if !e.IsDir() {
+				continue
+			}
+			bin := filepath.Join(ppDir, e.Name(), e.Name())
+			candidates = append(candidates, bin)
+		}
+	}
+	var present []string
+	for _, c := range candidates {
+		if _, err := os.Stat(c); err == nil {
+			present = append(present, c)
+		}
+	}
+	return present
 }
 
 // printBridgeHint tells the operator how PP CLIs use the cookie bridge.

--- a/internal/cli/wizard_keychain.go
+++ b/internal/cli/wizard_keychain.go
@@ -1,0 +1,240 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mvanhorn/agentcookie/internal/chrome"
+)
+
+var (
+	setKeychainExtraBinary []string
+	innerRunnerMode        bool
+)
+
+var setKeychainAccessCmd = &cobra.Command{
+	Use:   "set-keychain-access",
+	Short: "Broaden Chrome Safe Storage access so kooky-using CLIs read without per-binary prompts",
+	Long: `set-keychain-access tries each of several strategies (partition-list
+expansion, then per-binary trust-list additions) and lands on the first
+that lets kooky-CGO callers (instacart-pp-cli, bird, future PP CLIs)
+read Chrome Safe Storage silently from a LaunchAgent context.
+
+The mutations themselves run inside a one-shot LaunchAgent that
+agentcookie spawns. LaunchAgents run in the user's GUI session where
+the login keychain is auto-unlocked, so no login password prompt fires
+during the operation. Each strategy is followed by a probe (using the
+same Keychain API path kooky-CGO uses) to verify the change actually
+took.
+
+If the wizard invokes this with no prior install on the box, the
+default strategy chain is sufficient. Pass --extra-binary <absolute path>
+(repeatable) to add specific kooky-using CLIs to the per-binary
+trust-list fallback if the partition-list strategies are insufficient
+on your macOS version.`,
+	RunE: runSetKeychainAccess,
+}
+
+func init() {
+	setKeychainAccessCmd.Flags().StringArrayVar(&setKeychainExtraBinary, "extra-binary", nil, "absolute path to a kooky-using CLI binary; added to the trust-list fallback if partition-list strategies do not cover it; repeatable")
+	setKeychainAccessCmd.Flags().BoolVar(&innerRunnerMode, "inner-runner", false, "run the strategy loop in this process (used internally when invoked as a one-shot LaunchAgent); end users do not pass this")
+	_ = setKeychainAccessCmd.Flags().MarkHidden("inner-runner")
+	wizardCmd.AddCommand(setKeychainAccessCmd)
+}
+
+// strategyOutcome is the structured result one strategy attempt yields.
+// JSON-encoded by the inner runner so the outer wizard caller can parse
+// without re-parsing free-form text.
+type strategyOutcome struct {
+	Name      string `json:"name"`
+	Success   bool   `json:"success"`
+	Detail    string `json:"detail,omitempty"`
+	ProbeLen  int    `json:"probe_len,omitempty"`
+	ErrorText string `json:"error,omitempty"`
+}
+
+// runResult is what the inner runner emits as its final JSON line.
+type runResult struct {
+	WinningStrategy string            `json:"winning_strategy,omitempty"`
+	Attempts        []strategyOutcome `json:"attempts"`
+	OverallSuccess  bool              `json:"overall_success"`
+}
+
+func runSetKeychainAccess(cmd *cobra.Command, args []string) error {
+	if innerRunnerMode {
+		return runInnerStrategyLoop(cmd)
+	}
+	return runOuterWizard(cmd)
+}
+
+// runOuterWizard is the user-facing path. It writes a one-shot LaunchAgent
+// that re-invokes this binary with --inner-runner, then parses the
+// resulting JSON to report what happened.
+func runOuterWizard(cmd *cobra.Command) error {
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("locate this binary: %w", err)
+	}
+	exe, _ = filepath.Abs(exe)
+
+	argv := []string{exe, "wizard", "set-keychain-access", "--inner-runner"}
+	for _, b := range setKeychainExtraBinary {
+		argv = append(argv, "--extra-binary", b)
+	}
+
+	fmt.Fprintln(os.Stderr, "agentcookie wizard: running keychain strategies via a one-shot LaunchAgent (no prompts expected; if a Mac mini desktop prompt appears, click Always Allow and re-run)")
+
+	res, err := chrome.RunOneShotLaunchAgent(argv, 30*time.Second)
+	if err != nil {
+		return fmt.Errorf("LaunchAgent dispatch: %w (stdout=%q stderr=%q)", err, res.Stdout, res.Stderr)
+	}
+
+	// The inner runner's last stdout line is a JSON runResult.
+	var parsed runResult
+	if line := lastJSONLine(res.Stdout); line != "" {
+		if err := json.Unmarshal([]byte(line), &parsed); err != nil {
+			return fmt.Errorf("parse inner runner output (raw=%q): %w", res.Stdout, err)
+		}
+	} else {
+		return fmt.Errorf("inner runner produced no JSON output (stdout=%q stderr=%q exit=%d)", res.Stdout, res.Stderr, res.Exit)
+	}
+
+	for _, a := range parsed.Attempts {
+		if a.Success {
+			fmt.Fprintf(os.Stderr, "agentcookie wizard:   strategy %q -> success (probe len=%d)\n", a.Name, a.ProbeLen)
+		} else {
+			fmt.Fprintf(os.Stderr, "agentcookie wizard:   strategy %q -> failed (%s)\n", a.Name, a.ErrorText)
+		}
+	}
+
+	if parsed.OverallSuccess {
+		fmt.Fprintf(os.Stderr, "agentcookie wizard: keychain access: %s\n", parsed.WinningStrategy)
+		return nil
+	}
+	return fmt.Errorf("keychain access: FAILED (all strategies exhausted; see attempt log above and docs/runbook-v0.10-keychain-access.md)")
+}
+
+// runInnerStrategyLoop is invoked inside the one-shot LaunchAgent, where
+// the login keychain is unlocked. Iterates strategies, probes after
+// each, emits structured JSON on stdout for the outer wizard to parse.
+func runInnerStrategyLoop(cmd *cobra.Command) error {
+	strategies := buildStrategies(setKeychainExtraBinary)
+
+	var result runResult
+	for _, s := range strategies {
+		outcome := tryStrategy(s)
+		result.Attempts = append(result.Attempts, outcome)
+		if outcome.Success {
+			result.WinningStrategy = outcome.Name
+			result.OverallSuccess = true
+			break
+		}
+	}
+
+	// Emit JSON for the outer caller. Last line on stdout is parsed.
+	out, _ := json.Marshal(result)
+	fmt.Println(string(out))
+	if !result.OverallSuccess {
+		return fmt.Errorf("no strategy succeeded")
+	}
+	return nil
+}
+
+type kcStrategy struct {
+	name  string
+	apply func() (detail string, err error)
+}
+
+func buildStrategies(extraBinaries []string) []kcStrategy {
+	out := []kcStrategy{
+		{
+			name: "partition-list:apple-tool,apple",
+			apply: func() (string, error) {
+				return execSecurity("set-generic-password-partition-list",
+					"-S", "apple-tool:,apple:",
+					"-s", "Chrome Safe Storage", "-a", "Chrome")
+			},
+		},
+		{
+			name: "partition-list:apple-tool,apple,teamid",
+			apply: func() (string, error) {
+				return execSecurity("set-generic-password-partition-list",
+					"-S", "apple-tool:,apple:,teamid:",
+					"-s", "Chrome Safe Storage", "-a", "Chrome")
+			},
+		},
+	}
+
+	for _, bin := range extraBinaries {
+		bin := bin
+		out = append(out, kcStrategy{
+			name: "trust-list:" + filepath.Base(bin),
+			apply: func() (string, error) {
+				// Update existing item: preserve password, add this binary to trust list.
+				// Requires reading the current password first (which works from LaunchAgent
+				// context because keychain is unlocked).
+				pw, err := chrome.SafeStoragePassword()
+				if err != nil {
+					return "", fmt.Errorf("read existing password: %w", err)
+				}
+				return execSecurity("add-generic-password",
+					"-s", "Chrome Safe Storage", "-a", "Chrome",
+					"-w", pw, "-T", bin, "-U")
+			},
+		})
+	}
+
+	return out
+}
+
+// tryStrategy applies one strategy, then probes via the keybase/go-keychain
+// API path kooky-CGO uses. Returns a structured outcome.
+func tryStrategy(s kcStrategy) strategyOutcome {
+	outcome := strategyOutcome{Name: s.name}
+
+	detail, err := s.apply()
+	if err != nil {
+		outcome.ErrorText = "apply: " + err.Error()
+		return outcome
+	}
+	outcome.Detail = detail
+
+	probeLen, perr := chrome.KeybaseKeychainProbe(5 * time.Second)
+	if perr != nil {
+		outcome.ErrorText = "probe: " + perr.Error()
+		return outcome
+	}
+	outcome.ProbeLen = probeLen
+	outcome.Success = true
+	return outcome
+}
+
+// execSecurity runs /usr/bin/security with the given args, returns
+// "stdout||stderr" as detail. Caller treats non-zero exit as failure.
+func execSecurity(args ...string) (string, error) {
+	cmd := exec.Command("/usr/bin/security", args...)
+	out, err := cmd.CombinedOutput()
+	detail := strings.TrimSpace(string(out))
+	if err != nil {
+		return detail, fmt.Errorf("security %s: %w (%s)", args[0], err, detail)
+	}
+	return detail, nil
+}
+
+func lastJSONLine(s string) string {
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		trim := strings.TrimSpace(lines[i])
+		if strings.HasPrefix(trim, "{") && strings.HasSuffix(trim, "}") {
+			return trim
+		}
+	}
+	return ""
+}

--- a/internal/cli/wizard_keychain.go
+++ b/internal/cli/wizard_keychain.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	cryptorand "crypto/rand"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -155,18 +157,35 @@ type kcStrategy struct {
 func buildStrategies(extraBinaries []string) []kcStrategy {
 	out := []kcStrategy{
 		{
+			// Primary v0.10 strategy: delete the existing Chrome Safe Storage
+			// item, recreate it with -A ("any application may access without
+			// warning") and a fresh random password. The delete works from
+			// LaunchAgent context with an unlocked login keychain; the
+			// add-with-A works on a fresh (no-prior-ACL) item without a
+			// login-password prompt. Rotates the password as a side effect;
+			// agentcookie sink re-reads on next operation and the next source
+			// sync overwrites cookies with the new derivation. Mac mini Chrome
+			// stays quit, so Chrome's own cookies-encrypted-with-old-password
+			// concern does not bite.
+			name: "delete-and-recreate-with-A",
+			apply: func() (string, error) {
+				_, _ = execSecurity("delete-generic-password",
+					"-s", "Chrome Safe Storage", "-a", "Chrome") // best-effort; ok if item missing
+				pw := randomKeychainPassword()
+				return execSecurity("add-generic-password",
+					"-s", "Chrome Safe Storage", "-a", "Chrome",
+					"-w", pw, "-A")
+			},
+		},
+		{
+			// Fallback 1: try the partition-list expansion. Requires the
+			// login password in practice on modern macOS, so this usually
+			// fails from a LaunchAgent; kept here in case a future macOS
+			// version relaxes the requirement.
 			name: "partition-list:apple-tool,apple",
 			apply: func() (string, error) {
 				return execSecurity("set-generic-password-partition-list",
 					"-S", "apple-tool:,apple:",
-					"-s", "Chrome Safe Storage", "-a", "Chrome")
-			},
-		},
-		{
-			name: "partition-list:apple-tool,apple,teamid",
-			apply: func() (string, error) {
-				return execSecurity("set-generic-password-partition-list",
-					"-S", "apple-tool:,apple:,teamid:",
 					"-s", "Chrome Safe Storage", "-a", "Chrome")
 			},
 		},
@@ -177,9 +196,6 @@ func buildStrategies(extraBinaries []string) []kcStrategy {
 		out = append(out, kcStrategy{
 			name: "trust-list:" + filepath.Base(bin),
 			apply: func() (string, error) {
-				// Update existing item: preserve password, add this binary to trust list.
-				// Requires reading the current password first (which works from LaunchAgent
-				// context because keychain is unlocked).
 				pw, err := chrome.SafeStoragePassword()
 				if err != nil {
 					return "", fmt.Errorf("read existing password: %w", err)
@@ -192,6 +208,20 @@ func buildStrategies(extraBinaries []string) []kcStrategy {
 	}
 
 	return out
+}
+
+// randomKeychainPassword returns 16 random bytes base64-encoded (~22 chars).
+// Chrome uses a similar 16-byte random secret for its Safe Storage item;
+// matching the shape keeps any future Chrome interop reasonable.
+func randomKeychainPassword() string {
+	b := make([]byte, 16)
+	if _, err := cryptorand.Read(b); err != nil {
+		// Fall back to a less-random but non-empty default. This branch is
+		// essentially unreachable on darwin where crypto/rand is the system
+		// RNG; the fallback exists so the caller never gets an empty password.
+		return "agentcookie-fallback-secret"
+	}
+	return base64.RawStdEncoding.EncodeToString(b)
 }
 
 // tryStrategy applies one strategy, then probes via the keybase/go-keychain

--- a/internal/cli/wizard_keychain_test.go
+++ b/internal/cli/wizard_keychain_test.go
@@ -35,42 +35,51 @@ func TestLastJSONLine_TrailingNewlinesIgnored(t *testing.T) {
 	}
 }
 
-func TestBuildStrategies_DefaultsToTwoPartitionStrategies(t *testing.T) {
+func TestBuildStrategies_PrimaryIsDeleteAndRecreate(t *testing.T) {
 	s := buildStrategies(nil)
-	if len(s) != 2 {
-		t.Errorf("default strategy count: got %d, want 2", len(s))
+	if len(s) < 1 {
+		t.Fatal("expected at least one default strategy")
 	}
-	if !strings.Contains(s[0].name, "apple-tool,apple") || strings.Contains(s[0].name, "teamid") {
-		t.Errorf("first strategy should be apple-tool,apple without teamid, got %q", s[0].name)
-	}
-	if !strings.Contains(s[1].name, "teamid") {
-		t.Errorf("second strategy should include teamid, got %q", s[1].name)
+	if s[0].name != "delete-and-recreate-with-A" {
+		t.Errorf("primary strategy: got %q, want delete-and-recreate-with-A (this is the only strategy proven to work headlessly on macOS 25+)", s[0].name)
 	}
 }
 
-func TestBuildStrategies_ExtraBinariesAppearAsTrustListStrategies(t *testing.T) {
-	s := buildStrategies([]string{"/Users/me/go/bin/instacart-pp-cli", "/Users/me/go/bin/bird"})
-	if len(s) != 4 {
-		t.Fatalf("expected 2 default + 2 extra-binary strategies, got %d", len(s))
+func TestBuildStrategies_PartitionListFallbackComesSecond(t *testing.T) {
+	s := buildStrategies(nil)
+	if len(s) < 2 {
+		t.Fatal("expected partition-list fallback to exist")
 	}
-	if !strings.Contains(s[2].name, "trust-list:") || !strings.Contains(s[2].name, "instacart-pp-cli") {
-		t.Errorf("third strategy: got %q, want trust-list:instacart-pp-cli", s[2].name)
-	}
-	if !strings.Contains(s[3].name, "trust-list:") || !strings.Contains(s[3].name, "bird") {
-		t.Errorf("fourth strategy: got %q, want trust-list:bird", s[3].name)
+	if !strings.HasPrefix(s[1].name, "partition-list:") {
+		t.Errorf("second strategy should be partition-list fallback, got %q", s[1].name)
 	}
 }
 
-func TestBuildStrategies_PartitionListStrategiesComeFirst(t *testing.T) {
-	// Sequence matters: partition list is the cheaper, more universal fix.
-	// Per-binary trust list is a fallback. Verify ordering.
-	s := buildStrategies([]string{"/path/to/cli"})
-	for i := 0; i < 2; i++ {
-		if !strings.HasPrefix(s[i].name, "partition-list:") {
-			t.Errorf("strategy %d should be partition-list, got %q", i, s[i].name)
-		}
+func TestBuildStrategies_ExtraBinariesAppearAfterDefaultStrategies(t *testing.T) {
+	defaults := buildStrategies(nil)
+	withExtras := buildStrategies([]string{"/Users/me/go/bin/instacart-pp-cli", "/Users/me/go/bin/bird"})
+	if len(withExtras) != len(defaults)+2 {
+		t.Fatalf("expected %d default + 2 extra-binary strategies, got %d", len(defaults), len(withExtras))
 	}
-	if !strings.HasPrefix(s[2].name, "trust-list:") {
-		t.Errorf("strategy 2 should be trust-list, got %q", s[2].name)
+	last2 := withExtras[len(defaults):]
+	if !strings.Contains(last2[0].name, "trust-list:") || !strings.Contains(last2[0].name, "instacart-pp-cli") {
+		t.Errorf("first extra strategy: got %q, want trust-list:instacart-pp-cli", last2[0].name)
+	}
+	if !strings.Contains(last2[1].name, "trust-list:") || !strings.Contains(last2[1].name, "bird") {
+		t.Errorf("second extra strategy: got %q, want trust-list:bird", last2[1].name)
+	}
+}
+
+func TestRandomKeychainPassword_NonEmptyAndUnique(t *testing.T) {
+	a := randomKeychainPassword()
+	b := randomKeychainPassword()
+	if a == "" {
+		t.Error("password is empty")
+	}
+	if a == b {
+		t.Errorf("two consecutive calls returned same value: %q", a)
+	}
+	if len(a) < 16 {
+		t.Errorf("password unexpectedly short (%d chars): %q", len(a), a)
 	}
 }

--- a/internal/cli/wizard_keychain_test.go
+++ b/internal/cli/wizard_keychain_test.go
@@ -1,0 +1,76 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLastJSONLine_FindsLastJSONObject(t *testing.T) {
+	stdout := `some log line
+agentcookie: strategy partition-list:apple-tool,apple
+{"name":"partition-list:apple-tool,apple","success":false}
+{"winning_strategy":"trust-list:instacart-pp-cli","overall_success":true,"attempts":[]}`
+	got := lastJSONLine(stdout)
+	if !strings.HasPrefix(got, `{"winning_strategy"`) {
+		t.Errorf("expected last JSON line, got %q", got)
+	}
+}
+
+func TestLastJSONLine_NoJSON(t *testing.T) {
+	stdout := "just some log\nlines here"
+	if got := lastJSONLine(stdout); got != "" {
+		t.Errorf("no JSON expected, got %q", got)
+	}
+}
+
+func TestLastJSONLine_TrailingNewlinesIgnored(t *testing.T) {
+	stdout := `{"a":1}
+{"b":2}
+
+
+`
+	got := lastJSONLine(stdout)
+	if got != `{"b":2}` {
+		t.Errorf("got %q, want %q", got, `{"b":2}`)
+	}
+}
+
+func TestBuildStrategies_DefaultsToTwoPartitionStrategies(t *testing.T) {
+	s := buildStrategies(nil)
+	if len(s) != 2 {
+		t.Errorf("default strategy count: got %d, want 2", len(s))
+	}
+	if !strings.Contains(s[0].name, "apple-tool,apple") || strings.Contains(s[0].name, "teamid") {
+		t.Errorf("first strategy should be apple-tool,apple without teamid, got %q", s[0].name)
+	}
+	if !strings.Contains(s[1].name, "teamid") {
+		t.Errorf("second strategy should include teamid, got %q", s[1].name)
+	}
+}
+
+func TestBuildStrategies_ExtraBinariesAppearAsTrustListStrategies(t *testing.T) {
+	s := buildStrategies([]string{"/Users/me/go/bin/instacart-pp-cli", "/Users/me/go/bin/bird"})
+	if len(s) != 4 {
+		t.Fatalf("expected 2 default + 2 extra-binary strategies, got %d", len(s))
+	}
+	if !strings.Contains(s[2].name, "trust-list:") || !strings.Contains(s[2].name, "instacart-pp-cli") {
+		t.Errorf("third strategy: got %q, want trust-list:instacart-pp-cli", s[2].name)
+	}
+	if !strings.Contains(s[3].name, "trust-list:") || !strings.Contains(s[3].name, "bird") {
+		t.Errorf("fourth strategy: got %q, want trust-list:bird", s[3].name)
+	}
+}
+
+func TestBuildStrategies_PartitionListStrategiesComeFirst(t *testing.T) {
+	// Sequence matters: partition list is the cheaper, more universal fix.
+	// Per-binary trust list is a fallback. Verify ordering.
+	s := buildStrategies([]string{"/path/to/cli"})
+	for i := 0; i < 2; i++ {
+		if !strings.HasPrefix(s[i].name, "partition-list:") {
+			t.Errorf("strategy %d should be partition-list, got %q", i, s[i].name)
+		}
+	}
+	if !strings.HasPrefix(s[2].name, "trust-list:") {
+		t.Errorf("strategy 2 should be trust-list, got %q", s[2].name)
+	}
+}


### PR DESCRIPTION
## Summary

Closes the soup-to-nuts gap: kooky-using CLIs (instacart-pp-cli, bird, any future PP CLI) read Chrome cookies on the Mac mini sink without per-binary Always-Allow prompts.

- **U1**: `agentcookie internal keychain-probe` -- calls Chrome Safe Storage via the same keybase/go-keychain CGO API path kooky-CGO uses, with a 5s timeout that turns SecurityAgent-prompt hangs into typed failures.
- **U2**: `agentcookie wizard set-keychain-access` -- outer wizard fires a one-shot LaunchAgent that re-invokes the binary with `--inner-runner`; inner runner iterates strategies (delete-and-recreate-with-A primary, partition-list fallback, per-binary trust-list per `--extra-binary`) and verifies each via the probe; structured JSON result back to the outer caller.
- **U3**: `wizardInstallSink` auto-runs `set-keychain-access` after the existing Always-Allow trigger. New `--skip-keychain-access` flag. Failure prints a loud warning but does not abort install.
- **U4**: validated live on Mac mini -- `ssh matts-mac-mini 'instacart-pp-cli auth login'` returns `imported N cookies from Chrome` with exit 0 and no GUI prompt; `instacart-pp-cli doctor` reports `[ok] session: N cookies from chrome` (not "from paste") and `[ok] api: logged in as`.
- **U5**: docs, CHANGELOG, README, runbook (`docs/runbook-v0.10-keychain-access.md`) including the one-time GUI fallback for sinks where the keychain item is in a restrictive ACL state.

Also folds in: `chrome.SafeStoragePassword` tries the keybase CGO path first, falls back to the `security` CLI. The legacy CLI was returning exit 44 with empty stdout from LaunchAgent context on Mac mini today while keybase returned the password reliably; both hit the same Apple Security framework via different paths.

Plan: `docs/plans/2026-05-17-004-feat-keychain-partition-list-v0.10-plan.md`. Follows v0.9 (#28).

## Security trade-off

After v0.10, Chrome Safe Storage on a sink is any-app-readable. Documented in CHANGELOG + runbook. The threat model already assumes sink-side process compromise = lost cookies (the plaintext sidecar is there too). Pass `--skip-keychain-access` to the wizard to opt out.

## Test plan

- [x] `go test ./...` -> 116 pass (3 packages touched: chrome, cli, chromectl)
- [x] Mac mini live validation: `instacart auth login` over SSH -> imports cookies from Chrome, exits 0
- [x] Mac mini live validation: `instacart doctor` over SSH -> `[ok] session: N cookies from chrome`
- [ ] Fresh-Mac-mini validation: not yet -- the live test was on the existing keychain-access state set up earlier today via Matt's "Allow all applications" GUI click in Keychain Access; the `delete-and-recreate-with-A` programmatic strategy will need to be exercised on a sink that has not had its Chrome Safe Storage item touched yet.