### PR TITLE
fix(install-beta): tarball lookup, code/pair-url passthrough, codesign verify, headless skip

### DIFF
--- a/.github/RELEASE_NOTES_TEMPLATE.md
+++ b/.github/RELEASE_NOTES_TEMPLATE.md
@@ -19,12 +19,18 @@ See `quickstart-beta.md` inside the tarball for the ten-minute walkthrough.
 ## Verifying the binary
 
 ```
-spctl -a -vv agentcookie
-# expected: accepted (notarized Developer ID)
+codesign --verify --strict --verbose=2 agentcookie
+# expected: valid on disk / satisfies its Designated Requirement
 
 codesign -d -r- agentcookie
 # expected: identifier "agentcookie" ... certificate leaf[subject.OU] = NM8VT393AR
 ```
+
+`spctl -a` is the wrong assessment tool for this CLI binary - it
+expects an app bundle and reports "rejected: not an app" even when
+the binary is correctly signed and notarized. Use the `codesign`
+commands above instead. The notarization ticket is verified by
+Apple's notary service on first launch.
 
 ## What's in this release
 

--- a/docs/quickstart-beta.md
+++ b/docs/quickstart-beta.md
@@ -49,14 +49,20 @@ Same flow, opposite role:
 
 1. SSH or screen-share into your sink Mac.
 2. Extract the same release tarball.
-3. Run: `./install-beta.sh --as sink`. It will:
-   - Verify notarization
-   - Place the binary
-   - Prompt for your MacBook's Tailscale hostname and the pairing code
-   - Prompt for adapter binaries you want to grant Chrome cookie access to (e.g. `instacart-pp-cli`, `table-reservation-goat-pp-cli`)
-   - Run `agentcookie wizard install --as sink --peer <macbook> --code <pairing-code> --extra-binary ...` interactively
+3. Run: `./install-beta.sh --as sink --peer <macbook> --code <pairing-code> --pair-url <pair-url>` (the source's wizard install printed the code + URL for you to copy here).
+4. The script verifies the code signature, places the binary, runs `agentcookie wizard install --as sink ...`, and ends with `doctor`.
 
 You'll see one Keychain prompt asking permission for `agentcookie` to access Chrome Safe Storage. Click **Always Allow**.
+
+### Headless sink (SSH-only, no monitor on the second Mac)
+
+If the second Mac is headless and you're installing over SSH with no one at the screen to click prompts, `install-beta.sh` auto-detects "no TTY" and adds `--skip-keychain-prompt` to the wizard. The install completes, but the sink daemon won't be able to read Chrome Safe Storage until you grant Always Allow once. To do that, either physically log into the sink Mac or open a Screen Sharing session, then run:
+
+```
+~/bin/agentcookie sink
+```
+
+That triggers the Keychain prompt in the GUI session. Click **Always Allow**, then Ctrl-C and restart the LaunchAgent: `launchctl bootout "gui/$(id -u)/dev.agentcookie.sink"; launchctl bootstrap "gui/$(id -u)" ~/Library/LaunchAgents/dev.agentcookie.sink.plist`. Sync resumes within seconds.
 
 ## Verify both sides
 

--- a/scripts/install-beta.sh
+++ b/scripts/install-beta.sh
@@ -15,6 +15,12 @@
 # Optional flags:
 #   --peer <hostname>          Tailscale hostname of the OTHER machine.
 #                              If omitted, the script prompts interactively.
+#   --code <code>              [sink] Pairing code printed by the source's
+#                              wizard install. Forwarded to wizard install.
+#   --pair-url <url>           [sink] Source's pairing URL (e.g.
+#                              http://<source>:9998/pair). Forwarded to wizard install.
+#   --skip-keychain-prompt     [sink] Forwarded to wizard install. Auto-set
+#                              when no TTY is attached (e.g. SSH non-pty).
 #   --extra-binary <path>      Repeatable. PP CLI binaries to grant
 #                              Chrome Safe Storage access. Sink-side only.
 #   --bin-dir <dir>            Where to place the agentcookie binary.
@@ -37,6 +43,9 @@ set -euo pipefail
 
 ROLE=""
 PEER=""
+CODE=""
+PAIR_URL=""
+SKIP_KEYCHAIN_PROMPT=""
 EXTRA_BINS=()
 BIN_DIR=""
 TARBALL=""
@@ -70,6 +79,12 @@ while [[ $# -gt 0 ]]; do
       ROLE="$2"; shift 2 ;;
     --peer)
       PEER="$2"; shift 2 ;;
+    --code)
+      CODE="$2"; shift 2 ;;
+    --pair-url)
+      PAIR_URL="$2"; shift 2 ;;
+    --skip-keychain-prompt)
+      SKIP_KEYCHAIN_PROMPT="1"; shift ;;
     --extra-binary)
       EXTRA_BINS+=("$2"); shift 2 ;;
     --bin-dir)
