### PR TITLE
feat(v0.12 U10): pass paired keys directly; enforce shared_secret entropy floor

### DIFF
--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -14,8 +14,10 @@ func resolveTransportSecret(configDir, peerHost, legacy string) (string, error) 
 	if peerHost != "" {
 		pk, err := keystore.Load(configDir, peerHost)
 		if err == nil {
-			// The raw 32-byte key is passed through SealWithSecret's SHA256
-			// derivation. Both sides do the same so the AES key matches.
+			// pk.Key is the 32-byte HKDF output from pairing. transport.newGCM
+			// recognizes 32-byte secrets and uses them directly as the AES
+			// key, skipping the SHA-256 step that legacy shared_secret
+			// values go through (see internal/transport/crypto.go).
 			return string(pk.Key), nil
 		}
 		if legacy == "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -71,6 +71,9 @@ func LoadSource(dir string) (*SourceConfig, error) {
 	if cfg.Peer.Hostname == "" && cfg.Security.SharedSecret == "" {
 		return nil, fmt.Errorf("%s: either peer.hostname (paired key) or security.shared_secret (legacy) is required", path)
 	}
+	if err := validateSharedSecret(path, cfg.Security.SharedSecret); err != nil {
+		return nil, err
+	}
 	if cfg.Chrome.DBPath == "" {
 		cfg.Chrome.DBPath = DefaultChromeCookiesPath()
 	}
@@ -97,10 +100,30 @@ func LoadSink(dir string) (*SinkConfig, error) {
 	if cfg.Peer.Hostname == "" && cfg.Security.SharedSecret == "" {
 		return nil, fmt.Errorf("%s: either peer.hostname (paired key) or security.shared_secret (legacy) is required", path)
 	}
+	if err := validateSharedSecret(path, cfg.Security.SharedSecret); err != nil {
+		return nil, err
+	}
 	if cfg.Chrome.DBPath == "" {
 		cfg.Chrome.DBPath = DefaultChromeCookiesPath()
 	}
 	return &cfg, nil
+}
+
+// validateSharedSecret enforces a 32-byte minimum on the legacy
+// security.shared_secret YAML field. v0.12 rejects shorter values
+// because newGCM derives the AES key by SHA-256-hashing the secret;
+// a short secret produced a weak AEAD key. Pairing-derived 32-byte
+// keys bypass the SHA-256 step entirely and never fail this check.
+// Empty secret is permitted here: the paired-key path is the
+// canonical credential and the legacy field is optional.
+func validateSharedSecret(path, secret string) error {
+	if secret == "" {
+		return nil
+	}
+	if len(secret) < 32 {
+		return fmt.Errorf("%s: security.shared_secret must be at least 32 bytes (got %d); prefer pairing (`agentcookie pair`) over a typed secret", path, len(secret))
+	}
+	return nil
 }
 
 func loadYAML(path string, out any) error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -26,7 +26,7 @@ sink:
 chrome:
   db_path: ~/Library/Application Support/Google/Chrome/Default/Cookies
 security:
-  shared_secret: not-empty
+  shared_secret: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 `)
 	cfg, err := LoadSource(dir)
 	if err != nil {
@@ -44,7 +44,7 @@ func TestLoadSourceMissingSinkURL(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, dir, "source.yaml", `
 security:
-  shared_secret: not-empty
+  shared_secret: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 `)
 	if _, err := LoadSource(dir); err == nil {
 		t.Fatal("expected error for missing sink.url, got nil")
@@ -70,7 +70,7 @@ func TestLoadSinkEmptyListenIsError(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, dir, "sink.yaml", `
 security:
-  shared_secret: not-empty
+  shared_secret: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 `)
 	if _, err := LoadSink(dir); err == nil {
 		t.Fatal("expected error for missing listen.addr, got nil")
@@ -87,7 +87,7 @@ func TestLoadSinkHonorsExplicitListenAddr(t *testing.T) {
 listen:
   addr: 100.80.229.80:9999
 security:
-  shared_secret: not-empty
+  shared_secret: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 `)
 	cfg, err := LoadSink(dir)
 	if err != nil {
@@ -95,6 +95,44 @@ security:
 	}
 	if cfg.Listen.Addr != "100.80.229.80:9999" {
 		t.Errorf("listen addr: got %q", cfg.Listen.Addr)
+	}
+}
+
+// TestLoadSourceRejectsShortSharedSecret covers U10: a legacy
+// security.shared_secret below 32 bytes is now refused at config
+// load. The error names the byte count and points at pairing.
+func TestLoadSourceRejectsShortSharedSecret(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "source.yaml", `
+sink:
+  url: http://example.test:9999/sync
+security:
+  shared_secret: tooshort
+`)
+	_, err := LoadSource(dir)
+	if err == nil {
+		t.Fatal("expected error for short shared_secret, got nil")
+	}
+	if !strings.Contains(err.Error(), "at least 32 bytes") {
+		t.Errorf("error should name the 32-byte floor, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "agentcookie pair") {
+		t.Errorf("error should suggest pairing, got %v", err)
+	}
+}
+
+// TestLoadSourceAcceptsExactly32ByteSecret proves the entropy floor
+// is inclusive at exactly 32 bytes (matches the AES-256 key length).
+func TestLoadSourceAcceptsExactly32ByteSecret(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "source.yaml", `
+sink:
+  url: http://example.test:9999/sync
+security:
+  shared_secret: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+`)
+	if _, err := LoadSource(dir); err != nil {
+		t.Errorf("32-byte shared_secret should be accepted, got %v", err)
 	}
 }
 

