### PR TITLE
feat(v0.12 U1): refuse 0.0.0.0; require Tailscale interface for listeners

### DIFF
--- a/examples/sink.yaml
+++ b/examples/sink.yaml
@@ -2,8 +2,11 @@
 # where your AI agents run (your Mac mini, cloud VM, etc.).
 
 listen:
-  # Address the sink's /sync HTTP listener binds to. Bind to your tailnet IP
-  # not 0.0.0.0. Defaults to 127.0.0.1:9999 if omitted.
+  # Address the sink's /sync HTTP listener binds to. Must be your
+  # tailnet 100.x address, or "127.0.0.1" for local-dev testing.
+  # v0.12 hardening (S1): the sink refuses to start on 0.0.0.0 or
+  # any non-tailnet routable address. `agentcookie wizard install
+  # --as sink` writes the resolved 100.x address automatically.
   addr: 100.x.y.z:9999
 
 cdp:

--- a/internal/cli/pair.go
+++ b/internal/cli/pair.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/mvanhorn/agentcookie/internal/keystore"
 	"github.com/mvanhorn/agentcookie/internal/pairing"
+	"github.com/mvanhorn/agentcookie/internal/tsclient"
 )
 
 var (
@@ -47,7 +48,11 @@ than reading 'security.shared_secret' from those files.`,
 
 func init() {
 	pairCmd.Flags().StringVar(&pairRole, "as", "", "role: source | sink (required)")
-	pairCmd.Flags().StringVar(&pairListenAddr, "listen", "0.0.0.0:9998", "[source] address to listen on for the sink handshake")
+	// v0.12 S1: --listen no longer defaults to 0.0.0.0:9998. Empty
+	// triggers tailnet auto-detection; an explicit value is validated
+	// against the same tailnet-or-loopback policy. The detection-failed
+	// path fails loud rather than falling through to every interface.
+	pairCmd.Flags().StringVar(&pairListenAddr, "listen", "", "[source] address to listen on for the sink handshake (default: this machine's Tailscale 100.x:9998)")
 	pairCmd.Flags().StringVar(&pairLocalName, "local-name", "", "hostname identifier announced to the peer (defaults to os.Hostname)")
 	pairCmd.Flags().StringVar(&pairPeerURL, "pair-url", "", "[sink] full URL of the source's /pair endpoint")
 	pairCmd.Flags().StringVar(&pairCode, "code", "", "[sink] pairing code printed by the source")
@@ -69,7 +74,20 @@ func runPair(cmd *cobra.Command, args []string) error {
 }
 
 func runPairAsSource(ctx context.Context) error {
-	res, _, err := pairing.RunSource(ctx, pairListenAddr, pairLocalName, os.Stderr)
+	// v0.12 S1: resolve and validate the pair listener address before
+	// binding. Empty -> auto-detect tailnet 100.x; explicit -> must be
+	// tailnet or loopback. 0.0.0.0 is refused.
+	listenAddr := pairListenAddr
+	if listenAddr == "" {
+		ip, err := tsclient.RequireTailnetIP(ctx)
+		if err != nil {
+			return fmt.Errorf("detect Tailscale 100.x address for pair listener: %w", err)
+		}
+		listenAddr = fmt.Sprintf("%s:9998", ip)
+	} else if err := validateListenAddr(listenAddr); err != nil {
+		return fmt.Errorf("pair listen %q: %w", listenAddr, err)
+	}
+	res, _, err := pairing.RunSource(ctx, listenAddr, pairLocalName, os.Stderr)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/sink.go
+++ b/internal/cli/sink.go
@@ -56,6 +56,14 @@ func runSink(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// v0.12 S1: refuse to start on 0.0.0.0 or any non-tailnet address.
+	// Catches the case where an old sink.yaml has the v0.11 permissive
+	// default baked in, OR a user hand-edited the file. Explicit
+	// 127.0.0.1 stays allowed for local-dev binding (operator typed it).
+	if err := validateListenAddr(cfg.Listen.Addr); err != nil {
+		return fmt.Errorf("sink listen %q: %w", cfg.Listen.Addr, err)
+	}
+
 	var key []byte
 	if !sinkDryRun {
 		password, err := chrome.SafeStoragePassword()

--- a/internal/cli/sink_test.go
+++ b/internal/cli/sink_test.go
@@ -1,0 +1,129 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestValidateListenAddr_PolicyMatrix exercises the v0.12 S1 binding
+// policy enforced by validateListenAddr. The runtime sink startup
+// guard and the wizard's --listen flag both call this; one table
+// keeps the two callers honest about identical semantics.
+func TestValidateListenAddr_PolicyMatrix(t *testing.T) {
+	cases := []struct {
+		name      string
+		addr      string
+		wantErr   bool
+		wantInMsg string // substring asserted when wantErr is true
+	}{
+		// Refused: any-interface binds.
+		{
+			name:      "refuses 0.0.0.0",
+			addr:      "0.0.0.0:9999",
+			wantErr:   true,
+			wantInMsg: "every interface",
+		},
+		{
+			name:      "refuses :: (IPv6 any)",
+			addr:      "[::]:9999",
+			wantErr:   true,
+			wantInMsg: "every interface",
+		},
+		{
+			name:      "refuses bare :port (empty host)",
+			addr:      ":9999",
+			wantErr:   true,
+			wantInMsg: "every interface",
+		},
+
+		// Refused: non-tailnet routable address.
+		{
+			name:      "refuses LAN 192.168.x",
+			addr:      "192.168.1.5:9999",
+			wantErr:   true,
+			wantInMsg: "not a Tailscale 100.x address",
+		},
+		{
+			name:      "refuses 100.x but outside CGNAT block",
+			addr:      "100.63.0.5:9999",
+			wantErr:   true,
+			wantInMsg: "not a Tailscale 100.x address",
+		},
+
+		// Refused: unparseable input. SplitHostPort is loose about
+		// what it accepts as a host token (whitespace is fine), so
+		// the test case picks an input it definitively rejects:
+		// no port separator.
+		{
+			name:      "refuses input with no port",
+			addr:      "no-colon-here",
+			wantErr:   true,
+			wantInMsg: "host:port",
+		},
+
+		// Accepted: explicit loopback, tailnet 100.x.
+		{
+			name: "accepts 127.0.0.1 (operator-typed local dev)",
+			addr: "127.0.0.1:9999",
+		},
+		{
+			name: "accepts ::1 loopback",
+			addr: "[::1]:9999",
+		},
+		{
+			name: "accepts localhost",
+			addr: "localhost:9999",
+		},
+		{
+			name: "accepts tailnet 100.80.x",
+			addr: "100.80.229.80:9999",
+		},
+		{
+			name: "accepts tailnet boundary 100.64.0.1",
+			addr: "100.64.0.1:9999",
+		},
+		{
+			name: "accepts tailnet upper boundary 100.127.255.254",
+			addr: "100.127.255.254:9999",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateListenAddr(tc.addr)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q, got nil", tc.addr)
+				}
+				if !strings.Contains(err.Error(), tc.wantInMsg) {
+					t.Errorf("error for %q: got %v, want substring %q", tc.addr, err, tc.wantInMsg)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error for %q: %v", tc.addr, err)
+			}
+		})
+	}
+}
+
+// TestValidateListenAddr_RefusesV011DefaultFallback documents the
+// specific regression v0.12 closes. The pre-v0.12 wizard fell through
+// to "0.0.0.0:9999" when Tailscale detection failed, and the config
+// loader added a second silent fallback to "127.0.0.1:9999" on empty.
+// A sink that ends up bound to 0.0.0.0 at runtime must now refuse
+// to start so the operator sees the failure rather than serving
+// publicly.
+func TestValidateListenAddr_RefusesV011DefaultFallback(t *testing.T) {
+	err := validateListenAddr("0.0.0.0:9999")
+	if err == nil {
+		t.Fatal("v0.12: sink listener must refuse 0.0.0.0:9999")
+	}
+	// Operator-facing message must name the v0.12 remediation surfaces.
+	if !strings.Contains(err.Error(), "tailscale status") {
+		t.Errorf("error should name `tailscale status`: %v", err)
+	}
+	if !strings.Contains(err.Error(), "docs/quickstart.md") {
+		t.Errorf("error should name docs/quickstart.md: %v", err)
+	}
+}

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -159,9 +159,20 @@ func wizardInstallSource(ctx context.Context, binPath, logDir string) error {
 		fmt.Fprintf(os.Stderr, "agentcookie wizard: existing paired key for %q found; skipping pairing (use --repair to force)\n", wizardPeer)
 	} else {
 		// Step 3: run source-side pairing in foreground.
+		// v0.12 S1: refuse 0.0.0.0. The pair listener is reached over
+		// the tailnet; binding on every interface makes a flaky
+		// detection at install time silently turn a personal pair
+		// endpoint into an internet-reachable one. The wizard now
+		// fails loud if Tailscale isn't usable.
 		listen := wizardListen
 		if listen == "" {
-			listen = "0.0.0.0:9998"
+			ip, err := tsclient.RequireTailnetIP(ctx)
+			if err != nil {
+				return fmt.Errorf("detect Tailscale 100.x address for pair listener: %w", err)
+			}
+			listen = fmt.Sprintf("%s:9998", ip)
+		} else if err := validateListenAddr(listen); err != nil {
+			return fmt.Errorf("--listen %q: %w", listen, err)
 		}
 		// Write a pairing info file so an SSH'ing agent can grab it.
 		pairingInfo, code, err := beginSourcePairing(ctx, listen, wizardLocalName, binPath, logDir)
@@ -201,12 +212,27 @@ func wizardInstallSink(ctx context.Context, binPath, logDir string) error {
 		return err
 	}
 
-	if err := writeYAMLIfMissing(
-		filepath.Join(common.ConfigDir, "sink.yaml"),
-		renderSinkYAML(wizardPeer),
-		wizardForce,
-	); err != nil {
-		return err
+	// v0.12 S1: resolve the tailnet 100.x address BEFORE writing
+	// sink.yaml. If Tailscale is not up the helper returns a
+	// structured error and we refuse to write a permissive default.
+	// On an existing v0.11 install the sink.yaml already has a
+	// concrete 100.x address; writeYAMLIfMissing skips re-writing
+	// it unless --force is set, so this detection only fires for
+	// fresh installs and explicit --force overwrites.
+	sinkYAMLPath := filepath.Join(common.ConfigDir, "sink.yaml")
+	if wizardForce || !fileExists(sinkYAMLPath) {
+		ip, err := tsclient.RequireTailnetIP(ctx)
+		if err != nil {
+			return fmt.Errorf("detect Tailscale 100.x address for sink listener: %w", err)
+		}
+		listenAddr := fmt.Sprintf("%s:9999", ip)
+		if err := writeYAMLIfMissing(
+			sinkYAMLPath,
+			renderSinkYAML(wizardPeer, listenAddr),
+			wizardForce,
+		); err != nil {
+			return err
+		}
 	}
 	if err := writeYAMLIfMissing(
 		filepath.Join(common.ConfigDir, "blocklist.yaml"),
@@ -548,9 +574,12 @@ peer:
 `, sinkURL, peer)
 }
 