@@ -77,7 +92,7 @@ while [[ $# -gt 0 ]]; do
     --tarball)
       TARBALL="$2"; shift 2 ;;
     -h|--help)
-      sed -n '1,30p' "$0" >&2
+      sed -n '1,35p' "$0" >&2
       exit 0 ;;
     *)
       die "unknown argument: $1" ;;
@@ -138,18 +153,28 @@ fi
 
 WORK="$(mktemp -d -t agentcookie-install.XXXXXX)"
 tar -xzf "$TARBALL" -C "$WORK"
-NEW_BIN="$WORK/agentcookie"
-if [[ ! -x "$NEW_BIN" ]]; then
+# The release tarball wraps everything in a versioned directory
+# (agentcookie-${VERSION}-darwin-arm64/), so the binary is one level
+# deep. find tolerates both shapes (wrapped + flat).
+NEW_BIN="$(find "$WORK" -name agentcookie -type f -perm -u+x 2>/dev/null | head -n1)"
+if [[ -z "$NEW_BIN" || ! -x "$NEW_BIN" ]]; then
   die "agentcookie binary not found inside tarball ($TARBALL)"
 fi
 
-step "verifying notarization"
-SPCTL_OUT="$(spctl -a -vv "$NEW_BIN" 2>&1 || true)"
-if echo "$SPCTL_OUT" | grep -q 'accepted'; then
-  ok "binary is notarized and accepted by Gatekeeper"
+step "verifying code signature"
+# spctl -a is the wrong tool for CLI binaries (it assesses for app
+# bundles and reports "rejected: not an app" even when the binary is
+# correctly signed + notarized). Use codesign + Developer ID OU check
+# instead.
+if codesign --verify --strict --verbose=2 "$NEW_BIN" >/dev/null 2>&1; then
+  if codesign -d -r- "$NEW_BIN" 2>&1 | grep -q "subject.OU. = NM8VT393AR"; then
+    ok "binary is signed with the agentcookie Developer ID (NM8VT393AR)"
+  else
+    warn "binary signature is valid but Developer ID OU does not match NM8VT393AR"
+    warn "continuing; this binary may be from a fork or an unofficial build"
+  fi
 else
-  warn "spctl reports: $SPCTL_OUT"
-  warn "binary may not be notarized; LaunchAgent launches may fail. Continuing anyway."
+  warn "codesign verification failed; LaunchAgent launches may be blocked by Gatekeeper. Continuing anyway."
 fi
 
 xattr -c "$NEW_BIN" 2>/dev/null || true
@@ -172,8 +197,11 @@ chmod +x "$TARGET"
 ok "installed"
 
 if [[ ":$PATH:" != *":$BIN_DIR:"* ]]; then
-  warn "$BIN_DIR is not on your \$PATH. Add this to your shell profile:"
+  warn "$BIN_DIR is not on your \$PATH. The LaunchAgent uses absolute paths"
+  warn "and will work fine, but \`agentcookie\` from a shell will not. To fix,"
+  warn "add this line to your shell profile (~/.zshrc on macOS default):"
   warn "    export PATH=\"$BIN_DIR:\$PATH\""
+  warn "Then run \`exec \$SHELL -l\` to reload."
 fi
 
 # ---- run wizard ----
@@ -186,11 +214,49 @@ if [[ -z "$PEER" ]]; then
   prompt PEER "peer hostname"
 fi
 
