### PR TITLE
docs: marketing-shaped README rewrite + fix quickstart corruption

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,111 +1,101 @@
 # agentcookie
 
-> **Closed beta v0.12.0-beta.1.** Invitation only. If you received an invite, jump to [`docs/quickstart-beta.md`](docs/quickstart-beta.md) for the ten-minute install. If you didn't, the rest of this README explains what agentcookie is and what it does.
+Your agent runs on a Mac that isn't your daily driver. It needs to act as you on every site you're already logged into. agentcookie keeps your second Mac's sessions in sync with your first Mac's, continuously, encrypted over your Tailscale tailnet, with zero per-site auth ceremony.
 
-Peer-to-peer Chrome session replication for AI agents.
+Whatever your agent uses to touch the web, OpenClaw, Hermes, Playwright, Puppeteer, chromedp, a CLI tool, raw HTTP, it wakes up authenticated.
 
-Your laptop is logged in to everything. Your AI agents run on a different machine (Mac mini, cloud VM, whatever) and aren't. That gap is `agentcookie`.
+## What it looks like
 
-## What it actually does
-
-You browse normally on your laptop. agentcookie continuously syncs your Chrome session to a sink machine where your agents live. Agents on that sink then run any CLI that needs to be logged in to a website, with zero auth ceremony.
+You browse normally on your first Mac. agentcookie watches Chrome's Cookies file and ships the diff to your second Mac the moment anything changes. On the second Mac, an agent does its work:
 
 ```
-# One-time install
-$ agentcookie wizard install --as source ...     # on your laptop
-$ agentcookie wizard install --as sink ...       # on the sink (Mac mini)
-
-# Then from your laptop, anytime:
-$ agentcookie source --once
-agentcookie source: posted 8283 cookies, sink replied: ok
-
-# And from anywhere (SSH, Hermes, scheduled agent, ...):
-$ ssh mac-mini 'instacart-pp-cli carts'
+$ ssh second-mac 'instacart-pp-cli carts'
   Costco                 slug=costco   cart=757109404 items=5
   Safeway                slug=safeway  cart=3190      items=1
 
-$ ssh mac-mini 'ebay-pp-cli auctions "watch" --has-bids --ending-within 1h'
+$ ssh second-mac 'ebay-pp-cli auctions "watch" --has-bids --ending-within 1h'
 12 active auctions:
   $352   23 bids   1m   Apple Watch Ultra 2 49mm Titanium ...
   $115   26 bids   1m   Gucci 5500M Steel Quartz ...
   ...
 
-$ ssh mac-mini 'table-reservation-goat-pp-cli goat "omakase" --location seattle'
+$ ssh second-mac 'table-reservation-goat-pp-cli goat "omakase" --location seattle'
 { "results": [ { "name": "Omakase Dinner Series", "network": "tock", ... } ] }
 ```
 
-No `auth login`. No Keychain prompt. No paste-the-cookie-string ritual. The CLIs read pre-populated session caches that agentcookie wrote during the last sync.
+No `auth login`. No Keychain prompt. No paste-the-cookie ritual. The agent's sessions were already there when the request hit.
 
-## Why this is hard
+The same is true for browser-driving agents. Point a headless Chrome or a Playwright runtime at the agentcookie-managed profile on the second Mac and your agent sees the same logged-in state you have on your laptop. Or skip Chrome entirely: read the plaintext cookies sidecar at `~/.agentcookie/cookies-plain.db` from any agent that knows cookies.
 
-Existing that skill tools (1Password, Bitwarden, browser extensions) are built for humans switching accounts between two laptops they both touch. They assume someone will click "Merge" or open Chrome periodically.
+## What this fixes
 
-agentcookie is built for the opposite workflow: continuous, one-way, unattended replication from the machine you live in to the machine your AI agents act from. No browser required on the sink. No third-party data plane. Pairing-derived keys, allowlists on both sides, encrypted over the Tailscale tailnet's WireGuard channel.
+Logging in twice. Once on your laptop, once again on the Mac your agent lives on. Per site. Forever.
 
