### PR TITLE
feat(v0.12 U9): harden tarball unpack against traversal, symlinks, exhaustion

### DIFF
--- a/internal/chromedirsync/chromedirsync.go
+++ b/internal/chromedirsync/chromedirsync.go
@@ -15,6 +15,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // ErrSourceMissing is returned by Pack when the source directory does
@@ -120,15 +121,40 @@ func Pack(dir string, maxOriginSize int64) ([]byte, []string, error) {
 	return buf.Bytes(), skippedNames, nil
 }
 
+// MaxUnpackBytes is the largest tar payload Unpack will accept. A
+// payload over this size returns an error before any file write. The
+// number matches the SinkSync httpserver body cap so a hostile sink
+// cannot use a smaller payload-level cap to bypass the HTTP one.
+const MaxUnpackBytes = 256 * 1024 * 1024
+
+// MaxUnpackMembers caps the number of tar entries Unpack will process.
+// A tarball with more entries returns an error. Defends against
+// inode-exhaustion patterns where many tiny files exceed total-byte
+// limits with much smaller total size.
+const MaxUnpackMembers = 100_000
+
 // Unpack untars payload into stagingDir. Caller is responsible for
 // atomic-renaming stagingDir into place once Unpack returns. The
 // staging-then-rename pattern keeps the live directory intact if Unpack
 // fails partway through.
