### PR TITLE
docs(u6): closed-beta dry-run friction log (2026-05-19)

### DIFF
--- a/docs/dry-run-2026-05-19.md
+++ b/docs/dry-run-2026-05-19.md
@@ -1,0 +1,93 @@
+# U6 first-friend dry-run — 2026-05-19
+
+Plan: `2026-05-19-001 U6` (referenced in PR #48 commit body, not checked in as a plan file).
+
+Goal: walk the closed-beta `install-beta.sh` end-to-end on a clean sink, capture friction, decide go/no-go for the first friend invite.
+
+Setup:
+
+- Release artifact: `v0.12.0-beta.1` published as prerelease at https://github.com/mvanhorn/agentcookie/releases/tag/v0.12.0-beta.1 (sha256 `3ba6692282849bbfd4653cd0f99332248e869cd3243445dc0f57bd1705328409`).
+- Source: this laptop (Tailscale `macbook-pro-44`, Bonjour `MacBook-Pro-8.local`). Existing v0.12 install left in place per Matt's "sink-only reset" decision.
+- Sink: `matts-mac-mini` (Tailscale), `moltbot-mini.hsd1.wa.comcast.net` (Bonjour). Wiped before install:
+  - `launchctl bootout` of `dev.agentcookie.sink`
+  - `rm -rf ~/.agentcookie ~/bin/agentcookie ~/Library/LaunchAgents/dev.agentcookie.sink.plist`
+  - Backup tarball preserved at `/tmp/agentcookie-mac-mini-backup-20260519-225447.tar.gz` (used to restore at end).
+  - `~/.config/agentcookie/` NOT touched (see friction #13).
+- Install method: `ssh matts-mac-mini ./install-beta.sh --as sink --peer macbook-pro-44 --tarball <path>`.
+
+## Verdict
+
+**Not ready for friend #1.** Five blockers in a single attempt. The closed-beta path as shipped cannot install successfully on a clean Mac mini over SSH.
+
+## Friction log
+
+### Blockers (must fix before any invite)
+
+**#7 install-beta.sh tarball extraction is broken.** Script does `tar -xzf "$TARBALL" -C "$WORK"` then looks for `$WORK/agentcookie`, but `release-tarball.sh` wraps everything in a top-level `agentcookie-${VERSION}-darwin-arm64/` directory. Every friend will hit `die "agentcookie binary not found inside tarball"`. Fix: replace `NEW_BIN="$WORK/agentcookie"` with a `find`-based lookup, e.g. `NEW_BIN="$(find "$WORK" -name agentcookie -type f -perm -u+x | head -1)"`.
+
+**#9 install-beta.sh has no --code / --pair-url passthrough.** Wizard install on sink role requires `--code` and `--pair-url` (per `agentcookie wizard install --help`), but `install-beta.sh` only forwards `--as`, `--peer`, `--extra-binary`. Friends running `./install-beta.sh --as sink` get `agentcookie: --code and --pair-url are required when --as sink` with no hint that the wrapping script is missing the flags. Fix: add `--code` and `--pair-url` flags to install-beta.sh's arg parser and `WIZARD_ARGS` construction.
+
+**#11 Wizard install triggers a Keychain prompt that can't be answered over SSH.** Default wizard run prints "triggering Chrome Safe Storage Keychain prompt (click 'Always Allow' when macOS asks)" then `exit status 36 (re-run after granting Always Allow, or pass --skip-keychain-prompt)`. The expected friend deployment is headless Mac mini accessed via SSH, where no one is at the screen to click. Workaround flag `--skip-keychain-prompt` exists but isn't surfaced by `install-beta.sh`. Fix: install-beta.sh should auto-detect headless invocation (no TTY on the Mac mini's GUI session) and add `--skip-keychain-prompt` to WIZARD_ARGS, with a clear post-install message saying "you'll need to grant Keychain access manually on first physical visit."
+
+**#17 Pair handshake saves the source-side key under the sink's Bonjour FQDN, but `source.yaml.peer.hostname` is the Tailscale name, so the running source LaunchAgent looks up the wrong key file and silently fails to sync.**
+
+- Source's `~/.config/agentcookie/keys/moltbot-mini.hsd1.wa.comcast.net.json` was created (Bonjour FQDN).
+- Source's `source.yaml` has `peer.hostname: matts-mac-mini` (Tailscale name), so it looks up `keys/matts-mac-mini.json` (the stale pre-reset key).
+- Sink-side symmetric: sink's `keys/MacBook-Pro-8.local.json` (announced source name) vs `sink.yaml.peer.hostname: macbook-pro-44`. Wizard did NOT rewrite `sink.yaml` even though it knew the new peer name from `--peer`.
+- Failure mode is silent: source logs `connection refused` (looks like a transient network issue), not "key not found."
+
+Fix: pair handshake should write the key file using the peer's `--local-name` (which the wizard already knows because it generated it), not the peer's `os.Hostname()` discovered during the TLS handshake. Wizard install should also rewrite `source.yaml`/`sink.yaml`'s `peer.hostname` to match.
+
+**#18 Sink LaunchAgent does NOT bind the listener after wizard install over SSH.** Sink process runs and processes the adapter push loop (visible in `sink.out.log`), but `lsof -nP -iTCP:9999` shows zero listeners. Source repeatedly hits `connect: connection refused`. Foreground run shows `read Chrome Safe Storage from Keychain: exit status 36` — the listener startup path likely depends on a Keychain read that fails over SSH but the daemon doesn't crash; it just silently skips binding.
+
+Recovery from this state requires a physical visit to the Mac mini to grant Always Allow (or to re-run `wizard install` from a logged-in GUI session). Closed-beta `install-beta.sh` does not warn about this.
+
+### Major friction (degraded friend UX)
+
+**#10 Source announces Bonjour hostname (`MacBook-Pro-8.local`), not Tailscale name (`macbook-pro-44`).** Friends copy-paste the command the source prints (`agentcookie pair --as sink --peer MacBook-Pro-8.local --pair-url http://100.98.176.68:9998/pair --code ...`) and end up using Bonjour for everything. Works on same LAN, breaks cross-network (Tailscale across two LANs). Fix: when Tailscale is detected, default `--local-name` to the Tailscale hostname.
+
+**#12-14 State lives in TWO dirs and reset is incomplete.**
+
+- `~/.agentcookie/` — runtime state (cookies-plain.db, sink-state.json, logs, chrome-profile).
+- `~/.config/agentcookie/` — config (sink.yaml, allowlist.yaml, keys/).
+- Wizard install `--as sink --peer X` doesn't rewrite `sink.yaml.peer.hostname` even when the new peer is different from the existing config. Stale config silently survives a "fresh install."
+- There is no documented uninstall flow. Friends who want to start over have no clean path.
+
+Fix: ship `agentcookie wizard uninstall` that nukes both dirs + LaunchAgent + Keychain items. Document it in `quickstart-beta.md`.
+
+**#15 The v0.10 set-keychain-access strategy LaunchAgent hangs for 30s when a Keychain prompt appears over SSH and times out with a warning.** The wizard continues but kooky-using CLIs will then prompt per binary on first read. This is a documented degraded mode but the warning is buried in a wall of output friends won't parse.
+
+**#16 Wizard "tailnet peer not found in Tailscale status" check uses the source's announced (Bonjour) hostname instead of the Tailscale name, so the exit-node hint always fails.**
+
+### Cosmetic / lower-priority
+
+**#1 CI release workflow runs show "failed" instead of "skipped" when the job-level `if:` gate evaluates to false.** GitHub renders zero-job workflow runs as `failure`. Cosmetic but pollutes the runs tab. Three red runs created during v0.12.0-beta.1 release cut. Fix: add a tiny always-running summary job, or switch trigger to `workflow_dispatch` until CI signing secrets are wired.
+
+**#2 `agentcookie version` returns `0.0.1-dev`, not the release tag.** Makefile doesn't inject the tag at build time via `-ldflags`. Friends checking version will see a misleading value.
+
+**#3 / #4 `spctl -a -vv agentcookie` returns "rejected (the code is valid but does not seem to be an app)" for the CLI binary.** This is expected behavior — `spctl -a` assesses for app bundles, not standalone Mach-O executables. But the release-notes template, `install-beta.sh`'s notarization check, and friends running the documented verification will all see "rejected" and think the binary is broken. Fix: replace `spctl -a -vv` with `codesign --verify --strict --verbose=2` + `codesign -d -r-` in all three places; document the `spctl` behavior in the runbook.
+
+**#5 / #8 `~/bin` is not on the default macOS `$PATH`**, so `install-beta.sh` prints a warning and continues. The LaunchAgent uses absolute paths and works fine, but `agentcookie` invoked from a fresh shell fails. Friends running `agentcookie doctor` post-install hit `command not found`. Fix: either install to `/usr/local/bin` (requires sudo, which the script avoids), or write a brew formula, or add `export PATH="$HOME/bin:$PATH"` to a profile fragment with friend's consent.
+
+**#6 `gh release download` requires `gh auth` and access to a private repo.** Friends need to be added as collaborators to `mvanhorn/agentcookie` before they can fetch the release tarball via the script. The install-beta.sh `die` message for unauthed gh doesn't mention this. Fix: document the collaborator-add step in the invite DM template, and have install-beta.sh print a friendlier message linking to it.
+
+## State after dry-run
+
+- v0.12.0-beta.1 release published, prerelease, tarball attached. **Not safe to share with friends until #7/#9/#11/#17/#18 are fixed.**
+- Mac mini sink: restored to pre-reset binary + runtime state from backup, sink.yaml reverted to `peer: macbook-pro-44`, both old and new key files present in `keys/`. **Sink LaunchAgent runs but does NOT bind 9999** — sync from source is broken until manual recovery (probably needs physical Always-Allow click + wizard repair).
+- Source (this laptop): LaunchAgent restarted, restored old shared key (cp'd from sink's preserved `keys/macbook-pro-44.json`), repeatedly hits `connect: connection refused` on push. Will resume automatically when sink listener comes back.
+- Backup artifacts kept on Mac mini: `/tmp/agentcookie-mac-mini-backup-20260519-225447.tar.gz`, `/tmp/dev.agentcookie.sink.plist`.
+
+## Recommended next steps (sequenced)
+
+1. Cut a follow-up PR fixing **#7** (tarball lookup) + **#9** (install-beta.sh code/pair-url passthrough) + **#3/#4** (replace `spctl` with `codesign`) + **#11** (default `--skip-keychain-prompt` when no TTY) + **#5** (PATH hint). These are all one-file changes in `scripts/install-beta.sh` + `docs/quickstart-beta.md` + `.github/RELEASE_NOTES_TEMPLATE.md`.
+2. Fix **#17 / #14** (wizard install rewrites sink.yaml/source.yaml.peer.hostname; pair uses --local-name for key filename, not handshake-discovered name). This is the load-bearing correctness bug — without this, every fresh pair handshake produces a silently-broken config.
+3. Fix **#18** (sink listener should fail loud when Keychain read fails at startup, not silently keep running with adapter loop only).
+4. Re-cut as `v0.12.0-beta.2`. Re-run U6 dry-run with both source AND sink reset (Matt physically present at Mac mini for Keychain prompt OR test via VNC).
+5. After clean dry-run pass: ship invite #1.
+
+## Other observations
+
+- `gh release create v0.12.0-beta.1` worked cleanly; the `--target main` + `--prerelease` shape is the right pattern.
+- `make release` (build + sign + notarize) ran in ~30s as advertised. The notarytool credential setup (`agentcookie-notary` profile in login keychain) was already in place from earlier work.
+- The v0.12 hardening (sealed master key, tailnet-only listeners, rate-limited pairing) is invisible in this dry-run because **sealing is default-off** until U12 ships in cli-printing-press. Worth re-running this dry-run AFTER U12 lands to verify the sealed-by-default path.


### PR DESCRIPTION
## Summary

Walked the v0.12.0-beta.1 release end-to-end on a clean Mac mini sink over SSH. Found 5 blockers + 4 major issues + 8 cosmetic items in a single attempt. **Closed beta is not ready for friend #1.**

Full friction log: [`docs/dry-run-2026-05-19.md`](../blob/feat/u6-dry-run-friction-log/docs/dry-run-2026-05-19.md).

## Top-line blockers

| # | What |
|---|------|
| 7 | `install-beta.sh` extracts the tarball into `$WORK` then looks for `$WORK/agentcookie`, but `release-tarball.sh` wraps everything in a top-level dir |
| 9 | `install-beta.sh --as sink` always fails with `--code and --pair-url are required` because the wrapper script has no passthrough for those flags |
| 11 | Wizard install triggers a Keychain prompt that can't be answered over SSH; `--skip-keychain-prompt` workaround isn't surfaced |
| 17 | Pair handshake saves key under peer's Bonjour FQDN; `sink.yaml` / `source.yaml` hold Tailscale name; running daemons look up wrong key, silently fail to sync |
| 18 | Sink LaunchAgent runs the adapter loop but does NOT bind 9999 when Chrome Safe Storage keychain read fails; failure is silent |

## Recommended ship path

1. One PR fixes #7 + #9 + #11 + #3/#4 + #5 (all in `scripts/install-beta.sh` + docs)
2. One PR fixes #17 + #14 (wizard rewrites `peer.hostname`; pair uses `--local-name` for key filename)
3. One PR fixes #18 (listener startup fails loud)
4. Cut `v0.12.0-beta.2` and re-run U6 with both ends reset

## State after dry-run

- v0.12.0-beta.1 release is published as prerelease. Tarball is signed + notarized correctly.
- Mac mini sink restored from `/tmp` backup. Sink LaunchAgent runs but doesn't bind 9999 - sync is broken until physical Keychain Always-Allow grant on the Mac mini.
- Source LaunchAgent on this laptop retries `connection refused` harmlessly.

## Test plan

- [x] Friction log readable and actionable
- [ ] No follow-on changes in this PR; this is documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)