-func renderSinkYAML(peer string) string {
-	// Bind to the local tailnet IP for sink listener if available; otherwise 0.0.0.0:9999.
-	listenAddr := defaultSinkListenAddr()
+// renderSinkYAML formats sink.yaml with a caller-resolved listen
+// address. The wizard install path is the only place that calls this,
+// and it resolves listenAddr via tsclient.RequireTailnetIP first so a
+// detection failure refuses to write sink.yaml rather than silently
+// falling through to a permissive default. See v0.12 S1.
+func renderSinkYAML(peer, listenAddr string) string {
 	// v0.7: cdp.enabled is gone. Direct SQLite + leveldb file writes are
 	// the only path. The Chrome quit/relaunch ceremony around each sync
 	// is handled by the chromectl package.
@@ -561,22 +590,32 @@ peer:
 `, listenAddr, peer)
 }
 
-func defaultSinkListenAddr() string {
-	// Prefer a Tailscale IP if we can find one in 100.64.0.0/10 on a local interface.
-	addrs, err := net.InterfaceAddrs()
-	if err == nil {
-		for _, a := range addrs {
-			ipnet, ok := a.(*net.IPNet)
-			if !ok || ipnet.IP.To4() == nil {
-				continue
-			}
-			ip := ipnet.IP.To4()
-			if ip[0] == 100 && ip[1] >= 64 && ip[1] <= 127 {
-				return fmt.Sprintf("%s:9999", ip.String())
-			}
-		}
+// validateListenAddr enforces the v0.12 binding policy on a configured
+// listen address: must be tailnet (100.x) or an explicit local-dev
+// loopback. 0.0.0.0 and other any-interface binds are rejected. Used
+// by the wizard when --listen is passed explicitly, and by the sink
+// and pair runtime startup guards.
+//
+// The address string is in "host:port" form. Anything that does not
+// parse cleanly is rejected with a wrapping error so the caller can
+// surface "what you passed" plus the policy explanation.
+func validateListenAddr(addr string) error {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return fmt.Errorf("parse host:port: %w (v0.12 requires a tailnet 100.x address; see docs/quickstart.md)", err)
 	}
-	return "0.0.0.0:9999"
+	switch host {
+	case "0.0.0.0", "::", "":
+		return fmt.Errorf("refuses to bind on %q (every interface); v0.12 requires a tailnet 100.x address (run `tailscale status` and re-run; see docs/quickstart.md)", host)
+	case "127.0.0.1", "::1", "localhost":
+		// Explicit loopback is allowed for local-dev / test setups.
+		// Not the default fallback path; the operator typed it.
+		return nil
+	}
+	if tsclient.IsTailnetIP(host) {
+		return nil
+	}
+	return fmt.Errorf("refuses to bind on %q: not a Tailscale 100.x address (v0.12 hardening; pin a 100.x IP from `tailscale status` or use 127.0.0.1 for local dev)", host)
 }
 
 func starterBlocklistYAML() string {

--- a/internal/cli/wizard_test.go
+++ b/internal/cli/wizard_test.go
@@ -1,0 +1,58 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRenderSinkYAML_WritesResolvedAddr proves the wizard pipes the
+// resolved tailnet IP into sink.yaml verbatim. Pre-v0.12 the render
+// helper called net.InterfaceAddrs directly and fell through to
+// 0.0.0.0:9999 on failure; the v0.12 shape takes the address as an
+// argument so the call site can call tsclient.RequireTailnetIP and
+// fail loud before we ever reach this helper.
+func TestRenderSinkYAML_WritesResolvedAddr(t *testing.T) {
+	got := renderSinkYAML("my-laptop", "100.80.229.80:9999")
+	if !strings.Contains(got, "addr: 100.80.229.80:9999") {
+		t.Errorf("expected listen.addr in YAML, got:\n%s", got)
+	}
+	if !strings.Contains(got, "hostname: my-laptop") {
+		t.Errorf("expected peer.hostname in YAML, got:\n%s", got)
+	}
+	if strings.Contains(got, "0.0.0.0") {
+		t.Errorf("v0.12: sink.yaml must never carry 0.0.0.0; got:\n%s", got)
+	}
+}
+
+// TestValidateListenAddr_AcceptsExplicitOperatorInput is the regression
+// guard for the wizard's --listen flag. An operator passing an
+// explicit value (during local dev or for an unusual deployment) must
+// be allowed through if it matches the policy. The empty-flag path is
+// the one that auto-detects; this test covers the explicit path.
+func TestValidateListenAddr_AcceptsExplicitOperatorInput(t *testing.T) {
+	ok := []string{
+		"100.80.229.80:9998",
+		"127.0.0.1:9998",
+		"localhost:9998",
+	}
+	for _, addr := range ok {
+		if err := validateListenAddr(addr); err != nil {
+			t.Errorf("validateListenAddr(%q) unexpectedly errored: %v", addr, err)
+		}
+	}
+
+	refused := map[string]string{
+		"0.0.0.0:9998":   "every interface",
+		"192.168.1.5:9998": "not a Tailscale 100.x address",
+	}
+	for addr, want := range refused {
+		err := validateListenAddr(addr)
+		if err == nil {
+			t.Errorf("validateListenAddr(%q) should have errored", addr)
+			continue
+		}
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("validateListenAddr(%q): error %v, want substring %q", addr, err, want)
+		}
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -85,8 +85,14 @@ func LoadSink(dir string) (*SinkConfig, error) {
 		return nil, err
 	}
 	cfg.Chrome.DBPath = ExpandTilde(cfg.Chrome.DBPath)
+	// v0.12 S1: no permissive default for listen.addr. Pre-v0.12 sink.yaml
+	// files that omit the address used to fall through to 127.0.0.1:9999;
+	// that masked the wizard's silent-detection-failure -> 0.0.0.0 path
+	// further upstream. Empty here is now a config error; the wizard
+	// install writes a concrete tailnet 100.x address (see
+	// internal/tsclient.RequireTailnetIP).
 	if cfg.Listen.Addr == "" {
-		cfg.Listen.Addr = "127.0.0.1:9999"
+		return nil, fmt.Errorf("%s: listen.addr is required (run `agentcookie wizard install --as sink` to detect your Tailscale 100.x address, or set it explicitly)", path)
 	}
 	if cfg.Peer.Hostname == "" && cfg.Security.SharedSecret == "" {
 		return nil, fmt.Errorf("%s: either peer.hostname (paired key) or security.shared_secret (legacy) is required", path)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -62,9 +62,30 @@ sink:
 	}
 }
 
-func TestLoadSinkDefaultsListenAddr(t *testing.T) {
+func TestLoadSinkEmptyListenIsError(t *testing.T) {
+	// v0.12 S1: a sink.yaml without listen.addr used to fall through to
+	// 127.0.0.1:9999. That made the wizard's silent-detection-failure
+	// path one layer harder to spot. Now empty is a config error and the
+	// wizard install is the only place that writes the address.
 	dir := t.TempDir()
 	writeFile(t, dir, "sink.yaml", `
+security:
+  shared_secret: not-empty
+`)
+	if _, err := LoadSink(dir); err == nil {
+		t.Fatal("expected error for missing listen.addr, got nil")
+	} else if !strings.Contains(err.Error(), "listen.addr is required") {
+		t.Errorf("error should name listen.addr, got %v", err)
+	}
+}
+
+func TestLoadSinkHonorsExplicitListenAddr(t *testing.T) {
+	// Regression for v0.11 -> v0.12: an existing sink.yaml that already
+	// has a 100.x address keeps working without re-detection prompting.
+	dir := t.TempDir()
+	writeFile(t, dir, "sink.yaml", `
+listen:
+  addr: 100.80.229.80:9999
 security:
   shared_secret: not-empty
 `)
@@ -72,8 +93,8 @@ security:
 	if err != nil {
 		t.Fatalf("LoadSink: %v", err)
 	}
-	if cfg.Listen.Addr != "127.0.0.1:9999" {
-		t.Errorf("expected default listen 127.0.0.1:9999, got %q", cfg.Listen.Addr)
+	if cfg.Listen.Addr != "100.80.229.80:9999" {
+		t.Errorf("listen addr: got %q", cfg.Listen.Addr)
 	}
 }
 

--- a/internal/tsclient/require.go
+++ b/internal/tsclient/require.go
@@ -1,0 +1,119 @@
+package tsclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+)
+
+// Sentinel errors returned by RequireTailnetIP. Callers should use
+// errors.Is to distinguish reasons so the calling CLI can print a
+// remediation tailored to the missing piece.
+var (
+	// ErrTailscaleNotRunning is returned when the Tailscale CLI is
+	// missing, or `tailscale status --json` fails, or the daemon
+	// reports no Self peer. All three flow through this error so
+	// the caller can give one consistent remediation.
+	ErrTailscaleNotRunning = errors.New("tsclient: Tailscale not running")
+
+	// ErrNoTailnetInterface is returned when the Tailscale daemon is
+	// reachable but no 100.64.0.0/10 IPv4 address is bound on any
+	// local network interface. Distinct from ErrTailscaleNotRunning
+	// because the user has to take a different action: bring the
+	// tailnet interface up, not start the daemon.
+	ErrNoTailnetInterface = errors.New("tsclient: no Tailscale 100.x address on a local interface")
+
+	// ErrAmbiguousTailnetIP is returned when more than one 100.x
+	// IPv4 address is bound locally. Rare in practice (it happens
+	// on multi-tailnet machines or when an old tailnet interface
+	// did not clean up) but ambiguous: agentcookie refuses to pick.
+	// The caller should ask the user to pin a single IP in
+	// sink.yaml or source.yaml.
+	ErrAmbiguousTailnetIP = errors.New("tsclient: multiple Tailscale 100.x addresses present; cannot pick one")
+)
+
+// remediation is the user-facing block appended to every error message
+// returned by RequireTailnetIP. It names the two diagnostic surfaces
+// the user can reach: the tailscale CLI for daemon state, and the
+// quickstart doc for the wider install ceremony.
+const remediation = "run `tailscale status` to inspect the daemon, then re-run; see docs/quickstart.md"
+
+// interfaceAddrsFunc is the network-interface enumerator
+// RequireTailnetIP calls. Overridable for tests; production callers
+// should leave it alone.
+var interfaceAddrsFunc = net.InterfaceAddrs
+
+// RequireTailnetIP returns this machine's Tailscale 100.x IPv4 address
+// or a structured error explaining which piece is missing. agentcookie's
+// sink and pair listeners call this at startup and refuse to bind on
+// 0.0.0.0 or any non-tailnet interface; the wizard install path calls
+// this at config-write time and refuses to write sink.yaml on error
+// rather than silently falling through to a permissive default. S1 in
+// the v0.12 threat survey.
+//
+// The ctx is reserved for future expansion (probing the daemon over
+// `tailscale status --json`). Today RequireTailnetIP only consults
+// local interface state, which is what a Tailscale daemon ultimately
+// writes anyway, so a ctx parameter is taken to keep the signature
+// stable.
+func RequireTailnetIP(ctx context.Context) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	_ = ctx // reserved for the daemon-probe expansion (see doc comment)
+
+	addrs, err := interfaceAddrsFunc()
+	if err != nil {
+		// Enumerating local interfaces should not fail on a healthy
+		// macOS box. If it does, surface it as "not running" so the
+		// caller gives the same remediation block.
+		return "", fmt.Errorf("%w: enumerate interfaces: %v; %s", ErrTailscaleNotRunning, err, remediation)
+	}
+
+	var found []string
+	for _, a := range addrs {
+		ipnet, ok := a.(*net.IPNet)
+		if !ok {
+			continue
+		}
+		ip4 := ipnet.IP.To4()
+		if ip4 == nil {
+			continue
+		}
+		// Tailscale's CGNAT block is 100.64.0.0/10, i.e. 100.64.0.0
+		// through 100.127.255.255. The first octet check is cheap
+		// and the second octet bound matches the prefix exactly.
+		if ip4[0] != 100 || ip4[1] < 64 || ip4[1] > 127 {
+			continue
+		}
+		found = append(found, ip4.String())
+	}
+
+	switch len(found) {
+	case 0:
+		return "", fmt.Errorf("%w; %s", ErrNoTailnetInterface, remediation)
+	case 1:
+		return found[0], nil
+	default:
+		return "", fmt.Errorf("%w: candidates=%v; pin one in sink.yaml (listen.addr) or source.yaml; %s", ErrAmbiguousTailnetIP, found, remediation)
+	}
+}
+
+// IsTailnetIP reports whether s parses as a 100.64.0.0/10 IPv4 address
+// (Tailscale's CGNAT range). Used by the sink and pair listener startup
+// guards to confirm the configured listen address is actually on the
+// tailnet before binding. "localhost"/"127.0.0.1" callers should test
+// that separately (it is a legitimate local-dev binding, not a
+// tailnet binding).
+func IsTailnetIP(s string) bool {
+	ip := net.ParseIP(s)
+	if ip == nil {
+		return false
+	}
+	ip4 := ip.To4()
+	if ip4 == nil {
+		return false
+	}
+	return ip4[0] == 100 && ip4[1] >= 64 && ip4[1] <= 127
+}

--- a/internal/tsclient/require_test.go
+++ b/internal/tsclient/require_test.go
@@ -1,0 +1,180 @@
+package tsclient
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strings"
+	"testing"
+)
+
+// withFakeAddrs swaps interfaceAddrsFunc for the duration of a test.
+// All cases must mutate it through this helper so cleanup happens via
+// t.Cleanup even on a t.Fatal.
+func withFakeAddrs(t *testing.T, addrs []net.Addr, err error) {
+	t.Helper()
+	prev := interfaceAddrsFunc
+	t.Cleanup(func() { interfaceAddrsFunc = prev })
+	interfaceAddrsFunc = func() ([]net.Addr, error) { return addrs, err }
+}
+
+// ipnet builds a *net.IPNet from a CIDR string for the test tables.
+// Anything malformed in a test is a test bug, so t.Fatal.
+func ipnet(t *testing.T, cidr string) net.Addr {
+	t.Helper()
+	ip, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		t.Fatalf("parse %s: %v", cidr, err)
+	}
+	ipNet.IP = ip // preserve the host octets, not the network prefix
+	return ipNet
+}
+
+func TestRequireTailnetIP(t *testing.T) {
+	cases := []struct {
+		name     string
+		addrs    []net.Addr
+		addrsErr error
+		wantIP   string
+		wantErr  error // sentinel checked via errors.Is
+	}{
+		{
+			name: "happy path: one 100.x address",
+			addrs: []net.Addr{
+				ipnet(t, "192.168.1.42/24"),
+				ipnet(t, "100.80.229.80/32"),
+				ipnet(t, "fe80::1/64"),
+			},
+			wantIP: "100.80.229.80",
+		},
+		{
+			name: "edge: only non-tailnet interfaces; daemon down / interface down",
+			addrs: []net.Addr{
+				ipnet(t, "192.168.1.42/24"),
+				ipnet(t, "10.0.0.5/8"),
+				ipnet(t, "fe80::1/64"),
+			},
+			wantErr: ErrNoTailnetInterface,
+		},
+		{
+			name:    "edge: empty interface list",
+			addrs:   []net.Addr{},
+			wantErr: ErrNoTailnetInterface,
+		},
+		{
+			name: "edge: 100.x but outside CGNAT block is not tailnet",
+			addrs: []net.Addr{
+				// 100.0.0.0/8 around the CGNAT block: 100.63 and 100.128 are NOT
+				// tailnet space. agentcookie must not accept them.
+				ipnet(t, "100.63.0.5/32"),
+				ipnet(t, "100.128.0.5/32"),
+			},
+			wantErr: ErrNoTailnetInterface,
+		},
+		{
+			name: "edge: multiple 100.x addresses present",
+			addrs: []net.Addr{
+				ipnet(t, "100.80.229.80/32"),
+				ipnet(t, "100.98.176.68/32"),
+			},
+			wantErr: ErrAmbiguousTailnetIP,
+		},
+		{
+			name:     "edge: interface enumeration fails",
+			addrsErr: errors.New("syscall failed"),
+			wantErr:  ErrTailscaleNotRunning,
+		},
+		{
+			name: "edge: ignore IPv6 100:: addresses (different family)",
+			addrs: []net.Addr{
+				// IPv6 address that starts with 100 in text but is in a totally
+				// different range; must not be confused with the IPv4 CGNAT block.
+				ipnet(t, "100::1/128"),
+			},
+			wantErr: ErrNoTailnetInterface,
+		},
+		{
+			name: "edge: 100.64.x boundary is tailnet",
+			addrs: []net.Addr{
+				ipnet(t, "100.64.0.1/32"),
+			},
+			wantIP: "100.64.0.1",
+		},
+		{
+			name: "edge: 100.127.x upper boundary is tailnet",
+			addrs: []net.Addr{
+				ipnet(t, "100.127.255.254/32"),
+			},
+			wantIP: "100.127.255.254",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			withFakeAddrs(t, tc.addrs, tc.addrsErr)
+			got, err := RequireTailnetIP(context.Background())
+			if tc.wantErr != nil {
+				if err == nil {
+					t.Fatalf("expected error %v, got nil (ip=%q)", tc.wantErr, got)
+				}
+				if !errors.Is(err, tc.wantErr) {
+					t.Errorf("error: got %v, want sentinel %v", err, tc.wantErr)
+				}
+				// Every error message must name the remediation surfaces
+				// agentcookie users need to reach. This protects S1's
+				// "no silent fallback" property at the error-message
+				// level: a user sees the exact command and doc to consult.
+				if !strings.Contains(err.Error(), "tailscale status") {
+					t.Errorf("error should name `tailscale status`, got %v", err)
+				}
+				if !strings.Contains(err.Error(), "docs/quickstart.md") {
+					t.Errorf("error should name docs/quickstart.md, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.wantIP {
+				t.Errorf("ip: got %q, want %q", got, tc.wantIP)
+			}
+		})
+	}
+}
+
+func TestRequireTailnetIP_NilContext(t *testing.T) {
+	// Defensive: callers passing a nil context (a mistake) should not
+	// crash; RequireTailnetIP swaps a Background in. Verified by happy-path
+	// shape, since today no ctx-respecting path runs.
+	withFakeAddrs(t, []net.Addr{ipnet(t, "100.80.229.80/32")}, nil)
+	got, err := RequireTailnetIP(nil) //nolint:staticcheck // intentional nil ctx
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "100.80.229.80" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestIsTailnetIP(t *testing.T) {
+	cases := map[string]bool{
+		"100.80.229.80":  true,
+		"100.64.0.0":     true,
+		"100.127.255.255": true,
+		"100.63.0.0":     false, // one below the block
+		"100.128.0.0":    false, // one above the block
+		"127.0.0.1":      false, // loopback, not tailnet
+		"0.0.0.0":        false, // any-interface bind, definitely not tailnet
+		"192.168.1.1":    false,
+		"":               false,
+		"not an ip":      false,
+		"::1":            false, // IPv6 loopback
+		"100::1":         false, // IPv6 unrelated
+	}
+	for in, want := range cases {
+		t.Run(in, func(t *testing.T) {
+			if got := IsTailnetIP(in); got != want {
+				t.Errorf("IsTailnetIP(%q) = %v, want %v", in, got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add `internal/tsclient.RequireTailnetIP(ctx)` returning the Tailscale 100.x interface address or a typed error (`ErrTailscaleNotRunning`, `ErrNoTailnetInterface`, `ErrAmbiguousTailnetIP`). Every error message names `tailscale status` and `docs/quickstart.md`.
- `wizard install` calls `RequireTailnetIP` before writing `sink.yaml`; on failure the wizard refuses to write rather than falling back to `0.0.0.0`.
- Sink and pair listener startup call `validateListenAddr` which allows tailnet 100.x or explicit loopback and refuses `0.0.0.0`, `::`, and non-tailnet routables.
- `internal/config.LoadSink` no longer silently falls through to `127.0.0.1:9999` when listen.addr is empty — it's now a config error pointing at `agentcookie wizard install --as sink`.
- `pair.go` `--listen` flag default flipped from `0.0.0.0:9998` to empty (triggers auto-detect via the same helper).

Closes U1 of the v0.12 security plan. Closes the most direct path of finding S1 from the threat survey.

## Test plan

- [x] `go test -race ./...` passes — 232 tests in 20 packages
- [x] `internal/tsclient/require_test.go` covers happy path, missing interface, off-block 100.x, CGNAT boundaries, ambiguity, syscall failure, IPv6 100::1 confusion
- [x] `validateListenAddr` regression test proves a v0.11 `sink.yaml` with `0.0.0.0:9999` is now refused with the v0.12 remediation message
- [x] `wizard_test.go` proves `renderSinkYAML` never writes `0.0.0.0`

Note: the error messages reference `docs/quickstart.md` which exists but doesn't yet mention `tailscale status`. That gap closes in U13.

Generated with [Claude Code](https://claude.com/claude-code).