### PR TITLE
feat(v0.12 U7): seal adapter session secrets under the master key

### DIFF
--- a/internal/sinkpush/adapter_pycookiecheat.go
+++ b/internal/sinkpush/adapter_pycookiecheat.go
@@ -72,18 +72,28 @@ func (a *PycookiecheatStyleAdapter) CookieHostPatterns() []string {
 // and a matching cookies.json. Atomic writes via temp + rename. If
 // config.toml already exists, only the access_token line is rewritten
 // (preserves user-customized base_url and any other fields).
+//
+// v0.12: when the agentcookie master key Keychain item is present, the
+// header value is sealed (SealedPrefix + base64) before being written
+// to either file. PP CLIs that consume these files detect the prefix
+// and unseal transparently. Sinks without the master key fall back to
+// plaintext (v0.11 shape) so partial installs still work.
 func (a *PycookiecheatStyleAdapter) Push(cookies []chrome.Cookie) error {
 	header := formatCookieHeader(cookies)
 	if header == "" {
 		return nil
 	}
+	onDiskHeader, err := maybeSeal(header)
+	if err != nil {
+		return fmt.Errorf("seal header: %w", err)
+	}
 	if err := os.MkdirAll(a.configDir, 0o700); err != nil {
 		return fmt.Errorf("mkdir %s: %w", a.configDir, err)
 	}
-	if err := a.writeConfigTOML(header); err != nil {
+	if err := a.writeConfigTOML(onDiskHeader); err != nil {
 		return fmt.Errorf("write config.toml: %w", err)
 	}
-	if err := a.writeCookiesJSON(header); err != nil {
+	if err := a.writeCookiesJSON(onDiskHeader); err != nil {
 		return fmt.Errorf("write cookies.json: %w", err)
 	}
 	return nil

--- a/internal/sinkpush/adapter_tablereservation.go
+++ b/internal/sinkpush/adapter_tablereservation.go
@@ -108,6 +108,14 @@ func (a *TableReservationAdapter) Push(cookies []chrome.Cookie) error {
 			continue
 		}
 		sc := chromeToSessionCookie(c)
+		// v0.12: seal the cookie value when the agentcookie master
+		// key is installed. PP CLI reads the value, detects the
+		// SealedPrefix, unseals via pkg/sidecar's keystore.
+		sealed, err := maybeSeal(sc.Value)
+		if err != nil {
+			return fmt.Errorf("seal cookie value: %w", err)
+		}
+		sc.Value = sealed
 		switch {
 		case HostSuffixMatch(c.HostKey, "opentable.com"):
 			env.OpentableCookies = append(env.OpentableCookies, sc)

--- a/internal/sinkpush/seal.go
+++ b/internal/sinkpush/seal.go
@@ -1,0 +1,39 @@
+package sinkpush
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	"github.com/mvanhorn/agentcookie/internal/keystore"
+)
+
+// SealedPrefix mirrors pkg/sidecar.SealedPrefix. Sinkpush adapter
+// writers use the same on-disk envelope shape as the cookie sidecar:
+// "agc1:" + base64(seal(masterKey, plaintext)). PP CLIs that consume
+// adapter session files (config.toml access_token, cookies.json,
+// session.json fields) detect the prefix and unseal transparently.
+const SealedPrefix = "agc1:"
+
+// maybeSeal returns a sealed envelope when the agentcookie master key
+// is available in the user's macOS Keychain; otherwise returns plain
+// untouched. Adapters call this on every secret-bearing field they
+// write to disk so a v0.12 sink with a Keychain installed produces
+// sealed files automatically and a partial install (no master key
+// yet) falls back to v0.11 plaintext shape.
+//
+// Errors only when the master key item exists but cannot be read or
+// the seal step itself fails. Returns plain + nil otherwise.
+func maybeSeal(plain string) (string, error) {
+	if !keystore.MasterKeyExists() {
+		return plain, nil
+	}
+	mk, err := keystore.ReadMasterKey()
+	if err != nil {
+		return "", fmt.Errorf("read master key: %w", err)
+	}
+	env, err := keystore.Seal(mk, []byte(plain))
+	if err != nil {
+		return "", fmt.Errorf("seal: %w", err)
+	}
+	return SealedPrefix + base64.StdEncoding.EncodeToString(env), nil
+}


### PR DESCRIPTION
## Summary

When the agentcookie master Keychain item exists, the sinkpush adapters seal their secret-bearing fields before writing:

- `PycookiecheatStyleAdapter` (airbnb-pp-cli, ebay-pp-cli, pagliacci-pp-cli): `config.toml` `access_token` and `cookies.json` `cookies` field are sealed
- `TableReservationAdapter` (OpenTable, Tock): each cookie's `value` field in `session.json` is sealed

Same on-disk shape as the sidecar (\`SealedPrefix\` + base64). PP CLIs detect the prefix and unseal transparently in U12.

Adapters without the master key fall back to plaintext (v0.11 shape). `instacart-pp-cli`'s auth-paste pipe stays plaintext for now; sealing on that path lives in the PP CLI's own auth-loader, which U12 will update.

Closes U7 of the v0.12 security plan.

## Test plan

- [x] `go test -race ./...` passes (258 tests, 22 packages)
- [x] Existing adapter tests run against the no-master-key fallback path (plaintext shape preserved)
- [x] Sealing primitive (`maybeSeal`) reuses the keystore Seal/Unseal helpers covered by `keystore/seal_test.go`

Generated with [Claude Code](https://claude.com/claude-code).