### PR TITLE
feat(v0.12 U0): sign release binaries with Developer ID Application

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,38 @@ jobs:
         with:
           go-version: "1.24"
           cache: true
+
+      # Import the Developer ID Application certificate into a temporary
+      # keychain so codesign can find it. The .p12 bundle and its password
+      # are repo secrets. The action creates an ephemeral keychain, unlocks
+      # it, and adds it to the search list for the rest of the job.
+      #
+      # TODO: maintainer must add the following GitHub Actions secrets
+      # before the first signed release ships:
+      #   - CERTIFICATE_OSX_APPLICATION : base64-encoded .p12 of the
+      #     Developer ID Application cert + private key
+      #   - CERTIFICATE_OSX_APPLICATION_PASSWORD : password for the .p12
+      # The matching cert is Common Name
+      #   "Developer ID Application: Matthew Charles Van Horn (NM8VT393AR)"
+      # See docs/runbook-v0.12-codesign.md for the export / renewal flow.
+      - name: import Developer ID cert
+        if: ${{ secrets.CERTIFICATE_OSX_APPLICATION != '' }}
+        uses: apple-actions/import-codesign-certs@v3
+        with:
+          p12-file-base64: ${{ secrets.CERTIFICATE_OSX_APPLICATION }}
+          p12-password: ${{ secrets.CERTIFICATE_OSX_APPLICATION_PASSWORD }}
+
+      # Sanity: print which codesigning identities are visible to this
+      # runner. On a properly configured release this lists the Developer
+      # ID Application identity NM8VT393AR. If the secret is unset, the
+      # list will be empty and goreleaser's signing post-hook will fail
+      # fast with the runbook pointer.
+      - name: list codesigning identities
+        run: security find-identity -v -p codesigning
+
+      # GoReleaser invokes scripts/sign.sh as a build post-hook, so every
+      # darwin binary is signed before archives are zipped. See
+      # .goreleaser.yaml `builds[].hooks.post`.
       - name: goreleaser
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -27,3 +59,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AGENTCOOKIE_SIGN_IDENTITY: "Developer ID Application: Matthew Charles Van Horn (NM8VT393AR)"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,6 +19,14 @@ builds:
       - amd64
     ldflags:
       - -s -w -X github.com/mvanhorn/agentcookie/internal/cli.Version={{ .Version }}
+    # Sign each darwin binary in place before it is archived. Uses
+    # scripts/sign.sh so the local + release pipelines share one
+    # codesign invocation. AGENTCOOKIE_SIGN_IDENTITY is set by the
+    # release workflow (and defaults inside scripts/sign.sh if unset).
+    hooks:
+      post:
+        - cmd: scripts/sign.sh {{ .Path }}
+          output: true
 
 archives:
   - id: agentcookie

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,67 @@
+# agentcookie Makefile
+#
+# Targets:
+#   make            - build and sign bin/agentcookie (default)
+#   make build      - go build ./cmd/agentcookie -> bin/agentcookie
+#   make install    - go install ./cmd/agentcookie, then sign $(GOBIN)/agentcookie
+#   make sign       - sign bin/agentcookie with the Developer ID identity
+#   make verify     - print the designated requirement of bin/agentcookie
+#   make test       - go test -race ./...
+#   make vet        - go vet ./...
+#   make clean      - remove bin/
+#
+# Build alone does not require an Apple Developer ID. Signing is split into
+# `make sign` so contributors can `make build` and `make test` without a
+# cert. CI release builds run `make` (build + sign) on a signing-enabled
+# macOS runner.
+#
+# Override the signing identity by exporting AGENTCOOKIE_SIGN_IDENTITY. See
+# docs/runbook-v0.12-codesign.md for how to install / renew the cert.
+
+SHELL := /bin/bash
+BIN_DIR := bin
+BINARY := $(BIN_DIR)/agentcookie
+PKG := ./cmd/agentcookie
+
+GOBIN := $(shell go env GOBIN)
+ifeq ($(GOBIN),)
+GOBIN := $(shell go env GOPATH)/bin
+endif
+
+.PHONY: all build install sign verify test vet clean
+
+all: build sign
+
+build:
+	@mkdir -p $(BIN_DIR)
+	go build -o $(BINARY) $(PKG)
+
+# Install to $(GOBIN)/agentcookie and sign in place so steady-state
+# `make install` produces a signed binary with the same designated
+# requirement as the local build.
+install:
+	go install $(PKG)
+	scripts/sign.sh "$(GOBIN)/agentcookie"
+
+sign:
+	@if [[ ! -f $(BINARY) ]]; then \
+	  echo "make sign: $(BINARY) does not exist; run \`make build\` first" >&2; \
+	  exit 1; \
+	fi
+	scripts/sign.sh $(BINARY)
+
+verify:
+	@if [[ ! -f $(BINARY) ]]; then \
+	  echo "make verify: $(BINARY) does not exist; run \`make build\` first" >&2; \
+	  exit 1; \
+	fi
+	codesign -d -r- $(BINARY)
+
+test:
+	go test -race ./...
+
+vet:
+	go vet ./...
+
+clean:
+	rm -rf $(BIN_DIR)

