### PR TITLE
feat(v0.12 U3): persist replay-defense state across sink restarts

### DIFF
--- a/internal/cli/sink.go
+++ b/internal/cli/sink.go
@@ -85,10 +85,19 @@ func runSink(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(os.Stderr, "agentcookie sink: blocklist has %d opt-out patterns\n", blockMatcher.PatternCount())
 	}
 
-	seqTracker := protocol.NewSequenceTracker()
+	// Persistent replay-defense state. Survives sink restart so a
+	// captured /sync envelope cannot be replayed after a reboot. A
+	// corrupt sequence.json fails the sink boot rather than silently
+	// resetting the high-water marks (which would reopen the replay
+	// window). Operator recovery: delete ~/.agentcookie/sequence.json.
+	home, _ := os.UserHomeDir()
+	seqStore := protocol.NewFileSequenceStore(protocol.DefaultSequencePath(home))
+	seqTracker, err := protocol.NewTrackerFromStore(seqStore)
+	if err != nil {
+		return fmt.Errorf("load replay-defense state: %w", err)
+	}
 
 	// State writer for `agentcookie status` to read.
-	home, _ := os.UserHomeDir()
 	stateWriter := state.NewWriter(state.SinkPath(home))
 	sinkState := &state.SinkState{
 		Role:       "sink",

--- a/internal/cli/source.go
+++ b/internal/cli/source.go
@@ -210,7 +210,7 @@ func pushOnce(
 	envelope := protocol.SyncEnvelope{
 		ProtocolVersion:     protocol.Version,
 		SourceHostname:      pairing.LocalHostname(),
-		Sequence:            time.Now().Unix(),
+		Sequence:            time.Now().UnixNano(),
 		Cookies:             all,
 		LocalStorageTarball: lsTarball,
 		IndexedDBTarball:    idbTarball,

--- a/internal/protocol/sequence.go
+++ b/internal/protocol/sequence.go
@@ -1,34 +1,79 @@
 package protocol
 
 import (
+	"fmt"
 	"sync"
 )
 
-// SequenceTracker is the sink's in-memory record of the highest Sequence
-// number seen per source. Rejects equal-or-lower numbers to defend against
-// replay of captured payloads. State is process-local; it resets on restart,
-// at which point a stale captured payload could once again be played. That
-// trade-off is acceptable for v0.1; durable replay defense lands when the
-// envelope grows a nonce or timestamp window.
+// SequenceTracker is the sink's record of the highest Sequence number
+// seen per source. Rejects equal-or-lower numbers to defend against
+// replay of captured payloads. State is now persisted via SequenceStore
+// (typically ~/.agentcookie/sequence.json) so a sink restart does not
+// re-open a replay window. v0.12 also sources Sequence at nanosecond
+// granularity (internal/cli/source.go) so rapid syncs do not collide;
+// the tracker remains backward-compatible with legacy 1-second-grained
+// sequences because it only requires strict monotonic increase.
 type SequenceTracker struct {
-	mu   sync.Mutex
-	seen map[string]int64
+	mu    sync.Mutex
+	seen  map[string]int64
+	store SequenceStore
 }
 
-// NewSequenceTracker returns a fresh tracker.
+// NewSequenceTracker returns a fresh tracker with no persistence. Kept
+// for tests and for callers that genuinely want in-memory state. Sink
+// code should use NewTrackerFromStore so state survives restart.
 func NewSequenceTracker() *SequenceTracker {
-	return &SequenceTracker{seen: make(map[string]int64)}
+	return &SequenceTracker{
+		seen:  map[string]int64{},
+		store: NewMemorySequenceStore(nil),
+	}
 }
 
-// Accept returns true if seq is strictly greater than the highest previously
-// seen value for source. Updates the record on accept.
+// NewTrackerFromStore loads existing high-water marks from store and
+// returns a tracker that writes through to store on every accepted
+// envelope. A corrupt or otherwise unreadable store causes a startup
+// error so the sink refuses to boot (a silent fall-through to an
+// empty tracker would re-open the replay window the persistence is
+// meant to close).
+func NewTrackerFromStore(store SequenceStore) (*SequenceTracker, error) {
+	if store == nil {
+		return nil, fmt.Errorf("nil SequenceStore")
+	}
+	state, err := store.Load()
+	if err != nil {
+		return nil, err
+	}
+	if state == nil {
+		state = map[string]int64{}
+	}
+	return &SequenceTracker{seen: state, store: store}, nil
+}
+
+// Accept returns true if seq is strictly greater than the highest
+// previously seen value for source. Updates the in-memory record AND
+// the persistent store on accept; if the persistent store write fails
+// the in-memory update is rolled back and Accept returns false to
+// avoid acknowledging a write that did not survive a restart.
 func (t *SequenceTracker) Accept(source string, seq int64) bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	if last, ok := t.seen[source]; ok && seq <= last {
+	prev, hadPrev := t.seen[source]
+	if hadPrev && seq <= prev {
 		return false
 	}
 	t.seen[source] = seq
+	if t.store != nil {
+		if err := t.store.Save(t.seen); err != nil {
+			// Roll back the in-memory update so the persistent and
+			// in-memory state stay consistent across restarts.
+			if hadPrev {
+				t.seen[source] = prev
+			} else {
+				delete(t.seen, source)
+			}
+			return false
+		}
+	}
 	return true
 }
 

--- a/internal/protocol/sequence_store.go
+++ b/internal/protocol/sequence_store.go
@@ -1,0 +1,145 @@
+package protocol
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// SequenceStore is the persistence backend a SequenceTracker reads at
+// startup and writes to on every accepted envelope. The default
+// implementation is fileSequenceStore at ~/.agentcookie/sequence.json
+// (mode 0600). Tests inject MemorySequenceStore or a path under
+// t.TempDir() to keep the on-disk file out of the user's home.
+type SequenceStore interface {
+	// Load returns the persisted map of source-hostname to highest
+	// accepted sequence. A missing file is not an error; Load returns
+	// an empty map and nil. A present-but-corrupt file IS an error,
+	// surfaced so the sink can refuse to start.
+	Load() (map[string]int64, error)
+	// Save writes state atomically (write-tmp-then-rename) at mode 0600.
+	Save(state map[string]int64) error
+}
+
+// fileSequenceStore writes JSON to a path on disk. Atomic via
+// CreateTemp + Rename, mirroring internal/state/state.go.Writer.Save.
+type fileSequenceStore struct {
+	path string
+}
+
+// NewFileSequenceStore returns a SequenceStore backed by path. The
+// parent directory is created (mode 0700) on the first Save when
+// missing. path is typically filepath.Join(home, ".agentcookie",
+// "sequence.json").
+func NewFileSequenceStore(path string) SequenceStore {
+	return &fileSequenceStore{path: path}
+}
+
+// DefaultSequencePath is the canonical on-disk location of the
+// persistent replay-defense state.
+func DefaultSequencePath(home string) string {
+	return filepath.Join(home, ".agentcookie", "sequence.json")
+}
+
+func (s *fileSequenceStore) Load() (map[string]int64, error) {
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]int64{}, nil
+		}
+		return nil, fmt.Errorf("read sequence state %s: %w", s.path, err)
+	}
+	// Empty file is treated as fresh state (no high-water marks yet).
+	if len(data) == 0 {
+		return map[string]int64{}, nil
+	}
+	state := map[string]int64{}
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, fmt.Errorf("parse sequence state %s: %w (delete this file to reset replay-defense state)", s.path, err)
+	}
+	return state, nil
+}
+
+func (s *fileSequenceStore) Save(state map[string]int64) error {
+	dir := filepath.Dir(s.path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("ensure sequence dir %s: %w", dir, err)
+	}
+	tmp, err := os.CreateTemp(dir, ".tmp-sequence-*.json")
+	if err != nil {
+		return fmt.Errorf("create tmp sequence file in %s: %w", dir, err)
+	}
+	tmpName := tmp.Name()
+	// Best-effort chmod on the tmp file before write; final rename
+	// preserves these bits on the destination.
+	if err := os.Chmod(tmpName, 0o600); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return fmt.Errorf("chmod tmp sequence file: %w", err)
+	}
+	enc := json.NewEncoder(tmp)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(state); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return fmt.Errorf("encode sequence state: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("close tmp sequence file: %w", err)
+	}
+	if err := os.Rename(tmpName, s.path); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("rename sequence file into place: %w", err)
+	}
+	return nil
+}
+
+// MemorySequenceStore is an in-memory SequenceStore for tests. Captures
+// every Save so test assertions can verify write-through behavior.
+type MemorySequenceStore struct {
+	State     map[string]int64
+	SaveCount int
+	// FailLoad, when non-nil, is returned from Load. Lets tests
+	// exercise the sink-refuse-to-start path without writing a
+	// corrupt file to disk.
+	FailLoad error
+	// FailSave, when non-nil, is returned from every Save call. Lets
+	// tests exercise the write-through failure path.
+	FailSave error
+}
+
+// NewMemorySequenceStore returns a MemorySequenceStore seeded with the
+// given state. Pass nil for an empty store.
+func NewMemorySequenceStore(seed map[string]int64) *MemorySequenceStore {
+	st := map[string]int64{}
+	for k, v := range seed {
+		st[k] = v
+	}
+	return &MemorySequenceStore{State: st}
+}
+
+func (m *MemorySequenceStore) Load() (map[string]int64, error) {
+	if m.FailLoad != nil {
+		return nil, m.FailLoad
+	}
+	out := map[string]int64{}
+	for k, v := range m.State {
+		out[k] = v
+	}
+	return out, nil
+}
+
+func (m *MemorySequenceStore) Save(state map[string]int64) error {
+	if m.FailSave != nil {
+		return m.FailSave
+	}
+	m.SaveCount++
+	cp := map[string]int64{}
+	for k, v := range state {
+		cp[k] = v
+	}
+	m.State = cp
+	return nil
+}

