### PR TITLE
feat(v0.12): default at-rest sealing off until U12 PP CLI migration ships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,16 +66,36 @@ Shipped:
   AES-256-GCM cipher; legacy free-form `security.shared_secret`
   values below 32 bytes are now refused at config load.
 
+Sealing posture in v0.12: shipped but off by default.
+
+The at-rest sealing for the sidecar (U6) and adapter session files
+(U7) is wired into the writers but the wizard install does NOT
+create the `agentcookie-master` Keychain item by default. The PP
+CLI consumer side of the sealing handshake (U12, tracked in
+cli-printing-press) has not shipped yet; turning sealing on
+without that release would break v0.11 PP CLIs that read plaintext
+sidecars and adapter session files.
+
+To opt in once the matching cli-printing-press release lands:
+
+```
+agentcookie wizard set-keychain-access --enable-sealing
+```
+
+Threat-survey finding S5 (plaintext cookie sidecar at rest) stays
+open in the default install. Operators who only run agentcookie-
+controlled binaries on the sink can opt in immediately and close
+S5 themselves; the rest wait on U12. Chrome Safe Storage's `-T`
+ACL (replacing v0.10's any-app `-A`) is installed in both modes;
+only the master key step is gated.
+
 Pending follow-up:
 
 - U12: PP CLI sidecar-reader migration in cli-printing-press. Each
   of the five built-in adapter PP CLIs gains a small import of
   `pkg/sidecar` so it reads sealed session caches transparently.
-  v0.12 ships the writer side and the public reader API; the PP CLI
-  consumer-side change tracks in cli-printing-press. Until that
-  migration lands, PP CLIs continue to work against v0.11-shape
-  plaintext sidecars (the sink falls back when the master key
-  Keychain item is absent).
+  Unblocks flipping `--enable-sealing` to the default in a future
+  agentcookie release.
 
 ### v0.11: sinkpush adapter pushes cookies into each PP CLI's session cache
 

--- a/README.md
+++ b/README.md
@@ -126,18 +126,18 @@ Pre-release. macOS-only on both ends today: source-side cookie paths and decrypt
 
 Working today:
 
-- Continuous laptop -> sink sync (fsnotify on Chrome's Cookies file, debounced, allowlist-filtered, AES-256-GCM-sealed)
-- Sink writes Chrome's Cookies SQLite plus a sealed sidecar at `~/.agentcookie/cookies-plain.db`; PP CLIs link `pkg/sidecar.ReadSidecar` to unseal transparently
-- Five built-in PP CLI adapters push sealed session caches after every sync
+- Continuous laptop -> sink sync (fsnotify on Chrome's Cookies file, debounced, allowlist-filtered, AES-256-GCM over Tailscale)
+- Sink writes Chrome's Cookies SQLite plus a sidecar at `~/.agentcookie/cookies-plain.db`. At-rest sealing of the sidecar and adapter session files is wired up but off by default; turns on via `wizard set-keychain-access --enable-sealing` once U12 PP CLI support ships in cli-printing-press
+- Five built-in PP CLI adapters push session caches after every sync (plaintext today; sealed when sealing is opted in)
 - Tailnet-only listeners on both ends (sink and pair endpoints refuse `0.0.0.0`); pair endpoint rate-limited with a 64-bit code
 - Sink-side blocklist + allowlist, persistent replay defense (nanosecond sequence survives restart)
-- Apple Developer ID signed binaries; per-binary Keychain ACL on both Chrome Safe Storage and the new `agentcookie-master` key
+- Apple Developer ID signed binaries; per-binary `-T` Keychain ACL on Chrome Safe Storage replaces v0.10's any-app ACL
 - One-time install ceremony covered by `agentcookie wizard install`
-- 258 unit tests across 22 packages
+- 261 unit tests across 22 packages
 
 Not yet:
 
-- PP CLI sidecar-reader migration in cli-printing-press so each adapter PP CLI links `pkg/sidecar` directly (U12; the sink falls back to plaintext when older PP CLIs are detected)
+- PP CLI sidecar-reader migration in cli-printing-press so each adapter PP CLI links `pkg/sidecar` directly (U12). Unblocks flipping at-rest sealing on by default and closes threat-survey finding S5
 - `agentcookie pair --rotate` for live key rotation
 - One-to-many fan-out (one laptop, multiple sinks)
 - Linux + Windows source and sink support

--- a/docs/runbook-v0.12-security-hardening.md
+++ b/docs/runbook-v0.12-security-hardening.md
@@ -17,14 +17,31 @@ What changed behind the curtain:
 
 ## One-time install
 
-On a fresh Mac mini sink, the v0.12 wizard install runs the same `agentcookie wizard install --as sink ...` command as v0.11. The added steps run automatically:
+On a fresh Mac mini sink, the v0.12 wizard install runs the same `agentcookie wizard install --as sink ...` command as v0.11. Steps:
 
 1. Detect the Tailscale 100.x interface and write it as `listen.addr` in `sink.yaml`.
 2. Build a trust list naming the agentcookie sink binary (resolved via `os.Executable` + `filepath.EvalSymlinks`) plus each adapter binary passed via `--extra-binary`.
-3. Recreate the Chrome Safe Storage Keychain item with the v0.12 `-T` ACL.
-4. Create the `agentcookie-master` Keychain item (32 random bytes, hex-encoded) with the same `-T` ACL.
+3. Recreate the Chrome Safe Storage Keychain item with the v0.12 `-T` ACL. Replaces the v0.10 `-A` (any-app) ACL.
 
 A single Keychain unlock prompt fires once. After that, every silent read from the sink binary and registered adapter binaries works headlessly.
+
+## At-rest sealing (opt-in, off by default in v0.12)
+
+The sidecar SQLite and adapter session files have at-rest sealing wired up under the `agentcookie-master` Keychain item, but the wizard install does NOT create that Keychain item by default. The PP CLI consumer side of sealing (U12) has not shipped in cli-printing-press yet; turning sealing on without the matching PP CLI release would break v0.11 PP CLI reads.
+
+To opt in once the matching cli-printing-press release lands:
+
+```
+agentcookie wizard set-keychain-access --enable-sealing
+```
+
+After that command, the `agentcookie-master` Keychain item exists and the next sync writes sealed envelopes to the sidecar and adapter session files. To revert:
+
+```
+security delete-generic-password -s agentcookie-master -a agentcookie
+```
+
+The sink falls back to plaintext writes on the next sync.
 
 ## Verify
 
@@ -33,9 +50,10 @@ A single Keychain unlock prompt fires once. After that, every silent read from t
 security find-identity -v -p codesigning
 # Expect one identity matching "Developer ID Application: ... (NM8VT393AR)"
 
-# Confirm master key Keychain item exists
+# Confirm master key Keychain item is OFF (v0.12 default)
 security find-generic-password -s agentcookie-master -a agentcookie
-# Expect a "keychain:" line; no value (the -w flag would print it)
+# Expect: "could not be found in the keychain" (sealing off by default)
+# After `wizard set-keychain-access --enable-sealing`: expect a "keychain:" line
 
 # Confirm Chrome Safe Storage carries the v0.12 -T allowlist
 security dump-keychain | grep -A 5 "Chrome Safe Storage"
@@ -56,8 +74,8 @@ strings ~/.agentcookie/cookies-plain.db | head
 |---|---|---|
 | Sink fails to start with "listen.addr is required" | `sink.yaml` was generated before v0.12 | Re-run `agentcookie wizard install --as sink` to detect the Tailscale interface and write a concrete listen address. |
 | Sink fails to start with "Tailscale not running" | `tailscaled` is stopped | Start Tailscale (`tailscale up`) then re-run the wizard install. |
-| `agentcookie status` shows `master key: missing` | The `agentcookie-master` Keychain item was deleted | Re-run `agentcookie wizard install --as sink`; the master key is recreated and the trust list reapplied. Existing sealed sidecar / adapter session files become unreadable until the next source sync repopulates them. |
-| Sealed sidecar present but a PP CLI returns empty cookies | PP CLI is still on v0.11 and reads `value` directly; sees the `agc1:` prefix as gibberish | Update the PP CLI to import `pkg/sidecar.ReadSidecar` (U12 work in cli-printing-press). Until then, the sink falls back to plaintext when the master key is absent; deleting the master key Keychain item is a temporary workaround. |
+| `agentcookie status` shows `master key: missing` AND sealing is supposed to be on | The `agentcookie-master` Keychain item was deleted or never created | Run `agentcookie wizard set-keychain-access --enable-sealing`. The master key is created with the trust list reapplied. Existing sealed sidecar / adapter session files become unreadable until the next source sync repopulates them. |
+| Sealed sidecar present but a PP CLI returns empty cookies | PP CLI is still on v0.11 and reads `value` directly; sees the `agc1:` prefix as gibberish | Either update the PP CLI to import `pkg/sidecar.ReadSidecar` (U12 work in cli-printing-press) or revert sealing with `security delete-generic-password -s agentcookie-master -a agentcookie`. |
 | Pair endpoint returns 429 | Per-IP rate limit hit | Wait 500ms per token (max 5 tokens accumulate). Confirm the source's pair URL is correct; a typo in the URL hostname leads to repeated wrong-code POSTs. |
 | Pair endpoint hangs | Pre-v0.12 source talking to a v0.12 sink | The PairTimeout (10 minutes) still applies; the 30-second client-side timeout is the new floor. Update both ends to v0.12. |
 

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -19,7 +19,7 @@ agentcookie trusts:
 ## What agentcookie protects against
 
 - Plaintext cookies in transit. Every payload is AES-256-GCM-sealed with a per-pair key. The key never appears unencrypted on the wire.
-- Plaintext cookies at rest on the sink. When the v0.12 `agentcookie-master` Keychain item is present, the sink's plaintext sidecar SQLite is stored as sealed envelopes per value, and each adapter session file's secret-bearing fields are sealed under the same key. A non-allowlisted user-uid process reading those files sees opaque envelopes, not cookie values.
+- Plaintext cookies at rest on the sink (opt-in in v0.12). The sealing infrastructure is shipped: when the `agentcookie-master` Keychain item is present, the sink's sidecar SQLite is stored as sealed envelopes per value and each adapter session file's secret-bearing fields are sealed under the same key. The wizard install does NOT create the master key by default in v0.12 because the PP CLI consumer-side of sealing (U12) has not shipped in cli-printing-press yet. Pass `wizard set-keychain-access --enable-sealing` to opt in once the matching PP CLI release lands. Until then, the sidecar and adapter session files are plaintext on disk; finding S5 (plaintext sidecar) stays open in the default configuration.
 - Plaintext access to Chrome's own cookie store on the sink. v0.12 replaces the v0.10 `-A` (any-app) Keychain ACL on the Chrome Safe Storage password with a `-T` per-binary list. Only the agentcookie sink and registered adapter binaries can decrypt Chrome's Cookies SQLite silently; everything else needs a user prompt.
 - Online brute force of the pairing code. v0.12: 12 base32 characters (64 bits of entropy) and a per-IP token bucket capped at 5 attempts before a 429.
 - MITM during pairing. X25519 + HKDF salted with the pairing code means an attacker who intercepts the channel without knowing the code derives a different key, and the next AEAD message fails its tag check.
@@ -52,7 +52,7 @@ agentcookie trusts:
 
 ## What changes when
 
-- v0.12 (this release) closes every Critical and High finding from the v0.11 threat survey except U12 (PP CLI sidecar-reader migration). Until U12 lands, the PP CLI consumer side reads v0.11 plaintext sidecars; the sink writer detects the v0.11 client and emits plaintext rather than sealed envelopes.
+- v0.12 (this release) closes every Critical and High finding from the v0.11 threat survey except S5 (plaintext sidecar at rest), which stays open in the default install because turning sealing on requires the PP CLI consumer-side (U12) to ship in cli-printing-press first. Operators who only run agentcookie-controlled binaries on the sink can pass `wizard set-keychain-access --enable-sealing` to opt in; the on-disk sidecar and adapter session files become sealed and S5 closes for them.
 - v0.13 (planned) will migrate the paired key keystore at `~/.config/agentcookie/keys/<peer>.json` into the macOS Keychain, closing the last on-disk plaintext credential.
 - v0.14 or later may add Linux sink support, a Chrome extension on the sink, and one-to-many fan-out. Each of those reopens parts of this document; re-read before adopting.
 

--- a/internal/cli/wizard_keychain.go
+++ b/internal/cli/wizard_keychain.go
@@ -20,6 +20,7 @@ import (
 var (
 	setKeychainExtraBinary []string
 	innerRunnerMode        bool
+	setKeychainEnableSeal  bool
 )
 
 var setKeychainAccessCmd = &cobra.Command{
@@ -49,6 +50,13 @@ func init() {
 	setKeychainAccessCmd.Flags().StringArrayVar(&setKeychainExtraBinary, "extra-binary", nil, "absolute path to a kooky-using CLI binary; added to the trust-list fallback if partition-list strategies do not cover it; repeatable")
 	setKeychainAccessCmd.Flags().BoolVar(&innerRunnerMode, "inner-runner", false, "run the strategy loop in this process (used internally when invoked as a one-shot LaunchAgent); end users do not pass this")
 	_ = setKeychainAccessCmd.Flags().MarkHidden("inner-runner")
+	// --enable-sealing: hidden v0.12 flag that turns on at-rest sealing
+	// of the sidecar SQLite and adapter session files. Off by default
+	// because the PP CLI side of the sealing handshake (U12) has not
+	// shipped yet; flipping this on without that work breaks PP CLI
+	// reads. Will become default-on once U12 lands in cli-printing-press.
+	setKeychainAccessCmd.Flags().BoolVar(&setKeychainEnableSeal, "enable-sealing", false, "create the agentcookie-master Keychain item and turn on at-rest sealing of the sidecar SQLite and adapter session files")
+	_ = setKeychainAccessCmd.Flags().MarkHidden("enable-sealing")
 	wizardCmd.AddCommand(setKeychainAccessCmd)
 }
 
@@ -91,6 +99,9 @@ func runOuterWizard(cmd *cobra.Command) error {
 	for _, b := range setKeychainExtraBinary {
 		argv = append(argv, "--extra-binary", b)
 	}
+	if setKeychainEnableSeal {
+		argv = append(argv, "--enable-sealing")
+	}
 
 	fmt.Fprintln(os.Stderr, "agentcookie wizard: running keychain strategies via a one-shot LaunchAgent (no prompts expected; if a Mac mini desktop prompt appears, click Always Allow and re-run)")
 
@@ -128,7 +139,7 @@ func runOuterWizard(cmd *cobra.Command) error {
 // the login keychain is unlocked. Iterates strategies, probes after
 // each, emits structured JSON on stdout for the outer wizard to parse.
 func runInnerStrategyLoop(cmd *cobra.Command) error {
-	strategies := buildStrategies(setKeychainExtraBinary)
+	strategies := buildStrategies(setKeychainExtraBinary, setKeychainEnableSeal)
 
 	var result runResult
 	for _, s := range strategies {
@@ -155,7 +166,7 @@ type kcStrategy struct {
 	apply func() (detail string, err error)
 }
 
-func buildStrategies(extraBinaries []string) []kcStrategy {
+func buildStrategies(extraBinaries []string, enableSealing bool) []kcStrategy {
 	// Trust list: the running agentcookie binary plus every adapter
 	// binary in extraBinaries. Master key + Chrome Safe Storage ACLs
 	// both use this same list so any allowlisted process can read
@@ -179,9 +190,16 @@ func buildStrategies(extraBinaries []string) []kcStrategy {
 			// agentcookie binary carries a Developer ID Application
 			// designated requirement, the ACL stays valid across
 			// rebuilds with the same identity.
+			//
+			// When enableSealing is true, the strategy also installs the
+			// agentcookie-master Keychain item that the sidecar and
+			// adapter writers use for at-rest sealing. Off by default
+			// in v0.12 because the PP CLI consumer-side of sealing
+			// (U12) has not shipped; turning sealing on without that
+			// would break v0.11 PP CLIs that read plaintext.
 			name: "delete-and-recreate-with-T",
 			apply: func() (string, error) {
-				_, _ = execSecurity("delete-generic-password",
+				_, _ = execSecurityFunc("delete-generic-password",
 					"-s", "Chrome Safe Storage", "-a", "Chrome")
 				pw := randomKeychainPassword()
 				args := append([]string{
@@ -189,13 +207,13 @@ func buildStrategies(extraBinaries []string) []kcStrategy {
 					"-s", "Chrome Safe Storage", "-a", "Chrome",
 					"-w", pw,
 				}, trustArgs...)
-				if detail, err := execSecurity(args...); err != nil {
+				if detail, err := execSecurityFunc(args...); err != nil {
 					return detail, err
 				}
-				// Also (re)install the agentcookie-master Keychain item
-				// in the same flow so the entire v0.12 install is
-				// idempotent in one strategy step.
-				if err := keystore.CreateMasterKey(trustList, extraBinaries); err != nil {
+				if !enableSealing {
+					return "Chrome Safe Storage installed with -T allowlist (sealing not enabled; pass --enable-sealing once PP CLI U12 ships)", nil
+				}
+				if err := createMasterKeyFunc(trustList, extraBinaries); err != nil {
 					return "", fmt.Errorf("create agentcookie-master: %w", err)
 				}
 				return "Chrome Safe Storage + agentcookie-master installed with -T allowlist", nil
@@ -292,6 +310,12 @@ func tryStrategy(s kcStrategy) strategyOutcome {
 
 // execSecurity runs /usr/bin/security with the given args, returns
 // "stdout||stderr" as detail. Caller treats non-zero exit as failure.
+//
+// Indirection via execSecurityFunc lets tests inject a stub that records
+// invocations without shelling out. Production code calls the real
+// execSecurity via the function pointer.
+var execSecurityFunc = execSecurity
+
 func execSecurity(args ...string) (string, error) {
 	cmd := exec.Command("/usr/bin/security", args...)
 	out, err := cmd.CombinedOutput()
@@ -301,6 +325,11 @@ func execSecurity(args ...string) (string, error) {
 	}
 	return detail, nil
 }
+
+// createMasterKeyFunc indirects keystore.CreateMasterKey so tests can
+// observe whether the sealing-on path was taken without actually
+// writing to the macOS Keychain.
+var createMasterKeyFunc = keystore.CreateMasterKey
 
 func lastJSONLine(s string) string {
 	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")

--- a/internal/cli/wizard_keychain_sealing_test.go
+++ b/internal/cli/wizard_keychain_sealing_test.go
@@ -1,0 +1,105 @@
+package cli
+
+import (
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// TestPrimaryStrategy_OffByDefault_DoesNotCreateMasterKey proves the
+// v0.12-with-deferred-U12 default: a wizard install with no sealing
+// flag does NOT call keystore.CreateMasterKey, even after the Chrome
+// Safe Storage delete-and-recreate step succeeds. The detail message
+// surfaces the "sealing not enabled" line so log readers know why no
+// master key was installed.
+func TestPrimaryStrategy_OffByDefault_DoesNotCreateMasterKey(t *testing.T) {
+	origSec := execSecurityFunc
+	origMaster := createMasterKeyFunc
+	t.Cleanup(func() {
+		execSecurityFunc = origSec
+		createMasterKeyFunc = origMaster
+	})
+
+	execSecurityFunc = func(args ...string) (string, error) {
+		return "ok", nil
+	}
+	var masterCalls atomic.Int32
+	createMasterKeyFunc = func(bin string, extras []string) error {
+		masterCalls.Add(1)
+		return nil
+	}
+
+	strategies := buildStrategies(nil, false)
+	if len(strategies) < 1 {
+		t.Fatal("expected at least one strategy")
+	}
+	if strategies[0].name != "delete-and-recreate-with-T" {
+		t.Fatalf("primary strategy name: got %q, want delete-and-recreate-with-T", strategies[0].name)
+	}
+	detail, err := strategies[0].apply()
+	if err != nil {
+		t.Fatalf("primary strategy apply: %v", err)
+	}
+	if !strings.Contains(detail, "sealing not enabled") {
+		t.Errorf("expected sealing-disabled message in detail, got %q", detail)
+	}
+	if got := masterCalls.Load(); got != 0 {
+		t.Errorf("CreateMasterKey called %d times; want 0 in default-off mode", got)
+	}
+}
+
+// TestPrimaryStrategy_WithSealingFlag_CreatesMasterKey: with the
+// hidden --enable-sealing flag wired through, the strategy DOES call
+// keystore.CreateMasterKey exactly once.
+func TestPrimaryStrategy_WithSealingFlag_CreatesMasterKey(t *testing.T) {
+	origSec := execSecurityFunc
+	origMaster := createMasterKeyFunc
+	t.Cleanup(func() {
+		execSecurityFunc = origSec
+		createMasterKeyFunc = origMaster
+	})
+
+	execSecurityFunc = func(args ...string) (string, error) {
+		return "ok", nil
+	}
+	var masterCalls atomic.Int32
+	var masterBinary string
+	var masterExtras []string
+	createMasterKeyFunc = func(bin string, extras []string) error {
+		masterCalls.Add(1)
+		masterBinary = bin
+		masterExtras = extras
+		return nil
+	}
+
+	extras := []string{"/Users/me/go/bin/instacart-pp-cli"}
+	strategies := buildStrategies(extras, true)
+	if _, err := strategies[0].apply(); err != nil {
+		t.Fatalf("primary strategy apply: %v", err)
+	}
+	if got := masterCalls.Load(); got != 1 {
+		t.Errorf("CreateMasterKey called %d times; want 1 in sealing-on mode", got)
+	}
+	if masterBinary == "" {
+		t.Errorf("CreateMasterKey called with empty agentcookie binary path")
+	}
+	if len(masterExtras) != len(extras) || masterExtras[0] != extras[0] {
+		t.Errorf("CreateMasterKey extras: got %v, want %v", masterExtras, extras)
+	}
+}
+
+// TestBuildStrategies_ChainShapeUnchangedByFlag proves the strategy
+// chain length and ordering do not change when --enable-sealing is
+// toggled. Only the primary strategy's apply behavior differs.
+func TestBuildStrategies_ChainShapeUnchangedByFlag(t *testing.T) {
+	off := buildStrategies(nil, false)
+	on := buildStrategies(nil, true)
+	if len(off) != len(on) {
+		t.Errorf("strategy chain length differs by flag: off=%d on=%d", len(off), len(on))
+	}
+	for i := range off {
+		if off[i].name != on[i].name {
+			t.Errorf("strategy[%d] name differs by flag: off=%q on=%q", i, off[i].name, on[i].name)
+		}
+	}
+}

--- a/internal/cli/wizard_keychain_test.go
+++ b/internal/cli/wizard_keychain_test.go
@@ -36,7 +36,7 @@ func TestLastJSONLine_TrailingNewlinesIgnored(t *testing.T) {
 }
 
 func TestBuildStrategies_PrimaryIsDeleteAndRecreate(t *testing.T) {
-	s := buildStrategies(nil)
+	s := buildStrategies(nil, false)
 	if len(s) < 1 {
 		t.Fatal("expected at least one default strategy")
 	}
@@ -49,7 +49,7 @@ func TestBuildStrategies_PrimaryIsDeleteAndRecreate(t *testing.T) {
 }
 
 func TestBuildStrategies_PartitionListFallbackComesSecond(t *testing.T) {
-	s := buildStrategies(nil)
+	s := buildStrategies(nil, false)
 	if len(s) < 2 {
 		t.Fatal("expected partition-list fallback to exist")
 	}
@@ -59,8 +59,8 @@ func TestBuildStrategies_PartitionListFallbackComesSecond(t *testing.T) {
 }
 
 func TestBuildStrategies_ExtraBinariesAppearAfterDefaultStrategies(t *testing.T) {
-	defaults := buildStrategies(nil)
-	withExtras := buildStrategies([]string{"/Users/me/go/bin/instacart-pp-cli", "/Users/me/go/bin/bird"})
+	defaults := buildStrategies(nil, false)
+	withExtras := buildStrategies([]string{"/Users/me/go/bin/instacart-pp-cli", "/Users/me/go/bin/bird"}, false)
 	if len(withExtras) != len(defaults)+2 {
 		t.Fatalf("expected %d default + 2 extra-binary strategies, got %d", len(defaults), len(withExtras))
 	}


### PR DESCRIPTION
## Summary

The v0.12 work shipped through PR #45 turned at-rest sealing of the cookie sidecar SQLite and adapter session files on by default in the wizard install. With U12 (PP CLI sidecar-reader migration in cli-printing-press) still deferred, that default broke v0.11 PP CLIs: they read the sidecar's value column directly and saw `agc1:`-prefixed envelopes as gibberish cookie values.

This change gates master-key creation behind a hidden `--enable-sealing` flag on `wizard set-keychain-access`, off by default.

Net result:

- Fresh wizard install on v0.12 main produces a working sink with `keystore.MasterKeyExists()` returning false. U6 and U7's sealing branches stay dormant; sidecar and adapter session files stay plaintext (v0.11 shape). v0.11 PP CLIs continue to work unchanged.
- Chrome Safe Storage Keychain item is still recreated with the v0.12 `-T` allowlist (replacing v0.10's `-A`). That security win does not depend on PP CLI sealing support and stays in.
- Existing machines that already created the master key (by running v0.12 main between PR #42 and now) keep it. Manual removal via `security delete-generic-password -s agentcookie-master -a agentcookie` reverts.
- When U12 ships in cli-printing-press, the matching agentcookie release flips the `--enable-sealing` default to on.

Threat-survey finding S5 (plaintext sidecar at rest) stays open in the default install. Operators who control every binary on the sink can opt in immediately with `wizard set-keychain-access --enable-sealing`.

Docs updated in the same commit so the published threat-model.md and runbook-v0.12-security-hardening.md accurately describe the sealing-off-by-default state.

Plan: `docs/plans/2026-05-18-003-feat-defer-sealing-until-pp-cli-migration-plan.md`.

## Test plan

- [x] `go test -race ./...` passes (261 tests, 22 packages)
- [x] New `wizard_keychain_sealing_test.go` covers: default-off does not call CreateMasterKey; `--enable-sealing` does; chain shape unchanged by flag
- [x] Existing `wizard_keychain_test.go` updated for the new `buildStrategies` signature

Generated with [Claude Code](https://claude.com/claude-code).