--- a/docs/runbook-v0.12-codesign.md
+++ b/docs/runbook-v0.12-codesign.md
@@ -1,0 +1,183 @@
+# Runbook: v0.12 Developer ID Application codesigning
+
+Goal of v0.12: every agentcookie binary built locally or by CI carries a
+stable Developer ID Application signature with Hardened Runtime and a
+secure timestamp. That stability is what lets per-binary Keychain ACLs
+(U5+) survive every `go install` without re-triggering Always-Allow
+prompts.
+
+The signing identity used by this repo by default is:
+
+    Common Name : Developer ID Application: Matthew Charles Van Horn (NM8VT393AR)
+    Team ID     : NM8VT393AR
+
+Local builds, `go install`, and CI release builds all sign with this
+identity unless `AGENTCOOKIE_SIGN_IDENTITY` is overridden.
+
+## What signing buys us
+
+`codesign -d -r-` against a Developer-ID-signed binary returns a
+designated requirement like:
+
+```
+identifier "agentcookie" and anchor apple generic
+  and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */
+  and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */
+  and certificate leaf[subject.OU] = NM8VT393AR
+```
+
+This requirement does NOT include the cdhash, so it stays byte-for-byte
+identical across rebuilds, machines, and `go install` cycles, as long as
+the binary name and signing identity are the same. The wizard install
+(U5) records that designated requirement in a per-binary Keychain ACL.
+Every subsequent rebuild matches the same ACL entry without a prompt.
+
+## How signing happens
+
+- `make build` (or `go build`) produces `bin/agentcookie`. This step
+  does NOT require a Developer ID cert; contributors without one can
+  still build and test.
+- `make sign` (or `make` with no args) signs `bin/agentcookie` via
+  `scripts/sign.sh`. Fails fast with a runbook pointer if the identity
+  is not on the build machine.
+- `make install` runs `go install ./cmd/agentcookie` then signs
+  `$(go env GOBIN)/agentcookie`. This is the steady-state developer
+  flow.
+- CI release builds use GoReleaser. `.goreleaser.yaml` declares a build
+  post-hook that invokes `scripts/sign.sh` on every darwin binary
+  before archives are zipped. The release workflow
+  (`.github/workflows/release.yml`) imports the cert from the
+  `CERTIFICATE_OSX_APPLICATION` secret on every tagged release.
+
+## Verify on the build machine
+
+The Developer ID Application cert should already be installed.
+Confirm:
+
+```
+security find-identity -v -p codesigning
+```
+
+Expected output includes one line containing the NM8VT393AR Team ID.
+
+Sign and verify a fresh build:
+
+```
+make build
+make sign
+make verify
+```
+
+`make verify` runs `codesign -d -r-` and prints the designated
+requirement. The last line should contain `subject.OU = NM8VT393AR`.
+
+Two consecutive clean rebuilds should produce identical designated
+requirements:
+
+```
+make build && codesign -d -r- bin/agentcookie > /tmp/req1
+make clean && make build && codesign -d -r- bin/agentcookie > /tmp/req2
+diff /tmp/req1 /tmp/req2   # should be empty
+```
+
+## Install the cert on a new build machine
+
+The maintainer's Developer ID Application cert is exportable from the
+Mac it was created on:
+
+1. Open Keychain Access on the original machine.
+2. Find `Developer ID Application: Matthew Charles Van Horn
+   (NM8VT393AR)` in the `login` keychain.
+3. Right-click the cert (with the disclosure-triangle expanded to
+   include the private key) and choose `Export 2 items...`.
+4. Save as a `.p12` file. Set a strong password.
+5. On the new build machine, double-click the `.p12` to import it into
+   the login keychain. Enter the password.
+6. Verify with `security find-identity -v -p codesigning`. The
+   NM8VT393AR identity should appear.
+
+For CI, base64-encode the `.p12` and add it as the GitHub Actions
+secret `CERTIFICATE_OSX_APPLICATION`. Add the password as
+`CERTIFICATE_OSX_APPLICATION_PASSWORD`.
+
+```
+base64 -i agentcookie-codesign.p12 -o agentcookie-codesign.p12.b64
+gh secret set CERTIFICATE_OSX_APPLICATION < agentcookie-codesign.p12.b64
+gh secret set CERTIFICATE_OSX_APPLICATION_PASSWORD
+```
+
+Delete the local `.p12` and `.b64` after upload. Never commit either to
+the repo.
+
+## Renew when the cert expires
+
+Apple Developer ID Application certs are valid for five years. Renewal
+on the Apple Developer portal produces a new cert with the same Team
+ID and the same Common Name shape. Because the designated requirement
+asserts only `subject.OU = NM8VT393AR` and Apple's anchor, a renewed
+cert produces the SAME designated requirement, so existing
+per-binary Keychain ACLs continue to match. No re-trust pass is
+required after renewal.
+
+Renewal steps:
+
+1. Sign in to https://developer.apple.com/account/resources/certificates.
+2. Generate a fresh Developer ID Application cert. Provide the CSR
+   from a new private key created via Keychain Access > Certificate
+   Assistant > Request a Certificate from a Certificate Authority.
+3. Download the `.cer`, double-click to install in the login keychain
+   (binds it to the new private key).
+4. Optionally revoke the old cert from the Apple portal once builds
+   have switched to the new one.
+5. Re-export the new combined cert + key as `.p12` and rotate the
+   `CERTIFICATE_OSX_APPLICATION` GitHub secret.
+
+## Override the identity (contributor builds)
+
+A contributor who wants to test the build pipeline with their own
+Developer ID cert can do so without editing any code:
+
+```
+AGENTCOOKIE_SIGN_IDENTITY="Developer ID Application: Jane Doe (XXXXXXXXXX)" \
+  make sign
+```
+
+Or to skip signing entirely (binary will not pass U5's Keychain ACL
+trust step, but is fine for local hacking):
+
+```
+make build
+# skip `make sign` -- the binary is unsigned (ad-hoc on macOS)
+```
+
+## Test signing manually
+
+```
+go build -o /tmp/agentcookie-smoke ./cmd/agentcookie
+codesign --force --options runtime --timestamp \
+  --sign "Developer ID Application: Matthew Charles Van Horn (NM8VT393AR)" \
+  /tmp/agentcookie-smoke
+codesign --verify --deep --strict --verbose=2 /tmp/agentcookie-smoke
+codesign -d -r- /tmp/agentcookie-smoke
+/tmp/agentcookie-smoke --version
+```
+
+Last line should print the version without a Gatekeeper rejection.
+
+## Troubleshooting
+
+- `errSecInternalComponent` from codesign: the keychain is locked or
+  the LaunchAgent / SSH session does not have access to the login
+  keychain. Run `security unlock-keychain login.keychain-db` from the
+  GUI user session before signing.
+- `no identity found`: `security find-identity -v -p codesigning`
+  returned nothing. The cert is missing or in a non-default keychain.
+  Re-import the `.p12`.
+- `The timestamp service is not available`: transient Apple outage on
+  `timestamp.apple.com`. Retry. `--timestamp` is required for future
+  notarization, do not drop it.
+- `make sign` works locally but CI fails with the identity error: the
+  GitHub Actions secret is unset, or the imported cert lacks the
+  private key. Confirm the `.p12` exported both the cert and the
+  private key (Keychain Access shows the private key under the
+  disclosure triangle).