--- a/internal/protocol/sequence_test.go
+++ b/internal/protocol/sequence_test.go
@@ -1,0 +1,213 @@
+package protocol
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestPersistentTracker_WriteThroughOnEachAccept exercises the happy
+// path: every accepted envelope causes the store to see the new
+// high-water mark, so a subsequent process can read it back.
+func TestPersistentTracker_WriteThroughOnEachAccept(t *testing.T) {
+	store := NewMemorySequenceStore(nil)
+	tr, err := NewTrackerFromStore(store)
+	if err != nil {
+		t.Fatalf("NewTrackerFromStore: %v", err)
+	}
+	if !tr.Accept("laptop", 1000) {
+		t.Fatal("first sequence must be accepted")
+	}
+	if got := store.State["laptop"]; got != 1000 {
+		t.Errorf("store did not see 1000 after first accept; got %d", got)
+	}
+	if !tr.Accept("laptop", 2000) {
+		t.Fatal("higher sequence must be accepted")
+	}
+	if got := store.State["laptop"]; got != 2000 {
+		t.Errorf("store did not see 2000 after second accept; got %d", got)
+	}
+	if store.SaveCount != 2 {
+		t.Errorf("expected 2 saves, got %d", store.SaveCount)
+	}
+}
+
+// TestPersistentTracker_RejectsReplayAfterRestart simulates a sink
+// restart: build a fresh tracker from the same store and confirm a
+// captured payload at or below the prior high-water mark is rejected.
+// This is the regression that closes S9: in v0.11, a restart cleared
+// the in-memory map and reopened the replay window.
+func TestPersistentTracker_RejectsReplayAfterRestart(t *testing.T) {
+	store := NewMemorySequenceStore(nil)
+	tr, err := NewTrackerFromStore(store)
+	if err != nil {
+		t.Fatalf("NewTrackerFromStore: %v", err)
+	}
+	if !tr.Accept("laptop", 5000) {
+		t.Fatal("first sequence must be accepted")
+	}
+	// Simulate restart: same backing store, new tracker.
+	tr2, err := NewTrackerFromStore(store)
+	if err != nil {
+		t.Fatalf("NewTrackerFromStore (restart): %v", err)
+	}
+	if tr2.Accept("laptop", 5000) {
+		t.Fatal("replay of last-seen sequence must be rejected after restart")
+	}
+	if tr2.Accept("laptop", 4999) {
+		t.Fatal("lower sequence must be rejected after restart")
+	}
+	if !tr2.Accept("laptop", 5001) {
+		t.Fatal("strictly higher sequence must still be accepted after restart")
+	}
+}
+
+// TestPersistentTracker_NanosecondGranularity asserts that two
+// envelopes generated within a microsecond of each other can both be
+// accepted, which is the source-side regression v0.12 closes by
+// switching time.Now().Unix() to time.Now().UnixNano().
+func TestPersistentTracker_NanosecondGranularity(t *testing.T) {
+	store := NewMemorySequenceStore(nil)
+	tr, err := NewTrackerFromStore(store)
+	if err != nil {
+		t.Fatalf("NewTrackerFromStore: %v", err)
+	}
+	// Two sequences within 1 microsecond of each other. With Unix()
+	// seconds these would collide (same value, second rejected as
+	// replay). With UnixNano() they are distinct positive int64s.
+	seq1 := int64(1_700_000_000_000_000_000)
+	seq2 := seq1 + 250 // 250 nanoseconds later
+	if !tr.Accept("laptop", seq1) {
+		t.Fatal("first nano sequence must be accepted")
+	}
+	if !tr.Accept("laptop", seq2) {
+		t.Fatal("250ns-later sequence must be accepted with nano granularity")
+	}
+}
+
+// TestNewTrackerFromStore_CorruptFile asserts that a corrupt
+// sequence.json fails the tracker constructor so the sink boot path
+// can surface a clear error to the operator. Silently falling through
+// to an empty tracker would re-open the replay window.
+func TestNewTrackerFromStore_CorruptFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sequence.json")
+	if err := os.WriteFile(path, []byte("not json {"), 0o600); err != nil {
+		t.Fatalf("seed corrupt file: %v", err)
+	}
+	store := NewFileSequenceStore(path)
+	tr, err := NewTrackerFromStore(store)
+	if err == nil {
+		t.Fatalf("expected error from corrupt sequence file, got tracker %+v", tr)
+	}
+	// Surface the recovery instruction in the error message so an
+	// operator sees what to do.
+	if msg := err.Error(); msg == "" {
+		t.Errorf("expected non-empty error message, got %q", msg)
+	}
+}
+
+// TestNewTrackerFromStore_MissingFile asserts that a missing
+// sequence.json on first-ever boot initializes an empty tracker
+// without error.
+func TestNewTrackerFromStore_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sequence.json")
+	store := NewFileSequenceStore(path)
+	tr, err := NewTrackerFromStore(store)
+	if err != nil {
+		t.Fatalf("missing file should not error, got: %v", err)
+	}
+	if tr.Last("laptop") != 0 {
+		t.Errorf("expected empty tracker, got Last=%d", tr.Last("laptop"))
+	}
+	if !tr.Accept("laptop", 100) {
+		t.Fatal("first accept on empty tracker must succeed")
+	}
+}
+
+// TestPersistentTracker_FileBackingRoundTrip wires the real
+// fileSequenceStore (under t.TempDir()) and exercises the full
+// load -> accept -> save -> reload cycle.
+func TestPersistentTracker_FileBackingRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sequence.json")
+	store := NewFileSequenceStore(path)
+	tr, err := NewTrackerFromStore(store)
+	if err != nil {
+		t.Fatalf("NewTrackerFromStore: %v", err)
+	}
+	if !tr.Accept("a", 100) || !tr.Accept("b", 200) || !tr.Accept("a", 150) {
+		t.Fatal("unexpected reject during seed")
+	}
+	// File should exist now with mode 0600.
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat sequence file: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("expected mode 0600, got %o", info.Mode().Perm())
+	}
+	// Restart cycle.
+	tr2, err := NewTrackerFromStore(NewFileSequenceStore(path))
+	if err != nil {
+		t.Fatalf("NewTrackerFromStore (reload): %v", err)
+	}
+	if tr2.Last("a") != 150 || tr2.Last("b") != 200 {
+		t.Errorf("reload lost state: a=%d b=%d", tr2.Last("a"), tr2.Last("b"))
+	}
+	if tr2.Accept("a", 150) {
+		t.Error("replay at last high-water mark must be rejected after reload")
+	}
+	if tr2.Accept("b", 100) {
+		t.Error("lower sequence must be rejected after reload")
+	}
+}
+
+// TestPersistentTracker_RollsBackOnSaveFailure asserts that a Save
+// failure does not leave the in-memory map ahead of disk. If the
+// save fails, the in-memory high-water mark stays at the prior value
+// so the sink does not later reject a legitimate retry.
+func TestPersistentTracker_RollsBackOnSaveFailure(t *testing.T) {
+	store := NewMemorySequenceStore(map[string]int64{"laptop": 100})
+	tr, err := NewTrackerFromStore(store)
+	if err != nil {
+		t.Fatalf("NewTrackerFromStore: %v", err)
+	}
+	store.FailSave = errors.New("simulated disk failure")
+	if tr.Accept("laptop", 200) {
+		t.Fatal("Accept must return false when Save fails")
+	}
+	// In-memory state must be rolled back to the prior high-water.
+	if got := tr.Last("laptop"); got != 100 {
+		t.Errorf("expected rollback to 100, got %d", got)
+	}
+	// Recover: subsequent successful save should accept 200.
+	store.FailSave = nil
+	if !tr.Accept("laptop", 200) {
+		t.Fatal("Accept must succeed once Save recovers")
+	}
+}
+
+// TestPersistentTracker_LegacySecondGranularityStillWorks is the
+// regression scenario for the plan's "legacy sources sending
+// 1-second sequences" requirement.
+func TestPersistentTracker_LegacySecondGranularityStillWorks(t *testing.T) {
+	store := NewMemorySequenceStore(nil)
+	tr, err := NewTrackerFromStore(store)
+	if err != nil {
+		t.Fatalf("NewTrackerFromStore: %v", err)
+	}
+	// Two legacy syncs one second apart.
+	if !tr.Accept("legacy", 1_700_000_000) {
+		t.Fatal("first legacy sequence must be accepted")
+	}
+	if !tr.Accept("legacy", 1_700_000_001) {
+		t.Fatal("monotonically increasing legacy sequence must be accepted")
+	}
+	// Replay rejected as before.
+	if tr.Accept("legacy", 1_700_000_001) {
+		t.Error("legacy replay must be rejected")
+	}
+}


### PR DESCRIPTION
## Summary

- Replay tracker (`internal/protocol/SequenceTracker`) now persists last-seen sequence per peer to `~/.agentcookie/sequence.json` (mode 0600, atomic write-tmp-then-rename).
- Source bumps sequence granularity from `time.Now().Unix()` to `time.Now().UnixNano()` so two syncs within the same wall second no longer collide.
- Sink boot loads the persistent state via `NewTrackerFromStore`; a captured `/sync` envelope replayed after sink restart is now correctly rejected.
- Corrupt `sequence.json` surfaces a clear `delete this file to reset replay-defense state` message rather than silently truncating; missing file initializes empty.

Closes U3 of the v0.12 security plan (`docs/plans/2026-05-18-002`).

## Test plan

- [x] `go test -race ./...` passes — 191 tests in 20 packages
- [x] New `internal/protocol/sequence_test.go` covers write-through, restart-rejects-replay, nanosecond granularity, corrupt file, missing file, save-failure rollback, and 1-second-legacy regression
- [x] Mirrors the `internal/state/state.go` atomic-write pattern

Generated with [Claude Code](https://claude.com/claude-code).