### PR TITLE
fix(wizard): file source key under --peer; refuse silent peer.hostname drift

### DIFF
--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/mvanhorn/agentcookie/internal/chrome"
+	"github.com/mvanhorn/agentcookie/internal/config"
 	"github.com/mvanhorn/agentcookie/internal/keystore"
 	"github.com/mvanhorn/agentcookie/internal/launchd"
 	"github.com/mvanhorn/agentcookie/internal/pairing"
@@ -137,6 +138,15 @@ func wizardInstallSource(ctx context.Context, binPath, logDir string) error {
 	}
 
 	// Step 1: drop source.yaml + allowlist.yaml if missing or force.
+	// v0.12.0-beta.2: if source.yaml already exists with a peer.hostname
+	// that differs from --peer, fail loud rather than silently keeping the
+	// stale value (per friction log #14, 2026-05-19 dry-run). A future
+	// pair handshake would then save the new key under wizardPeer while
+	// the running daemon would keep looking up the stale name -> silent
+	// sync failure.
+	if err := guardConfigPeerMismatch("source", filepath.Join(common.ConfigDir, "source.yaml"), wizardPeer); err != nil {
+		return err
+	}
 	if err := writeYAMLIfMissing(
 		filepath.Join(common.ConfigDir, "source.yaml"),
 		renderSourceYAML(wizardPeer, wizardSinkURL),
@@ -220,6 +230,12 @@ func wizardInstallSink(ctx context.Context, binPath, logDir string) error {
 	// it unless --force is set, so this detection only fires for
 	// fresh installs and explicit --force overwrites.
 	sinkYAMLPath := filepath.Join(common.ConfigDir, "sink.yaml")
+	// v0.12.0-beta.2: if sink.yaml already exists with a peer.hostname
+	// that differs from --peer, fail loud rather than silently keeping
+	// the stale value (per friction log #14, 2026-05-19 dry-run).
+	if err := guardConfigPeerMismatch("sink", sinkYAMLPath, wizardPeer); err != nil {
+		return err
+	}
 	if wizardForce || !fileExists(sinkYAMLPath) {
 		ip, err := tsclient.RequireTailnetIP(ctx)
 		if err != nil {
@@ -481,12 +497,26 @@ func beginSourcePairing(ctx context.Context, listen, localName, binPath, logDir 
 		return "", code, err
 	}
 
+	// v0.12.0-beta.2: file the key under the operator-supplied peer
+	// name (--peer / wizardPeer), not the sink's announced os.Hostname()
+	// returned in res.RemotePeer. source.yaml stores the operator-supplied
+	// name; if the key file is saved under the announced name (often a
+	// Bonjour FQDN like "moltbot-mini.hsd1.wa.comcast.net") then the
+	// running source LaunchAgent looks up the wrong filename at sync time
+	// and reports connection-refused with no hint that the failure is
+	// actually a missing key. The announced name is still recorded in
+	// the saved PeerKey for diagnostics. See friction log #17 (dry-run
+	// 2026-05-19).
 	pk := &keystore.PeerKey{
-		Peer:        res.RemotePeer,
+		Peer:        wizardPeer,
+		AnnouncedAs: res.RemotePeer,
 		Key:         res.Key,
 		PairedAt:    res.PairedAt,
 		Fingerprint: res.Fingerprint,
 		ProtocolVer: pairing.ProtocolVersion,
+	}
+	if wizardPeer != res.RemotePeer {
+		fmt.Fprintf(os.Stderr, "agentcookie wizard: sink announced itself as %q; storing key under operator-supplied --peer %q\n", res.RemotePeer, wizardPeer)
 	}
 	if err := keystore.Save(common.ConfigDir, pk); err != nil {
 		return "", code, fmt.Errorf("save key: %w", err)
@@ -495,6 +525,42 @@ func beginSourcePairing(ctx context.Context, listen, localName, binPath, logDir 
 	_ = os.Remove(infoPath)
 
 	return fmt.Sprintf("agentcookie wizard: paired (code %s, fingerprint %s)", code, res.Fingerprint), code, nil
+}
+
+// guardConfigPeerMismatch refuses to leave a stale peer.hostname in
+// place when the operator has explicitly passed a different --peer.
+// If the existing config has a matching peer or no peer set, returns
+// nil. If they differ and --force isn't passed, returns an error
+// pointing at remediation.
+func guardConfigPeerMismatch(role, path, wantPeer string) error {
+	if !fileExists(path) {
+		return nil
+	}
+	var existing string
+	switch role {
+	case "source":
+		cfg, err := config.LoadSource(filepath.Dir(path))
+		if err != nil {
+			return nil // let writeYAMLIfMissing decide what to do
+		}
+		existing = cfg.Peer.Hostname
+	case "sink":
+		cfg, err := config.LoadSink(filepath.Dir(path))
+		if err != nil {
+			return nil
+		}
+		existing = cfg.Peer.Hostname
+	default:
+		return nil
+	}
+	if existing == "" || existing == wantPeer {
+		return nil
+	}
+	if wizardForce {
+		fmt.Fprintf(os.Stderr, "agentcookie wizard: rewriting %s.yaml peer.hostname %q -> %q (--force)\n", role, existing, wantPeer)
+		return nil
+	}
+	return fmt.Errorf("existing %s.yaml has peer.hostname %q but --peer is %q; pass --force to overwrite (otherwise pair handshake will save a key the running daemon cannot find)", role, existing, wantPeer)
 }
 
 // pairingInfoWriter intercepts the source-side pairing announcement and writes

--- a/internal/cli/wizard_test.go
+++ b/internal/cli/wizard_test.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -54,5 +56,48 @@ func TestValidateListenAddr_AcceptsExplicitOperatorInput(t *testing.T) {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("validateListenAddr(%q): error %v, want substring %q", addr, err, want)
 		}
+	}
+}
+
+// TestGuardConfigPeerMismatch is the regression guard for friction #14
+// (2026-05-19 dry-run). Re-running wizard install with a --peer that
+// differs from the existing sink.yaml peer.hostname used to silently
+// keep the stale config and produce broken sync after the next pair
+// handshake. The guard now errors out unless --force is passed.
+func TestGuardConfigPeerMismatch(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sink.yaml")
+	yaml := []byte("listen:\n  addr: 100.80.229.80:9999\npeer:\n  hostname: old-name\n")
+	if err := os.WriteFile(path, yaml, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Matching peer: no error.
+	if err := guardConfigPeerMismatch("sink", path, "old-name"); err != nil {
+		t.Errorf("matching peer should not error, got: %v", err)
+	}
+
+	// Mismatching peer without --force: error pointing at remediation.
+	prev := wizardForce
+	wizardForce = false
+	defer func() { wizardForce = prev }()
+	err := guardConfigPeerMismatch("sink", path, "new-name")
+	if err == nil {
+		t.Fatal("mismatching peer without --force should error")
+	}
+	if !strings.Contains(err.Error(), "old-name") || !strings.Contains(err.Error(), "new-name") || !strings.Contains(err.Error(), "--force") {
+		t.Errorf("error should mention old, new, and --force; got: %v", err)
+	}
+
+	// Mismatching peer with --force: no error (caller writes the new YAML).
+	wizardForce = true
+	if err := guardConfigPeerMismatch("sink", path, "new-name"); err != nil {
+		t.Errorf("mismatching peer with --force should not error, got: %v", err)
+	}
+
+	// Missing file: no error (writeYAMLIfMissing will write fresh).
+	missing := filepath.Join(dir, "missing.yaml")
+	if err := guardConfigPeerMismatch("sink", missing, "any-name"); err != nil {
+		t.Errorf("missing file should not error, got: %v", err)
 	}
 }

--- a/internal/keystore/keystore.go
+++ b/internal/keystore/keystore.go
@@ -17,12 +17,22 @@ import (
 )
 
 // PeerKey is one paired peer's long-term symmetric key plus metadata.
+//
+// Peer is the on-disk filename (sanitized) AND the lookup key the
+// running daemon uses to find this key via the running config's
+// peer.hostname. AnnouncedAs records what the remote announced itself
+// as during the handshake (often differs from Peer when Peer is the
+// operator-supplied --peer Tailscale name and AnnouncedAs is the
+// remote's os.Hostname() Bonjour FQDN). AnnouncedAs is diagnostic
+// only and is omitted from JSON when empty for backward compat with
+// pre-beta.2 key files.
 type PeerKey struct {
-	Peer         string    `json:"peer"`
-	Key          []byte    `json:"key"`
-	PairedAt     time.Time `json:"paired_at"`
-	Fingerprint  string    `json:"fingerprint"`
-	ProtocolVer  int       `json:"protocol_version"`
+	Peer        string    `json:"peer"`
+	AnnouncedAs string    `json:"announced_as,omitempty"`
+	Key         []byte    `json:"key"`
+	PairedAt    time.Time `json:"paired_at"`
+	Fingerprint string    `json:"fingerprint"`
+	ProtocolVer int       `json:"protocol_version"`
 }
 
 // Dir returns the keys subdirectory under the given config dir.


### PR DESCRIPTION
## Summary

Two friction items from the [2026-05-19 first-friend dry-run](https://github.com/mvanhorn/agentcookie/blob/main/docs/dry-run-2026-05-19.md) that together produce a silent sync failure after any fresh pair handshake where the operator-supplied `--peer` differs from the remote's announced `os.Hostname()`.

| # | What | Fix |
|---|------|-----|
| 17 | `beginSourcePairing` saved the new key under `res.RemotePeer` (the sink's `os.Hostname()`, often a Bonjour FQDN) while `source.yaml` stores the operator's `--peer`. Source LaunchAgent then looked up the wrong key file at sync time | Save the key under `wizardPeer`; record the announced name in a new `AnnouncedAs` field for diagnostics |
| 14 | `wizardInstallSink` / `wizardInstallSource` called `writeYAMLIfMissing`, which silently kept any pre-existing config. Re-running wizard install with a different `--peer` paired under the new name but left the old config in place | New `guardConfigPeerMismatch()` helper errors out unless `--force` is passed, with a clear remediation message |

## Schema change

`keystore.PeerKey` gains `announced_as` (omitempty), so pre-beta.2 key files load unchanged.

## Test plan

- [x] `go test ./...` - 300/300 pass
- [x] New `TestGuardConfigPeerMismatch` covers matching peer / mismatch without `--force` / mismatch with `--force`
- [ ] Cleared after the listener-fails-loud fix lands and v0.12.0-beta.2 is cut, by re-running the U6 dry-run end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)