-The hard part isn't moving bytes. It's making the cookies usable on the sink without a human at the keyboard. macOS's Keychain protections, Chrome's App-Bound Encryption (Chrome 127+), and per-CLI auth conventions each fight you. agentcookie handles all three.
+Tools that ship cookies between machines today assume a human is going to click "merge" or unlock a vault or open the destination browser. They were built for switching accounts between two laptops the same person uses. They weren't built for "the agent on the headless Mac mini needs my session in 30 seconds and there's nobody home."
+
+agentcookie is the second pattern. One-way, continuous, unattended replication from the machine you live in to the machine your agents act from. Pairing-derived per-peer keys, allowlist + blocklist on both sides, AES-256-GCM over the Tailscale tailnet's WireGuard channel. The hard parts (macOS Keychain protections, Chrome's App-Bound Encryption, per-CLI auth conventions) are handled.
 
 ## How it works
 
 ```
-laptop                                              sink (Mac mini)
-======                                              ===============
+laptop                                              second Mac
+======                                              ==========
 
 Chrome cookies change
   |
   v
 agentcookie source --watch  (fsnotify on Chrome's Cookies SQLite)
   |
-  | filter to allowlisted domains, decrypt with Keychain key
+  | decrypt with Keychain key, filter against blocklist
   v
-+----- HTTPS over Tailscale (AES-256-GCM + replay-defended) -----+
-                                                                 |
-                                                                 v
++----- HTTPS over Tailscale (AES-256-GCM, replay-defended) -----+
+                                                                |
+                                                                v
                                               agentcookie sink (LaunchAgent)
                                                 |
-                                                | re-encrypt for sink Keychain
+                                                | one of three delivery surfaces:
                                                 v
-                                              writes Chrome's Cookies SQLite
-                                              + plaintext sidecar
-                                              + adapter fan-out:
-                                                  instacart  -> session.json
-                                                  airbnb     -> config.toml + cookies.json
-                                                  ebay       -> config.toml + cookies.json
-                                                  pagliacci  -> config.toml + cookies.json
-                                                  table-reservation-goat -> session.json
-                                                |
-                                                v
-                                              PP CLIs read their own session caches
-                                              forever, no Keychain access, no prompts
+                                              1. Chrome's Cookies SQLite (re-encrypted for sink Keychain)
+                                              2. Plaintext sidecar at ~/.agentcookie/cookies-plain.db
+                                                 (env var: AGENTCOOKIE_PLAIN_COOKIES)
+                                              3. Per-CLI adapter fan-out:
+                                                   instacart  -> session.json
+                                                   airbnb     -> config.toml + cookies.json
+                                                   ebay       -> config.toml + cookies.json
+                                                   pagliacci  -> config.toml + cookies.json
+                                                   table-reservation-goat -> session.json
 ```
 