--- a/internal/transport/crypto.go
+++ b/internal/transport/crypto.go
@@ -44,9 +44,27 @@ func OpenWithSecret(ciphertext []byte, secret string) ([]byte, error) {
 	return pt, nil
 }
 
+// newGCM returns an AES-256-GCM cipher derived from secret.
+//
+// Two paths:
+//
+//   - When secret is exactly 32 bytes long, it is treated as an
+//     already-uniform key (the pairing-derived HKDF-SHA256 output is
+//     32 bytes of uniformly random data) and used directly. No
+//     redundant SHA-256 step.
+//
+//   - Otherwise, secret goes through SHA-256 to produce a 32-byte
+//     AES key. This covers the legacy security.shared_secret YAML
+//     path. The config layer rejects secrets below a 32-byte entropy
+//     floor so attackers cannot drive this path with a weak secret.
 func newGCM(secret string) (cipher.AEAD, error) {
-	keyHash := sha256.Sum256([]byte(secret))
-	block, err := aes.NewCipher(keyHash[:])
+	var key [32]byte
+	if len(secret) == 32 {
+		copy(key[:], secret)
+	} else {
+		key = sha256.Sum256([]byte(secret))
+	}
+	block, err := aes.NewCipher(key[:])
 	if err != nil {
 		return nil, err
 	}

--- a/internal/transport/crypto_kdf_test.go
+++ b/internal/transport/crypto_kdf_test.go
@@ -1,0 +1,74 @@
+package transport
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"testing"
+)
+
+// TestNewGCM_32BytePassThrough proves U10's no-double-hash property:
+// a 32-byte secret (the shape of a pairing-derived HKDF output) is
+// used directly as the AES-256 key, NOT re-hashed through SHA-256.
+// Asserts the round trip succeeds; the structural property is that
+// the inverse-of-SHA-256 path would never produce the same key.
+func TestNewGCM_32BytePassThrough(t *testing.T) {
+	// 32-byte secret, all 0xAB
+	secret := string(bytes.Repeat([]byte{0xAB}, 32))
+	plaintext := []byte("hello world")
+
+	sealed, err := SealWithSecret(plaintext, secret)
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+	opened, err := OpenWithSecret(sealed, secret)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if !bytes.Equal(plaintext, opened) {
+		t.Errorf("round-trip mismatch: got %q want %q", opened, plaintext)
+	}
+
+	// Re-seal with the SHA-256 hash of the same secret. If U10's
+	// pass-through is wired up, the AEAD key from the 32-byte secret
+	// will be that secret directly, not the SHA-256 of it, so the
+	// hashed secret produces a different ciphertext.
+	hashed := sha256.Sum256([]byte(secret))
+	hashedSecret := string(hashed[:])
+	sealedHashed, err := SealWithSecret(plaintext, hashedSecret)
+	if err != nil {
+		t.Fatalf("Seal hashed: %v", err)
+	}
+	// Try to open the original sealed with the hashed secret.
+	if _, err := OpenWithSecret(sealed, hashedSecret); err == nil {
+		t.Errorf("opening pass-through-keyed sealed with hashed secret should fail; pass-through broken")
+	}
+	// And opening hashed-sealed with the original 32-byte secret.
+	if _, err := OpenWithSecret(sealedHashed, secret); err == nil {
+		t.Errorf("opening hashed-keyed sealed with raw 32-byte secret should fail; pass-through broken")
+	}
+}
+
+// TestNewGCM_NonStandardLengthGoesThroughSHA256 keeps the legacy path
+// alive: any secret that isn't exactly 32 bytes is hashed before use.
+func TestNewGCM_NonStandardLengthGoesThroughSHA256(t *testing.T) {
+	cases := []string{
+		"short",
+		string(bytes.Repeat([]byte{0xCC}, 31)),
+		string(bytes.Repeat([]byte{0xCC}, 33)),
+		string(bytes.Repeat([]byte{0xCC}, 64)),
+	}
+	for _, secret := range cases {
+		plaintext := []byte("round trip")
+		sealed, err := SealWithSecret(plaintext, secret)
+		if err != nil {
+			t.Fatalf("Seal len=%d: %v", len(secret), err)
+		}
+		opened, err := OpenWithSecret(sealed, secret)
+		if err != nil {
+			t.Fatalf("Open len=%d: %v", len(secret), err)
+		}
+		if !bytes.Equal(plaintext, opened) {
+			t.Errorf("round-trip mismatch at len=%d", len(secret))
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- `internal/transport/newGCM` branches on input length: 32 bytes pass through as the AES key directly; other lengths go through SHA-256 (legacy path).
- `internal/config.validateSharedSecret` rejects any legacy `security.shared_secret` shorter than 32 bytes with an actionable error pointing at \`agentcookie pair\`.
- Updates the comment in `internal/cli/common.go` so future readers know the paired-key path no longer takes the SHA-256 detour.

Closes U10 of the v0.12 security plan.

## Test plan

- [x] `go test -race ./...` passes (245 tests, 21 packages)
- [x] `crypto_kdf_test.go` proves the 32-byte pass-through by showing that ciphertext sealed with a 32-byte key cannot be opened with the SHA-256 of that key, and vice versa
- [x] Legacy-length round trips (5, 31, 33, 64 bytes) still work
- [x] `TestLoadSourceRejectsShortSharedSecret` and `TestLoadSourceAcceptsExactly32ByteSecret` cover the validation gate
- [x] Existing happy-path tests updated to use 32-byte secrets

Generated with [Claude Code](https://claude.com/claude-code).