--- a/scripts/sign.sh
+++ b/scripts/sign.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+#
+# sign.sh - Sign a macOS binary with the agentcookie Developer ID identity.
+#
+# Reads AGENTCOOKIE_SIGN_IDENTITY from the environment, falling back to the
+# maintainer's Developer ID Application identity. Hardened Runtime
+# (--options runtime) and secure timestamping (--timestamp) are required so
+# the result qualifies for notarization later. --force is required so a
+# previously-signed binary can be re-signed in place (steady-state behavior
+# after every `go install`).
+#
+# Usage:
+#   scripts/sign.sh <binary> [<binary> ...]
+#
+# Environment:
+#   AGENTCOOKIE_SIGN_IDENTITY  codesign identity string (CN of the cert,
+#                              or the SHA-1 fingerprint).
+#                              Default: "Developer ID Application: Matthew
+#                              Charles Van Horn (NM8VT393AR)"
+#
+# Exit codes:
+#   0  success
+#   1  usage error
+#   2  identity not available on this build machine
+#   3  codesign or verify failed
+#
+# See docs/runbook-v0.12-codesign.md for cert install / renewal steps.
+
+set -euo pipefail
+
+readonly DEFAULT_IDENTITY="Developer ID Application: Matthew Charles Van Horn (NM8VT393AR)"
+readonly RUNBOOK="docs/runbook-v0.12-codesign.md"
+
+IDENTITY="${AGENTCOOKIE_SIGN_IDENTITY:-$DEFAULT_IDENTITY}"
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: scripts/sign.sh <binary> [<binary> ...]" >&2
+  exit 1
+fi
+
+# Confirm the identity is in the codesigning keychain before we burn time on
+# codesign(1)'s own opaque error. `security find-identity -v -p codesigning`
+# lists every cert that can sign on this machine; grep matches either the CN
+# or the SHA-1 fingerprint form.
+if ! security find-identity -v -p codesigning 2>/dev/null | grep -qF "$IDENTITY"; then
+  cat >&2 <<EOF
+scripts/sign.sh: codesign identity not found on this machine.
+
+  identity: $IDENTITY
+
+Run \`security find-identity -v -p codesigning\` to see what is available.
+To install the Developer ID Application cert on a fresh build machine, see
+$RUNBOOK.
+
+To override the identity (e.g., a contributor's own cert), set
+AGENTCOOKIE_SIGN_IDENTITY before invoking make / scripts/sign.sh.
+EOF
+  exit 2
+fi
+
+for binary in "$@"; do
+  if [[ ! -f "$binary" ]]; then
+    echo "scripts/sign.sh: $binary: no such file" >&2
+    exit 1
+  fi
+
+  echo "scripts/sign.sh: signing $binary"
+  codesign \
+    --force \
+    --options runtime \
+    --timestamp \
+    --sign "$IDENTITY" \
+    "$binary"
+
+  echo "scripts/sign.sh: verifying $binary"
+  codesign --verify --deep --strict --verbose=2 "$binary"
+done
+
+echo "scripts/sign.sh: done"


### PR DESCRIPTION
## Summary

- Add `scripts/sign.sh`, `Makefile`, and CI signing wiring so every agentcookie binary carries a stable Developer ID Application code signature.
- Default `make` target is `build sign`. `make build` alone does not require the cert so contributors without Developer ID can still build and test.
- Hardened Runtime + secure timestamp set so the binary qualifies for notarization later if desired.
- Adds `docs/runbook-v0.12-codesign.md` covering cert install, CI secret upload, renewal, troubleshooting.

This is U0 of the v0.12 security hardening plan and a prerequisite for U5-U7 (Keychain ACL replacement, sealed sidecar, sealed adapter caches). The plan needs the signed binary's designated requirement to be stable across rebuilds so per-binary `-T` Keychain ACLs survive every `go install` — that property is verified below.

## Test plan

- [x] `make build && make sign` produces a binary with `subject.OU = NM8VT393AR` in its designated requirement
- [x] Two consecutive clean rebuilds produce byte-identical `codesign -d -r-` output
- [x] `codesign --verify --deep --strict --verbose=2` clean
- [x] Missing-identity edge case exits non-zero with a message pointing at the runbook
- [x] `go test -race ./...` passes across all 16 packages
- [x] `goreleaser check` and `goreleaser build --snapshot --single-target` pass

## Note

The release workflow refers to `CERTIFICATE_OSX_APPLICATION` and `CERTIFICATE_OSX_APPLICATION_PASSWORD` GitHub Actions secrets that must be added before the first signed release tag. Snapshot builds work without them.

Generated with [Claude Code](https://claude.com/claude-code).