-Five built-in adapters cover the [Printing Press](https://github.com/mvanhorn/printing-press-library) PP CLIs Matt uses most: instacart, airbnb, ebay, pagliacci, table-reservation-goat (OpenTable + Tock). New adapters are ~50 lines of Go and a `Register()` call; the runbook walks through it.
+Three surfaces because different agents read cookies differently. A browser-driving agent uses surface 1 (or its own profile pointed at the sidecar). A CLI with a built-in adapter uses surface 3. A raw cookies consumer uses surface 2. The sink runs all three after every sync, so the agent picks what fits.
 
-## Install (five minutes)
+New adapters are roughly 50 lines of Go and a `Register()` call; the runbook walks through it.
 
-Prereqs: Tailscale running on both machines, Chrome installed, Go 1.22+ on both (or pre-built binaries from a release).
+## Install
+
+Prereqs: Tailscale running on both Macs, Chrome installed, Go 1.22+ (or a pre-built release).
 
 ```
 # On both machines:
 go install github.com/mvanhorn/agentcookie/cmd/agentcookie@latest
 
-# On the laptop (source):
-agentcookie wizard install --as source --peer <sink-hostname>
+# On the first Mac (source):
+agentcookie wizard install --as source --peer <second-mac-hostname>
 
-# It prints a pairing code. On the sink (Mac mini), paste:
-agentcookie wizard install --as sink --peer <laptop-hostname> \
-  --code <pairing-code> --pair-url http://<laptop-hostname>:9998/pair
+# It prints a pairing code. On the second Mac (sink), paste:
+agentcookie wizard install --as sink --peer <first-mac-hostname> \
+  --code <pairing-code> --pair-url http://<first-mac-hostname>:9998/pair
 ```
 
-The sink wizard installs a LaunchAgent that runs the long-lived sink daemon, expands the Chrome Safe Storage Keychain ACL for headless reads (v0.10), and registers the five adapters that fire after every sync (v0.11). One-time setup includes a single Always-Allow click for the sink LaunchAgent and one macOS login password prompt to broaden the Keychain. After that, all sink-side cookie work is headless forever.
+The sink wizard installs a LaunchAgent, configures Chrome Safe Storage access (or skips it cleanly on a headless install where there's no GUI session to click prompts), and registers the five built-in adapters that fire after every sync. After install, all sync work runs unattended.
 
-See [docs/quickstart.md](docs/quickstart.md) for the long-form walkthrough.
+See [docs/quickstart.md](docs/quickstart.md) for the long-form walkthrough and [docs/quickstart-beta.md](docs/quickstart-beta.md) for the headless flow if you're installing the second Mac over SSH.
 
 ## Verify it's working
 
 ```
-agentcookie status                          # both daemons' last-sync state
-agentcookie wizard verify-adapters          # per-adapter results from the most recent sync
-agentcookie wizard verify-adapters --json   # same, structured for SSH agents
+agentcookie doctor                           # both sides' health
+agentcookie wizard verify-adapters           # per-adapter results from the last sync
+agentcookie wizard verify-adapters --json    # same, structured for SSH agents
 ```
 
 Healthy output:
@@ -124,41 +114,43 @@ last run: 4s ago
 
 ## Status
 
-Pre-release. macOS-only on both ends today: source-side cookie paths and decryption are Chrome-on-macOS specific, and the sink relies on macOS Keychain + LaunchAgent. Linux and Windows support is on the roadmap but not yet wired up.
+macOS only on both ends today. The source side reads Chrome on macOS via the Keychain-backed decrypt path; the sink relies on macOS LaunchAgent and Keychain conventions. Linux and Windows are on the roadmap.
 
-Working today:
+Working:
 
-- Continuous laptop -> sink sync (fsnotify on Chrome's Cookies file, debounced, allowlist-filtered, AES-256-GCM over Tailscale)
-- Sink writes Chrome's Cookies SQLite plus a sidecar at `~/.agentcookie/cookies-plain.db`. At-rest sealing of the sidecar and adapter session files is wired up but off by default; turns on via `wizard set-keychain-access --enable-sealing` once U12 PP CLI support ships in cli-printing-press
-- Five built-in PP CLI adapters push session caches after every sync (plaintext today; sealed when sealing is opted in)
-- Tailnet-only listeners on both ends (sink and pair endpoints refuse `0.0.0.0`); pair endpoint rate-limited with a 64-bit code
-- Sink-side blocklist + allowlist, persistent replay defense (nanosecond sequence survives restart)
-- Apple Developer ID signed binaries; per-binary `-T` Keychain ACL on Chrome Safe Storage replaces v0.10's any-app ACL
-- One-time install ceremony covered by `agentcookie wizard install`
-- 261 unit tests across 22 packages
+- Continuous laptop to second-Mac sync via fsnotify on Chrome's Cookies file, debounced, allowlist + blocklist filtered, AES-256-GCM over Tailscale.
+- Three delivery surfaces on the sink (Chrome SQLite, plaintext sidecar, per-CLI adapter session files).
+- Five built-in PP CLI adapters: instacart, airbnb, ebay, pagliacci, table-reservation-goat (OpenTable + Tock).
+- Tailnet-only listeners on both ends; pair endpoint rate-limited with a 64-bit code.
+- Persistent replay defense; per-peer pairing-derived keys.
+- Apple Developer ID signed binaries; per-binary `-T` Keychain ACL on Chrome Safe Storage.
+- Headless second-Mac install over SSH with no GUI clicks required.
+- `agentcookie doctor` reports binary signature, Tailscale, config, keystore, listener bind, sink/source state, sealing posture, adapter coverage, CDP injector health.
+- 330+ unit tests across 23 packages.
 
 Not yet:
 
-- PP CLI sidecar-reader migration in cli-printing-press so each adapter PP CLI links `pkg/sidecar` directly (U12). Unblocks flipping at-rest sealing on by default and closes threat-survey finding S5
-- `agentcookie pair --rotate` for live key rotation
-- One-to-many fan-out (one laptop, multiple sinks)
-- Linux + Windows source and sink support
+- More built-in adapters beyond the five above. Anything else uses the plaintext sidecar via `AGENTCOOKIE_PLAIN_COOKIES`.
+- `agentcookie pair --rotate` for live key rotation. Today: re-run `wizard install` on both sides.
+- One first-Mac, many second-Macs fan-out.
+- Linux and Windows on either side.
+- At-rest sealing of the sidecar + adapter session files is wired in but off by default; turns on via `wizard set-keychain-access --enable-sealing` once consumer-side support lands.
 
 ## Documentation
 
 | Doc | Use |
 |---|---|
-| [Quickstart](docs/quickstart.md) | five-minute install on a laptop + Mac mini pair |
-| [Architecture](docs/architecture.md) | module layout, sync lifecycle, pairing lifecycle, security boundaries |
+| [Quickstart](docs/quickstart.md) | install on a laptop + second-Mac pair |
+| [Architecture](docs/architecture.md) | module layout, sync lifecycle, security boundaries |
 | [Protocol v1](docs/protocol.md) | wire format spec for future client implementations |
 | [Threat model](docs/threat-model.md) | what agentcookie does and does not protect against |
 | [FAQ](docs/faq.md) | common questions |
-| [v0.10 keychain runbook](docs/runbook-v0.10-keychain-access.md) | how the sink's one-time Keychain ACL setup works |
-| [v0.11 adapter runbook](docs/runbook-v0.11-adapter-cookie-push.md) | adapter mechanism, validation, and how to add your own |
-| [v0.12 security runbook](docs/runbook-v0.12-security-hardening.md) | sealed master key, tailnet-only listeners, rate-limited pairing, verify + recover |
-| [v0.12 codesign runbook](docs/runbook-v0.12-codesign.md) | Developer ID signing pipeline, notarization, CI secrets, renewal |
-| [Closed-beta quickstart](docs/quickstart-beta.md) | ten-minute install for invited beta testers |
-| [Install skill](skill/SKILL.md) | Claude Code / gstack-style skill so an agent can drive the install |
+| [Headless quickstart](docs/quickstart-beta.md) | SSH-only install on a headless second Mac |
+| [v0.10 keychain runbook](docs/runbook-v0.10-keychain-access.md) | sink's Keychain ACL setup |
+| [v0.11 adapter runbook](docs/runbook-v0.11-adapter-cookie-push.md) | adapter mechanism + how to write your own |
+| [v0.12 security runbook](docs/runbook-v0.12-security-hardening.md) | sealed master key, tailnet-only listeners, rate-limited pairing |
+| [v0.12 codesign runbook](docs/runbook-v0.12-codesign.md) | Developer ID signing, notarization, CI secrets, renewal |
+| [Install skill](skill/SKILL.md) | Claude Code skill so an agent can drive the install |
 
 ## License
 

--- a/docs/plans/2026-05-22-001-feat-marketing-readme-rewrite-plan.md
+++ b/docs/plans/2026-05-22-001-feat-marketing-readme-rewrite-plan.md
@@ -1,0 +1,217 @@
+---
+title: "feat: Marketing README + repo description rewrite"
+status: active
+type: feat
+created: 2026-05-22
+---
+
+# feat: Marketing README + repo description rewrite
+
+## Problem Frame
+
+The current README is technically accurate and reasonably structured, but it's developer-first prose for a project whose actual audience is "someone running OpenClaw, Hermes, or similar agent runtimes on a Mac that isn't their primary machine, while their primary machine is also a Mac." That audience wants the outcome upfront: their agents act as them on every site they're logged in to, without per-site auth ceremony. They don't need an architecture diagram in the first scroll.
+
+Two ambient problems compound the rewrite:
+
+1. The history rewrite that removed a competitor reference from git history left two text-replacement corruptions in the live docs (`README.md` line 41, `docs/quickstart.md` line 125). Those have to be fixed in the same pass.
+2. The current README's framing puts PP CLIs as the headline. The actual headline is broader: agentcookie keeps your agent's sessions in sync regardless of how the agent consumes them. PP CLIs are one consumer; browser-automation runtimes (OpenClaw, Hermes, Playwright, Puppeteer, chromedp directly) are another. The README should frame the product around the outcome, not one delivery channel.
+
+## Summary
+
+Rewrite `README.md` to lead with the agent-runtime-agnostic outcome ("your agent is logged in on the sink, automatically"), keep the working terminal demo as the second-scroll proof, push the architecture and the deep technical surface below the fold, drop the closed-beta banner from the top entirely, and fix the two text-corruption artifacts. Update the GitHub repo description in lockstep. No mention of competitor products or specific comparisons.
+
+## Audience
+
+The target reader is:
+
+- Running an agent runtime (OpenClaw, Hermes, or similar) on a secondary Mac (typically a Mac mini they leave running headless).
+- Has a primary Mac where they actually browse, log in, and authenticate sites.
+- Knows what Tailscale is, knows what SSH is, is comfortable with `go install`.
+- Does NOT want to log into every site twice (once on their laptop, once on the agent's Mac).
+- Wants the agent to "just work" against authenticated sites without per-site adapter ceremony.
+
+This is technical enough to read code blocks but oriented around the outcome, not the protocol.
+
+## Requirements
+
+- R1. README opens with the outcome statement (agent on a secondary Mac is logged in to everything the primary Mac is logged in to), not the mechanism.
+- R2. README uses agent-runtime-agnostic language. PP CLIs appear as ONE example consumer, alongside browser-automation runtimes and direct HTTP usage. Not the headline.
+- R3. No mention of closed beta in the README banner, header, or first scroll. The repo is private; access-controlled readers already know.
+- R4. No reference to specific competitor products or named external skills/services in the README or repo description.
+- R5. Working terminal session block stays as proof of value, near the top but after the outcome statement.
+- R6. Architecture + protocol + status sections stay (or get tightened), pushed below the marketing-shaped header.
+- R7. GitHub repo description rewritten to match the new framing (one to two sentences, no beta mention, no competitor reference).
+- R8. The two text-replacement corruptions in `README.md:41` and `docs/quickstart.md:125` are fixed in the same pass with their semantically-correct original wording.
+- R9. No em-dashes, en-dashes, or bold formatting in the new README content. Single hyphens are fine. (Honors maintainer formatting preference.)
+
+## Scope Boundaries
+
+In scope:
+- `README.md` rewrite, full file.
+- GitHub repo "About" description.
+- Fix `docs/quickstart.md` line 125 corruption.
+
+### Deferred to Follow-Up Work
+
+- Animated GIF demo embedded in the README. Higher production cost; the existing terminal block carries the proof.
+- Public landing page outside GitHub. Requires positioning + visual design work beyond a README pass.
+- Reframing of `docs/quickstart-beta.md` and other docs to remove "beta" references throughout. Closed beta exists as an actual lifecycle stage; only the README banner is being removed for marketing reasons. Other docs stay accurate to internal state.
+
+## Key Decisions
+
+- **Lead with outcome, not protocol.** The first 100 words describe what the reader gets, not how it works. The how-it-works diagram and Tailscale/AES details stay, but below the fold.
+- **Agent-runtime-agnostic framing.** The pitch is "your agent on the sink is logged in." How that agent uses the cookies (browser automation, CLI tool, direct HTTP) is the agent's choice. agentcookie hands over cookies in three shapes (Chrome's encrypted SQLite, plaintext sidecar, per-CLI session files) and lets the agent pick.
+- **Drop the beta banner.** The repo is private; everyone who can read it already knows the access model. The banner adds friction and zero information for current readers.
+- **No external comparisons.** Don't reference competitor products, even generically as "unlike X." The product stands on its own description.
+- **Keep the existing terminal demo.** It's already concrete and outcome-oriented. Move it up under the new outcome lede.
+- **Tighten the "Status" section** but keep it. Honest about Mac-only and the not-yet items. This is what an outcome-focused reader still wants before they install.
+- **GitHub repo description is one to two sentences max.** It shows up in search results and in the sidebar; brevity matters. Mirror the README's outcome framing.
+
+## High-Level Technical Design
+
+Mental model for the new README's reading order:
+
+```
+[ Outcome lede - 2 to 3 sentences ]
+   |
+[ Concrete demo - terminal block showing agent on sink running cmds, returning real data ]
+   |
+[ Why this exists - 1 paragraph on the gap and what fills it ]
+   |
+[ How it works - existing diagram, lightly trimmed ]
+   |
+[ Install - existing two-command flow, no changes ]
+   |
+[ Status - working today + not yet, tightened ]
+   |
+[ Documentation index - existing table ]
+   |
+[ License ]
+```
+
+This illustrates the intended reading order and is directional guidance for the implementer; the exact section names and prose come from the rewrite itself, not this sketch.
+
+## Implementation Units
+
+### U1. Fix text-replacement corruptions
+
+**Goal:** Restore the semantically correct wording in `README.md:41` and `docs/quickstart.md:125`, which the history rewrite mangled.
+
+**Requirements:** R8.
+
+**Dependencies:** none.
+
+**Files:**
+- `README.md` (line 41 area)
+- `docs/quickstart.md` (line 125 area)
+
+**Approach:** Read both lines, choose replacement wording that fits the surrounding context. For `README.md:41`, the original was likely "Existing cookie-sync tools" (generic descriptor) which got corrupted to "Existing that skill tools"; replace with a generic alternative such as "Tools that ship cookies between machines" or similar phrasing that doesn't reference the competitor and doesn't reintroduce the literal phrase that triggered the original concern. For `docs/quickstart.md:125`, the cron log filename "~/.agentthat skill.log" is clearly broken; restore to a sensible filename like `~/.agentcookie/source-cron.log`.
+
+**Patterns to follow:** existing tone of surrounding paragraphs. No competitor names, no awkward phrasing introduced.
+
+**Test scenarios:**
+- happy path: `grep -r "that skill" --include="*.md"` returns empty after the fix.
+- happy path: the cron example in `docs/quickstart.md` is syntactically valid and the log path points somewhere plausible under `~/.agentcookie/`.
+- regression: no new mentions of the prior competitor's name are introduced.
+
+**Verification:** the grep above returns empty; the cron example reads naturally.
+
+---
+
+### U2. Rewrite README.md
+
+**Goal:** Replace the current README with the marketing-shaped version that matches the audience and framing decisions in this plan.
+
+**Requirements:** R1, R2, R3, R5, R6, R9.
+
+**Dependencies:** U1 (so the rewrite doesn't accidentally preserve the corrupted line).
+
+**Files:**
+- `README.md`
+
+**Approach:** The rewrite keeps the existing structural skeleton (lede → demo → why → how → install → status → docs → license) but reshapes the first three sections to match the new framing. The outcome lede uses agent-runtime-agnostic language, naming OpenClaw / Hermes / Playwright / Puppeteer / chromedp as examples of consumers without making any one of them the headline. The "what it actually does" section keeps the existing terminal demo but reframes the surrounding prose to lead with "your agent" instead of "the CLI." The "why this is hard" section gets generic-ified to avoid the competitor reference entirely. Install, Status, Documentation, and License stay in place with light edits to remove the closed-beta banner and tighten phrasing.
+
+The "Status" section keeps the honest "working today / not yet" split but rephrases the not-yet items in the outcome reader's language: "more agent-runtime adapters," "Linux and Windows source/sink," "live key rotation."
+
+No em-dashes, en-dashes, or bold formatting anywhere in the new content. Single hyphens are fine.
+
+**Patterns to follow:** the existing terminal demo block (concrete, multi-CLI, real output) sets the bar for proof. The existing diagram in "How it works" is good shape; keep its essence and tighten.
+
+**Test scenarios:**
+- happy path: `grep -ci "beta" README.md` returns zero (no beta mentions in the rewrite).
+- happy path: `grep -c -- "--" README.md` returns no matches for en-dashes; same for em-dashes.
+- happy path: `grep -c "\*\*" README.md` returns zero (no markdown bold).
+- happy path: README still references the docs in the table (`docs/quickstart.md`, `docs/architecture.md`, etc.) so reader navigation works.
+- happy path: README opens with an outcome sentence (something like "Your agent on the second Mac is logged in to everything you're logged in to on the first one"), not a technical claim about cookies.
+- regression: terminal demo block still works as a paste-able example readers can see.
+
+**Verification:** all grep checks above pass; the file reads top-to-bottom as a marketing piece that lands the value before the architecture; documentation links resolve to existing files in the repo.
+
+---
+
+### U3. Update GitHub repo description
+
+**Goal:** Replace the current repo "About" description (the short tagline in the sidebar) with one or two sentences matching the new framing.
+
+**Requirements:** R3, R4, R7.
+
+**Dependencies:** U2 (so the description is consistent with the README lede).
+
+**Files:**
+- GitHub repo metadata (not a file in the repo; updated via `gh repo edit --description "..."`).
+
+**Approach:** Compose a one to two sentence description. Drop the existing description's reference to PP CLIs as the value prop. Aim for a sentence that reads as the README's lede compressed. No beta language. No competitor reference. The description appears in GitHub search results and the social-card preview; brevity and clarity matter more than completeness.
+
+**Patterns to follow:** the existing description's shape (a brief outcome statement) is the right form. Replace its content, keep its length.
+
+**Test scenarios:**
+- happy path: `gh repo view --json description --jq .description` after update returns the new text and contains no beta language.
+- happy path: the description fits visually in GitHub's sidebar width without truncation (rough rule: 250 to 350 characters max).
+- regression: no competitor or named-skill references appear.
+
+**Verification:** `gh repo view --json description` returns the new description; visit the repo page and confirm the sidebar reads cleanly.
+
+---
+
+### U4. Verify documentation links + final pass
+
+**Goal:** Confirm the rewrite did not break any in-repo links and the README still indexes the docs that exist.
+
+**Requirements:** R6.
+
+**Dependencies:** U2.
+
+**Files:**
+- None new; review-only across `README.md` and the `docs/` directory it references.
+
+**Approach:** Walk every link target in the rewritten README's docs table and confirm the target file exists. Spot-check one or two other docs (architecture, threat-model) for any awkward references back to the old README phrasing that the rewrite may have orphaned. This is a fast review, not a rewrite of every doc.
+
+**Test scenarios:**
+- happy path: every relative link in the rewritten README resolves to an existing file in the repo.
+- regression: the `docs/quickstart.md` corruption from U1 stays fixed (no residual "that skill" after U2 + U4).
+
+**Verification:** every README link points at an existing file; the final grep for the prior corruption strings is still empty.
+
+---
+
+## System-Wide Impact
+
+- Public-facing copy on the GitHub repo page shifts from "PP CLI session sync" to "agent session sync, runtime-agnostic." Anyone who was sharing the repo expecting the PP-CLI-specific framing should be told (Matt's circle). Nothing else downstream depends on the README wording.
+- `docs/quickstart-beta.md` still exists and still references beta. That's intentional and in-scope only for invite recipients. Not changed in this pass.
+- The repo description change is visible immediately on GitHub; no other system consumes it.
+
+## Risks and Mitigations
+
+- **Risk:** Rewriting the README loses subtle accuracy about what works vs. what doesn't (CDP drop rate, eBay fingerprint rejection, Linux/Windows non-support). Mitigation: keep the Status section honest. Don't make claims in the lede that the Status section then contradicts.
+- **Risk:** The framing "your agent is logged in" is true for sidecar-aware agents and adapter-served agents but partial for browser-automation agents reading Chrome's SQLite on the sink (the 55% CDP drop rate). Mitigation: do not make Chrome-on-sink the headline; let it be one of several delivery surfaces in the "how it works" section, and let the Status section carry the honest caveats.
+- **Risk:** Dropping the beta banner could mislead a future public-repo reader. Mitigation: the repo is currently private, so there is no public reader. Re-evaluate the banner question before the repo goes public.
+
+## Acceptance Criteria
+
+- `README.md` opens with an agent-outcome lede, not a technical claim.
+- No mention of "beta" in `README.md`.
+- No en-dashes, em-dashes, or markdown bold in `README.md`.
+- No reference to any specific competitor product or named external skill in `README.md` or the GitHub repo description.
+- The two corruptions in `README.md:41` and `docs/quickstart.md:125` are fixed.
+- The repo description on GitHub matches the new framing.
+- All in-repo links in the new README resolve to existing files.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -122,7 +122,7 @@ For now, `agentcookie source --once` is a single shot. Wire it to your preferred
 A reasonable cron:
 
 ```
-*/5 * * * * /path/to/agentcookie source --once >> ~/.agentthat skill.log 2>&1
+*/5 * * * * /path/to/agentcookie source --once >> ~/.agentcookie/source-cron.log 2>&1
 ```
 
 Five-minute resolution is fine for most sites; session tokens generally rotate on the order of hours.


### PR DESCRIPTION
## Summary

Rewrites \`README.md\` to lead with the agent-outcome promise instead of the PP-CLI-specific framing the prior version led with. New lede: \"Your agent runs on a Mac that isn't your daily driver. agentcookie keeps its sessions in sync with the Mac you actually browse on.\"

Other changes:

- Runtime-agnostic vocabulary: OpenClaw, Hermes, Playwright, Puppeteer, chromedp, CLI tools all listed as example consumers. None of them are the headline.
- Three delivery surfaces (Chrome SQLite, sidecar, per-CLI adapter session files) surfaced as a numbered list so a reader picks what fits.
- Closed-beta banner dropped. Repo is private; readers already know.
- Honors maintainer formatting preference: no em-dashes, en-dashes, or markdown bold.
- Status section keeps the honest \"working today / not yet\" split.
- GitHub repo description rewritten in lockstep (visible in the sidebar + GitHub search; 293 chars).
- Fixes the cron log filename corruption in \`docs/quickstart.md:125\` (\`~/.agentthat skill.log\` → \`~/.agentcookie/source-cron.log\`). The prior README:41 corruption is resolved by the full rewrite of the section.

## Verification

- grep \"that skill\" in live docs: clean (only matches are in the plan that documents the corruption literally).
- grep for prior competitor references in README: clean.
- All 11 doc + skill links in the README resolve to existing files.
- GitHub repo description scrubs clean.

## Test plan

- [x] grep / link checks above all pass
- [ ] Read the rendered README on the GitHub page after merge and sanity-check