+//
+// v0.12 hardening: rejects payloads over MaxUnpackBytes, tarballs with
+// more than MaxUnpackMembers entries, and any member whose path
+// escapes stagingDir (absolute path, "..", or symlink). Symlink and
+// hardlink members are unconditionally rejected.
 func Unpack(payload []byte, stagingDir string) error {
+	if int64(len(payload)) > MaxUnpackBytes {
+		return fmt.Errorf("chromedirsync: payload %d bytes exceeds limit %d", len(payload), MaxUnpackBytes)
+	}
 	if err := os.MkdirAll(stagingDir, 0o755); err != nil {
 		return fmt.Errorf("chromedirsync: mkdir %s: %w", stagingDir, err)
 	}
+	absStaging, err := filepath.Abs(stagingDir)
+	if err != nil {
+		return fmt.Errorf("chromedirsync: abs %s: %w", stagingDir, err)
+	}
 	tr := tar.NewReader(bytes.NewReader(payload))
+	members := 0
 	for {
 		hdr, err := tr.Next()
 		if err == io.EOF {
@@ -137,7 +163,14 @@ func Unpack(payload []byte, stagingDir string) error {
 		if err != nil {
 			return fmt.Errorf("chromedirsync: read tar header: %w", err)
 		}
-		dst := filepath.Join(stagingDir, hdr.Name)
+		members++
+		if members > MaxUnpackMembers {
+			return fmt.Errorf("chromedirsync: tarball exceeds %d members", MaxUnpackMembers)
+		}
+		dst, err := safeDestPath(absStaging, hdr.Name)
+		if err != nil {
+			return err
+		}
 		switch hdr.Typeflag {
 		case tar.TypeDir:
 			if err := os.MkdirAll(dst, os.FileMode(hdr.Mode)); err != nil {
@@ -158,9 +191,29 @@ func Unpack(payload []byte, stagingDir string) error {
 			if err := f.Close(); err != nil {
 				return fmt.Errorf("chromedirsync: close %s: %w", dst, err)
 			}
+		case tar.TypeSymlink, tar.TypeLink:
+			return fmt.Errorf("chromedirsync: symlink / hardlink members not allowed (%q)", hdr.Name)
+		default:
+			// Unknown member types (devices, FIFOs, etc.) are also rejected.
+			return fmt.Errorf("chromedirsync: unsupported tar entry type %d for %q", hdr.Typeflag, hdr.Name)
 		}
 	}
 	return nil
+}
+
+// safeDestPath joins stagingAbs and member, then verifies the result
+// stays under stagingAbs. Rejects absolute member paths and any path
+// whose cleaned form escapes the staging directory (".." traversal).
+func safeDestPath(stagingAbs, member string) (string, error) {
+	if filepath.IsAbs(member) {
+		return "", fmt.Errorf("chromedirsync: absolute tar path %q not allowed", member)
+	}
+	dst := filepath.Join(stagingAbs, member)
+	cleaned := filepath.Clean(dst)
+	if cleaned != stagingAbs && !strings.HasPrefix(cleaned, stagingAbs+string(filepath.Separator)) {
+		return "", fmt.Errorf("chromedirsync: tar entry %q escapes staging dir", member)
+	}
+	return cleaned, nil
 }
 
 // AtomicReplaceDir renames stagingDir over liveDir as atomically as the

--- a/internal/chromedirsync/hardening_helpers_test.go
+++ b/internal/chromedirsync/hardening_helpers_test.go
@@ -1,0 +1,7 @@
+package chromedirsync
+
+import "os"
+
+// openRead is a tiny indirection that lets hardening_test.go open
+// files without importing os directly in the same file.
+func openRead(path string) (*os.File, error) { return os.Open(path) }

--- a/internal/chromedirsync/hardening_test.go
+++ b/internal/chromedirsync/hardening_test.go
@@ -1,0 +1,148 @@
+package chromedirsync
+
+import (
+	"archive/tar"
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// makeTar builds an in-memory tarball from the given members. Used by
+// the hardening tests to construct hostile-shaped tarballs without
+// touching disk.
+func makeTar(t *testing.T, members []tar.Header, bodies map[string][]byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	for _, hdr := range members {
+		h := hdr
+		body := bodies[h.Name]
+		h.Size = int64(len(body))
+		if err := tw.WriteHeader(&h); err != nil {
+			t.Fatalf("tar header %q: %v", h.Name, err)
+		}
+		if len(body) > 0 {
+			if _, err := tw.Write(body); err != nil {
+				t.Fatalf("tar body %q: %v", h.Name, err)
+			}
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tar close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// TestUnpack_RejectsPathTraversal exercises the canonical archive
+// vulnerability: a member whose path resolves outside the staging dir.
+func TestUnpack_RejectsPathTraversal(t *testing.T) {
+	dst := t.TempDir()
+	payload := makeTar(t, []tar.Header{
+		{Name: "../escape.txt", Typeflag: tar.TypeReg, Mode: 0o644},
+	}, map[string][]byte{"../escape.txt": []byte("hostile")})
+
+	err := Unpack(payload, dst)
+	if err == nil {
+		t.Fatal("expected traversal rejection, got nil")
+	}
+	if !strings.Contains(err.Error(), "escapes staging dir") {
+		t.Errorf("expected escape error, got %v", err)
+	}
+}
+
+// TestUnpack_RejectsAbsolutePath: a tar entry with an absolute path
+// (e.g. /etc/passwd) is refused.
+func TestUnpack_RejectsAbsolutePath(t *testing.T) {
+	dst := t.TempDir()
+	payload := makeTar(t, []tar.Header{
+		{Name: "/tmp/hostile", Typeflag: tar.TypeReg, Mode: 0o644},
+	}, map[string][]byte{"/tmp/hostile": []byte("nope")})
+
+	err := Unpack(payload, dst)
+	if err == nil {
+		t.Fatal("expected absolute-path rejection, got nil")
+	}
+	if !strings.Contains(err.Error(), "absolute tar path") {
+		t.Errorf("expected absolute-path error, got %v", err)
+	}
+}
+
+// TestUnpack_RejectsSymlinkMember
+func TestUnpack_RejectsSymlinkMember(t *testing.T) {
+	dst := t.TempDir()
+	payload := makeTar(t, []tar.Header{
+		{Name: "evil-link", Typeflag: tar.TypeSymlink, Linkname: "/etc/passwd", Mode: 0o777},
+	}, nil)
+
+	err := Unpack(payload, dst)
+	if err == nil {
+		t.Fatal("expected symlink rejection, got nil")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Errorf("expected symlink error, got %v", err)
+	}
+}
+
+// TestUnpack_RejectsHardlinkMember
+func TestUnpack_RejectsHardlinkMember(t *testing.T) {
+	dst := t.TempDir()
+	payload := makeTar(t, []tar.Header{
+		{Name: "evil-hardlink", Typeflag: tar.TypeLink, Linkname: "anything", Mode: 0o644},
+	}, nil)
+
+	err := Unpack(payload, dst)
+	if err == nil {
+		t.Fatal("expected hardlink rejection, got nil")
+	}
+}
+
+// TestUnpack_RejectsOversizedPayload
+func TestUnpack_RejectsOversizedPayload(t *testing.T) {
+	dst := t.TempDir()
+	// A buffer of MaxUnpackBytes+1 bytes is enough to fail the size
+	// check before any tar parsing.
+	big := make([]byte, MaxUnpackBytes+1)
+	err := Unpack(big, dst)
+	if err == nil {
+		t.Fatal("expected size-cap rejection, got nil")
+	}
+	if !strings.Contains(err.Error(), "exceeds limit") {
+		t.Errorf("expected size-limit error, got %v", err)
+	}
+}
+
+// TestUnpack_AcceptsNormalTarball is the regression: legitimate
+// LocalStorage tarballs continue to unpack correctly.
+func TestUnpack_AcceptsNormalTarball(t *testing.T) {
+	dst := t.TempDir()
+	payload := makeTar(t, []tar.Header{
+		{Name: "subdir", Typeflag: tar.TypeDir, Mode: 0o755},
+		{Name: "subdir/file.txt", Typeflag: tar.TypeReg, Mode: 0o644},
+	}, map[string][]byte{"subdir/file.txt": []byte("hello")})
+
+	if err := Unpack(payload, dst); err != nil {
+		t.Fatalf("normal tarball should unpack cleanly, got %v", err)
+	}
+	expected := filepath.Join(dst, "subdir", "file.txt")
+	data, err := readFile(expected)
+	if err != nil {
+		t.Fatalf("expected file %s, got %v", expected, err)
+	}
+	if string(data) != "hello" {
+		t.Errorf("file content mismatch: %q", string(data))
+	}
+}
+
+func readFile(path string) ([]byte, error) {
+	var b bytes.Buffer
+	f, err := openRead(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	if _, err := b.ReadFrom(f); err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
+}


### PR DESCRIPTION
## Summary

`internal/chromedirsync.Unpack` now rejects:

- Payloads over `MaxUnpackBytes` (256 MB; matches SinkSync httpserver body cap)
- Tarballs with more than `MaxUnpackMembers` (100,000) entries
- Member paths that resolve outside the staging directory (\`..\` or absolute)
- Symlink and hardlink members (`TypeSymlink`, `TypeLink`)
- Unknown member types (devices, FIFOs)

`safeDestPath` compares the cleaned absolute destination against the staging-dir prefix before any file is created.

Closes U9 of the v0.12 security plan.

## Test plan

- [x] `go test -race ./...` passes (251 tests, 21 packages)
- [x] `hardening_test.go` covers: traversal, absolute path, symlink, hardlink, oversized payload, and a regression for normal tarballs

Generated with [Claude Code](https://claude.com/claude-code).