### PR TITLE
docs: dry-run 2026-05-21 verdict + friction log (ship it)

### DIFF
--- a/docs/dry-run-2026-05-21.md
+++ b/docs/dry-run-2026-05-21.md
@@ -1,0 +1,96 @@
+# U7 first-friend dry-run, take 2 — 2026-05-21
+
+Plan: `docs/plans/2026-05-21-001-feat-headless-sink-click-free-plan.md`, U7.
+
+Goal: walk the closed-beta `install-beta.sh` end-to-end on a clean Mac mini sink over SSH after the v0.12.0-beta.3 ship. Verify the click-free headless install path works. Decide go/no-go for friend invite #1.
+
+Setup:
+
+- Release artifact: `v0.12.0-beta.3` published as prerelease at https://github.com/mvanhorn/agentcookie/releases/tag/v0.12.0-beta.3 (sha256 `4c9b749b3f53c3c971c22b6afb78f13d287998f824a13ab000b4de4a44710f8a`).
+- Source: this laptop (Tailscale `macbook-pro-44`, Bonjour `MacBook-Pro-8.local`). Fully reset for this dry-run: stopped LaunchAgent, wiped `~/.agentcookie`, wiped `~/.config/agentcookie`. Re-installed via `install-beta.sh --as source --peer matts-mac-mini --bin-dir ~/bin --tarball <local v0.12.0-beta.3>`.
+- Sink: `matts-mac-mini` (Tailscale), `moltbot-mini.hsd1.wa.comcast.net` (Bonjour). Fully reset: backup tarballs at `/tmp/agentcookie-mac-mini-pre-beta3-*.tar.gz` and `/tmp/agentcookie-mac-mini-config-pre-beta3-*.tar.gz`. Removed binary, runtime, config, LaunchAgent.
+- Install method: `ssh matts-mac-mini ./install-beta.sh --as sink --peer MacBook-Pro-8.local --code <code> --pair-url <url> --tarball <local>`.
+
+## Verdict
+
+**SHIP IT.** End-to-end SSH-only install completed with zero GUI prompts. Sync resumed automatically. PP CLI adapters fired. CDP injection landed cookies into the agentcookie-owned Chrome profile on the sink.
+
+The five blockers from the 2026-05-19 dry-run that were fixed in v0.12.0-beta.2 stayed fixed. The Phase 1 + Phase 2 work in this plan closes the last GUI-prompt requirement. Closed beta is ready for friend invite #1.
+
+## Evidence
+
+Sink log on first sync after wizard install:
+
+```
+agentcookie sink: skip_chrome_sqlite set; sidecar + adapter push only (no Chrome Safe Storage read, no Chrome SQLite write)
+agentcookie sink: blocklist empty; sync-all mode
+agentcookie sink: listening on http://100.80.229.80:9999 (db=/Users/mvanhorn/Library/Application Support/Google/Chrome/Default/Cookies)
+agentcookie sink: wrote 0 cookies (+ 8387 sidecar) + 0 localStorage origins + 0 indexedDB origins (mode=sidecar+adapter, dropped 0 non-allowlisted cookies)
+agentcookie sink: CDP injection pushed 8387 cookies into ~/.agentcookie/chrome-profile
+agentcookie sink: adapter instacart-pp-cli pushed 33 cookies
+agentcookie sink: adapter airbnb-pp-cli pushed 26 cookies
+agentcookie sink: adapter ebay-pp-cli pushed 51 cookies
+agentcookie sink: adapter pagliacci-pp-cli skipped (no matching cookies)
+agentcookie sink: adapter table-reservation-goat-pp-cli pushed 36 cookies
+```
+
+`agentcookie doctor` on the fresh sink (after first sync):
+
+```
+agentcookie doctor 0.0.1-dev
+  [OK]   Binary signature: Developer ID Application (NM8VT393AR)
+  [OK]   Tailscale: 100.80.229.80 reachable on local tailnet interface
+  [OK]   Config: sink.yaml present, parses OK
+  [OK]   Keystore: peer key for MacBook-Pro-8.local present (mode 0600)
+  [OK]   Sink listener: bound on 100.80.229.80:9999
+  [OK]   Sink state: last write 20s ago, mode=sidecar+adapter+cdp, 0 rejected
+  [--]   Source state: sink-only install
+  [OK]   Sealing: disabled (default in v0.12 closed beta)
+  [WARN] Adapter coverage: 1490 of 1509 host_keys in sidecar have no adapter
+  [OK]   CDP injector: profile_dir=~/.agentcookie/chrome-profile, Chrome=/Applications/Google Chrome.app
+1 WARN (informational); install otherwise green
+```
+
+CDP-injected cookie count in the agentcookie-owned Chrome profile:
+
+```
+$ sqlite3 ~/.agentcookie/chrome-profile/Default/Cookies "SELECT COUNT(*) FROM cookies"
+3036
+```
+
+## Friction log
+
+### Resolved by this release
+
+- **#7, #9, #11, #14, #17, #18 (2026-05-19)** all gone. install-beta.sh tarball lookup, --code / --pair-url passthrough, no-TTY headless default, peer.hostname rewrite guard, source-side key filing under --peer, sink listener fails-loud — all working as designed.
+- **The Chrome Safe Storage Keychain prompt is dead** on a headless install. Zero GUI interactions required.
+
+### New friction (non-blocking, deferred)
+
+**#19 (minor)**: v0.10 set-keychain-access strategy loop still fires on headless installs and times out per the v0.12.0-beta.2 fix (PR #53). Wastes ~60s of install time and prints an alarming `WARNING keychain access strategy loop failed: ... timed out after 10s` block. When `skip_chrome_sqlite` is set, kooky-using CLIs reading Chrome SQLite directly is not the target use case anyway. Fix: skip the strategy loop entirely when wizard resolves `skip_chrome_sqlite: true`.
+
+**#20 (cosmetic)**: "Adapter coverage" WARN reports `1490 of 1509 host_keys in sidecar have no adapter`. The number is loud and a friend reading the output may think 99% of cookies are broken. The actual semantics are "1490 host_keys have no built-in adapter; all of them are still served via the plaintext sidecar to any cookiesource-aware PP CLI." Fix: downgrade to INFO when the gap is below 90%, or rephrase to lead with "all sidecar host_keys are served via the plaintext path; <N> have no built-in adapter for kooky-style readers."
+
+**#21 (worth understanding)**: CDP injection landed 3036 of 8387 synced cookies in the agentcookie Chrome profile's SQLite. The drop happens inside Chrome's `Storage.setCookies` validation — likely some combination of expired session cookies, invalid domain assertions, and duplicate keys collapsing. Acceptable for v0.12.0-beta.3, but worth a follow-up to count + log the drop reasons so a friend knows whether their critical site cookies made it through.
+
+**#22 (cosmetic, inherited)**: Source still announces Bonjour name (`MacBook-Pro-8.local`) in the pair output. Friend copies that into the sink command. Works on the same LAN but not cross-LAN over Tailscale. Same as friction #10 from 2026-05-19, deferred again.
+
+**#23 (cosmetic, inherited)**: `agentcookie version` still returns `0.0.1-dev` instead of the release tag. Makefile doesn't inject the tag via `-ldflags`. Same as friction #2 from 2026-05-19, deferred.
+
+## State after dry-run
+
+- Mac mini sink: clean install of v0.12.0-beta.3 from the published release tarball. `skip_chrome_sqlite: true`, `cdp.enabled: true`, listener bound, sync flowing, adapter pushes firing. **This is the live config now**; no restoration needed.
+- Source on this laptop: clean install via `install-beta.sh --as source --bin-dir ~/bin`. Binary at `~/bin/agentcookie`. LaunchAgent at `~/Library/LaunchAgents/dev.agentcookie.source.plist`. Pushing successfully.
+- Sync state: source `total_pushes: 1, last_push_count: 8387`; sink `total_writes: 1, last_write_mode: sidecar+adapter+cdp`. Both ends green.
+- Backup artifacts preserved on the Mac mini: `/tmp/agentcookie-mac-mini-pre-beta3-20260521-074027.tar.gz`, `/tmp/agentcookie-mac-mini-config-pre-beta3-20260521-074027.tar.gz`, `/tmp/sink-plist-pre-beta3.plist`.
+
+## Recommended next steps
+
+1. Send invite to friend #1. The closed beta is ready.
+2. File one cleanup PR for #19 (skip the v0.10 keychain strategy loop on headless installs) before broader invites.
+3. File a tracking issue for #21 (CDP injection drop count visibility) so a friend's "the sites I care about aren't logged in on the sink Chrome" feedback has a debugging surface.
+4. Decide whether #22 (Bonjour vs Tailscale name) needs fixing before friend #2 — depends on whether friend #1 is single-LAN or cross-LAN.
+
+## Notes for ce-work shipping flow
+
+`/ce-work`'s shipping phase typically wants PRs for friction items. Items #19-#23 here are deferred follow-ups, not blockers — file as issues, not PRs against this branch.


### PR DESCRIPTION
## Summary

End-to-end U7 dry-run for v0.12.0-beta.3. Reset both source and sink to a clean state, installed via published release artifact, verified the click-free path works.

**Verdict: SHIP IT.** Closed beta is ready for friend invite #1.

## Evidence

- Sink install over SSH: zero GUI Keychain prompts fired.
- First sync after install: 8387 cookies via sidecar+adapter+cdp mode.
- `agentcookie doctor`: 0 FAIL, 1 informational WARN.
- CDP injection landed cookies in the agentcookie-owned Chrome profile on the sink.

Full friction log: [`docs/dry-run-2026-05-21.md`](../blob/docs/dry-run-2026-05-21/docs/dry-run-2026-05-21.md).

## New friction items (all non-blocking, deferred)

- #19 v0.10 keychain strategy loop fires unnecessarily on headless installs
- #20 Adapter coverage WARN reads alarmingly when most cookie domains lack a built-in adapter
- #21 CDP injection drop reasons should be logged for debugability
- #22 (inherited) Source announces Bonjour name, not Tailscale name
- #23 (inherited) `agentcookie version` returns `0.0.1-dev`

## Test plan

- [x] Friction log committed
- [ ] Merge, then send invite #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)