+# Sink-only: collect the pair code and pair URL from the source's
+# wizard install output. Both are required (the wizard refuses to
+# start without them) so prompt if not passed.
+if [[ "$ROLE" == "sink" ]]; then
+  if [[ -z "$CODE" ]]; then
+    echo "    Paste the pairing code printed by the source's wizard install"
+    echo "    (looks like 'XXXX-YYYY-ZZZZ'):"
+    prompt CODE "pair code"
+  fi
+  if [[ -z "$PAIR_URL" ]]; then
+    echo "    Paste the pair URL printed by the source's wizard install"
+    echo "    (looks like 'http://<source-host>:9998/pair'):"
+    prompt PAIR_URL "pair URL"
+  fi
+fi
+
 WIZARD_ARGS=(wizard install --as "$ROLE" --peer "$PEER")
+if [[ "$ROLE" == "sink" ]]; then
+  WIZARD_ARGS+=(--code "$CODE" --pair-url "$PAIR_URL")
+fi
 for b in "${EXTRA_BINS[@]:-}"; do
   [[ -z "$b" ]] && continue
   WIZARD_ARGS+=(--extra-binary "$b")
 done
+
+# When there's no controlling TTY (headless SSH install on a Mac mini),
+# any Keychain GUI prompt the wizard would normally trigger will sit
+# forever on the GUI session's screen with no one to click it. Default
+# --skip-keychain-prompt in that case so the install completes; the
+# sink daemon will surface the prompt on first sync instead. Operators
+# who do have a GUI session can pass --skip-keychain-prompt explicitly
+# or just let the wizard trigger the prompt normally.
+if [[ -z "$SKIP_KEYCHAIN_PROMPT" ]] && [[ "$ROLE" == "sink" ]] && ! [[ -t 0 ]]; then
+  warn "no TTY detected; defaulting --skip-keychain-prompt for the wizard."
+  warn "You will need to grant Chrome Safe Storage access manually:"
+  warn "  1) physically log into the Mac mini (or Screen Share into it)"
+  warn "  2) open Terminal and run: $TARGET sink"
+  warn "  3) click 'Always Allow' on the Keychain prompt that appears"
+  SKIP_KEYCHAIN_PROMPT="1"
+fi
+if [[ -n "$SKIP_KEYCHAIN_PROMPT" ]]; then
+  WIZARD_ARGS+=(--skip-keychain-prompt)
+fi
 
 "$TARGET" "${WIZARD_ARGS[@]}"
 


### PR DESCRIPTION
## Summary

Five blockers from the [2026-05-19 first-friend dry-run](https://github.com/mvanhorn/agentcookie/blob/main/docs/dry-run-2026-05-19.md), all fixable in `scripts/install-beta.sh` + the release notes template + quickstart:

| # | What | Fix |
|---|------|-----|
| 7 | Tarball extraction looked for `$WORK/agentcookie` but release-tarball.sh wraps everything in a versioned dir | Replace with `find` lookup that tolerates both shapes |
| 9 | `--as sink` had no `--code` / `--pair-url` passthrough; every sink install died with "--code and --pair-url required" | Add flags to arg parser + interactive prompts + forward to WIZARD_ARGS |
| 11 | No way to install on a headless sink over SSH; keychain prompt sat unanswered on the GUI session | Auto-detect no-TTY and default `--skip-keychain-prompt` with a clear post-install guidance block |
| 3/4 | `spctl -a -vv` rejected CLI binaries ("not an app") even when correctly notarized | Replace with `codesign --verify --strict` + Developer ID OU check (NM8VT393AR) in both script and release notes template |
| 5 | `$PATH` warning was terse | Add shell-profile guidance + `exec $SHELL -l` hint |

## Test plan

- [x] `bash -n scripts/install-beta.sh` passes
- [x] `./install-beta.sh --as sink --peer fakehost --tarball /local/v0.12.0-beta.1.tar.gz --code FAKE --pair-url http://fakehost:9998/pair --bin-dir /tmp/test-bin` reaches the wizard step cleanly (tarball found, codesign OK, --skip-keychain-prompt auto-added under no-TTY)
- [ ] After this and the wizard peer.hostname + listener-fails-loud fixes land, re-run the full U6 dry-run end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)