### PR TITLE
feat: secrets bus (v0.13.0-beta.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ go.work.sum
 hack/
 /dist/
 .claude/
+
+.claude/worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 ## [Unreleased]
 
+### v0.13.0-beta.1: secrets bus
+
+A standardized, runtime-agnostic format for CLIs to consume auth tokens
+that ride alongside cookies. New per-CLI directory at
+`~/.agentcookie/secrets/<cli>/secrets.env` carries `KEY=VALUE` lines,
+optional sealed twin at `secrets.env.sealed` under the v0.12 master key,
+and an optional `manifest.toml` for per-key sync overrides.
+
+Source watches the bus via fsnotify, includes the payload in the
+existing push envelope, and the sink writes per-CLI files at mode 0600
+after defensive name validation. Bus values win over env vars at the
+reader-library level so users who set both expect the bus to override.
+
+New `agentcookie secret` subcommand (list/get/set/rm/import-from/env)
+gives the friend a one-shot path to seed the bus from an existing
+config file. The doctor check (now 11 categories) reports cli count,
+key count, and sealed/plaintext/mixed mode.
+
+Companion artifacts:
+
+- `docs/spec-agentcookie-secrets-bus-v1.md` -- format specification
+- `docs/audits/2026-05-22-pp-cli-auth-inventory.md` -- audit of all 34 PP CLIs
+- `docs/runbook-secrets-bus-adoption.md` -- migration runbook for CLI authors
+- `docs/runbook-secrets-bus-gh-example.md` -- worked example for GitHub CLI
+- `examples/gh-shim/` -- 50-line bash shim proving non-PP CLI consumability
+- `pkg/agentcookiesecret/` -- Go reader library for in-process consumers
+
+Python reader (clients/python/agentcookie_secret) is queued for
+v0.13.1 alongside three documented v1.1 spec gaps: multi-account
+namespacing, per-file local-only markers, and "device-bound-but
+-shippable" third classification.
+
 ### v0.12.0-beta.6: skip keychain strategy loop on headless installs
 
 **Friction #19 fix (2026-05-21 dry-run).** On a headless wizard install

--- a/docs/audits/2026-05-22-pp-cli-auth-inventory.md
+++ b/docs/audits/2026-05-22-pp-cli-auth-inventory.md
@@ -1,0 +1,252 @@
+# Audit: PP CLI auth storage inventory (2026-05-22)
+
+## Methodology
+
+This audit walks every Printing Press CLI installed locally under `~/printing-press/library/` (34 unique CLIs once `*.bak.*` and `*.preserve-*` backup directories are excluded), inventories where each persists its auth surface, and classifies what kind of secret lives in each file. Sources walked:
+
+1. `~/.config/<name>-pp-cli/` — primary XDG-style PP CLI config directory.
+2. `~/.config/<name>/` — alternate non-`-pp-cli` layout used by some CLIs (instacart, agent-capture).
+3. `~/.<name>-pp-cli/` — per-CLI dotdir under `$HOME`. On inspection, every existing instance of this directory holds only `feedback.jsonl` (anonymous local feedback log) and occasionally a `profiles.json` (named flag-set bundle). No secrets observed here in any of the 27 such dirs present.
+4. `~/.tesla/` — Tesla's documented non-XDG layout (the plan's worst case).
+5. `~/.slack/` — Slack PP CLI's `~/.slack/`-style layout.
+6. Binary inspection: `<binary> --help`, `<binary> auth --help`, and `strings` greps for env-var names (`*_TOKEN`, `*_API_KEY`, `*_CLIENT_SECRET`, `*_ACCESS_TOKEN`) to find documented or hard-coded auth surfaces beyond what files reveal.
+
+All file values were inspected by field/key name only. Values were never printed or stored; redaction was enforced by piping through `awk -F= '{print $1}'`, `jq 'keys'`, or `sqlite3 '.schema'`. No real account IDs, OAuth bearers, refresh tokens, API keys, signing key bytes, VINs, phone numbers, or session-cookie values appear anywhere in this document.
+
+The PP-CLI inventory is exhaustive for the 34 real CLIs in the library. Where a CLI has no config dir present, the auth surface is inferred from `auth --help` and `strings` grep on the binary; gaps are called out explicitly.
+
+## Summary
+
+Three storage patterns dominate, and the variance that matters for the secrets-bus format spec is more about which secret categories cluster than about file formats.
+
+**Pattern A: standard `config.toml`.** Eleven CLIs use the same scaffolded `config.toml` with the canonical seven-field set: `base_url`, `auth_header`, `access_token`, `refresh_token`, `token_expiry`, `client_id`, `client_secret`. That is the Printing Press meta-CLI's default auth scaffold. A handful extend it with extra fields (Tesla adds `auth_token`; Suno adds `token`; Dominos adds `token`; Superhuman adds `jwt` and `active_email`; Podcast Goat adds five third-party API key fields; Expensify adds `auth_token` + `partner_user_id` + `partner_user_secret`; ordertogo adds Stripe customer IDs and Mesh user metadata).
+
+**Pattern B: companion JSON files alongside the TOML.** Six CLIs need state that does not fit the canonical TOML shape: browser-session-proof JSON (eBay, OpenArt, Suno), session cookies (Airbnb, OrderToGo, Contact Goat, table-reservation-goat), multi-account OAuth token bundles (Superhuman `tokens.json`), and offline send queues (Superhuman `send-queue.json`).
+
+**Pattern C: non-XDG dotdir for legacy/special cases.** Two CLIs persist outside `~/.config/`: Tesla's `~/.tesla/` (eight files including OAuth, refresh, partner-app creds, an ECDSA EC P-256 keypair, and a vehicle command token) and Slack's `~/.slack/` (config + credentials JSON; multi-team store keyed by Slack team ID).
+
+The variance the secrets-bus format must absorb:
+
+- **Multi-account stores.** Superhuman holds N accounts indexed by email under `accounts`, each with its own access token / refresh token / device ID / Superhuman-issued token. Slack credentials.json is keyed by Slack team ID. The bus format needs an account-namespacing convention or a per-account file convention.
+- **Per-CLI signing keys that must stay machine-local.** Tesla's `snowflake-private.pem` (EC private key for signed-command authorization on the car). These cannot be synced; the manifest convention in R5 must mark them `local-only`.
+- **Browser session proofs.** Three CLIs persist a "I logged in as this human in Chrome" fingerprint (cookie domain, validation method, credential fingerprint). These are device-bound today (they certify a session that lived in a specific browser profile), but the threat model would accept syncing them when the sink is the agent-controlled machine the source already trusts. Flag for follow-up review.
+- **SQLite-backed token blobs.** Linear's `store.db` is mostly sync cache, but its companion `LINEAR_API_KEY` env var is the actual secret. Dominos' `store.db` is sync cache only; its auth lives in `config.toml`. The bus does not need to ship sqlite blobs, only the env vars / TOML fields the CLI reads at boot.
+- **Env-var overlay path.** Most CLIs accept both file-based config and an env-var override (e.g. `SALESFORCE_ACCESS_TOKEN`, `LINEAR_API_KEY`, `HUBSPOT_ACCESS_TOKEN`, `SLACK_BOT_TOKEN`, `TESLA_FLEET_CLIENT_SECRET`). This is excellent news for the secrets-bus design: a CLI that already reads `LINEAR_API_KEY` from the environment will read it from `~/.agentcookie/secrets/linear-pp-cli/secrets.env` with zero code change once the launcher exports it.
+
+## Per-CLI table
+
+| CLI | Storage paths | Format | Secret categories | Sync-safety | Notes |
+| --- | ------------- | ------ | ----------------- | ----------- | ----- |
+| agent-capture | (none observed; ~/.config/agent-capture/presets/ holds saved presets, no secrets) | n/a | none | n/a | macOS screen-capture tool; no remote API auth. |
+| airbnb-vrbo | inferred: ~/.config/airbnb-vrbo-pp-cli/ (not present; user has not authed) | toml + json (inferred from twin `airbnb-pp-cli` shape) | session cookies (Chrome harvest) | safe-to-sync | `auth login` documented; Airbnb SSR scrape; no auth needed for read-only listings. |
+| airbnb-pp-cli (legacy slug, present on disk) | ~/.config/airbnb-pp-cli/config.toml, ~/.config/airbnb-pp-cli/cookies.json | toml + json | canonical TOML scaffold (likely unused), session cookies in cookies.json | safe-to-sync | The TOML carries scaffold OAuth fields that may be placeholders; the real auth is the cookies.json. |
+| alaska-airlines | ~/.config/alaska-airlines-pp-cli/ (not present on disk; binary supports `auth login/logout/status`) | toml (canonical scaffold expected) | OAuth bearer + refresh token (presumed) | safe-to-sync | User has never run `auth login`; only feedback.jsonl in `~/.alaska-airlines-pp-cli/`. |
+| archive-is | (no config dir present; `auth set-token` would create one) | toml (canonical scaffold) | API token (presumed) | safe-to-sync | Read-only API; auth optional. |
+| booking-com | ~/.config/booking-com-pp-cli/config.toml | toml | canonical TOML scaffold (base_url, auth_header, access_token, refresh_token, token_expiry, client_id, client_secret) | safe-to-sync | Standard PP scaffold; OAuth bearer + refresh. |
+| bugbounty-goat | ~/.config/bugbounty-goat-pp-cli/ (empty dir, no config persisted) | toml (canonical scaffold expected) | API token (set-token surface) | safe-to-sync | User has not authed yet. |
+| contact-goat | ~/.config/contact-goat-pp-cli/cookies-happenstance.json | json | Happenstance browser session cookies (Chrome-harvested) | device-bound-but-shippable | Session keyed by browser profile; HAPPENSTANCE_API_KEY env-var alternative documented. Fields: cookies[], saved_at, service, source_os. |
+| digg | ~/.config/digg-pp-cli/ (not present; binary has doctor but no documented `auth login` for digg-pp-cli) | toml (canonical scaffold expected) | API token (set-token surface) | safe-to-sync | Tracks Digg/AI-news; auth optional for public endpoints. |
+| dominos | ~/.config/dominos-pp-cli/config.toml, ~/.config/dominos-pp-cli/store.db | toml + sqlite | canonical TOML scaffold + extra `token`; store.db is sync cache (menu, stores, graphql) with no secrets | safe-to-sync | Store.db is regenerable; only config.toml is bus material. |
+| drudgereport | ~/.config/drudgereport-pp-cli/ (empty dir) | n/a (read-only) | none | n/a | Drudge Report scraper; no remote auth. |
+| ebay | ~/.config/ebay-pp-cli/config.toml, ~/.config/ebay-pp-cli/browser-session-proof.json | toml + json | canonical TOML scaffold + browser session proof (api_name, auth_source, cookie_domain, credential_fingerprint, status_code, validation_method, validation_path, verified_at) | safe-to-sync (TOML) + device-bound-but-shippable (session-proof JSON) | Browser-session-proof certifies a specific Chrome login; bus sync would replicate the fingerprint, which is what we want for the agent sink. |
+| espn-pp-cli | ~/.config/espn-pp-cli/config.toml, ~/.config/espn-pp-cli/watchlist.json | toml + json | no secrets (favorites list only); watchlist is user-curated UI state | n/a | ESPN's public APIs need no auth; config holds preferences. |
+| expensify | ~/.config/expensify-pp-cli/config.toml | toml | canonical TOML scaffold + `auth_token`, `partner_user_id`, `partner_user_secret` | safe-to-sync | Expensify has a "partner app" credential model; bus must carry all three companion fields together. |
+| granola | ~/.config/granola-pp-cli/ (not present; auth supports set-token + setup) | toml (canonical scaffold expected) | OAuth bearer (presumed) | safe-to-sync | Reads Granola's local cache file at `~/Library/Application Support/Granola/`; CLI's own auth is for upstream API. |
+| greatclips | ~/.config/greatclips-pp-cli/ (not present; auth supports set-token) | toml (canonical scaffold expected) | API token | safe-to-sync | Great Clips check-in API. |
+| hubspot-pp-cli | (no config dir present) | env-var primary (`HUBSPOT_ACCESS_TOKEN`); set-token can write canonical TOML | env var + (canonical TOML) | safe-to-sync | Hubspot CLI prefers env var; bus delivery via `secrets.env` is the natural fit. |
+| instacart | documented in binary as `~/.config/instacart/session.json` (mode 0600); not currently present on disk (user has likely logged out) | json | session cookies (Chrome-harvested incl. HttpOnly: `__Host-instacart_sid`, `_instacart_session_id`, `forterToken`, etc.) | safe-to-sync | Uses `kooky` to read Chrome's cookie DB. Optional `~/.config/instacart/config.json` for `postal_code`. Sub-dir naming differs from `-pp-cli` convention. |
+| linear-pp-cli | ~/.config/linear-pp-cli/store.db | sqlite | sync cache only (no auth in DB); real secret is `LINEAR_API_KEY` env var | safe-to-sync (env var) | The CLI prints `export LINEAR_API_KEY=<your-key>` on logout. Bus delivers via secrets.env. Store.db is regenerable from API; not bus material. |
+| microsoft-graph-teams | ~/.config/microsoft-graph-teams-pp-cli/ (not present; binary supports `auth login` via OAuth2) | toml (canonical scaffold + delta tokens) | OAuth bearer + refresh token + delta cursor tokens | safe-to-sync | Delta tokens are resumable-sync state; arguably regenerable but cheap to sync. |
+| openart | ~/.config/openart-pp-cli/config.toml, ~/.config/openart-pp-cli/browser-session-proof.json | toml + json | canonical TOML scaffold + browser session proof | safe-to-sync (TOML) + device-bound-but-shippable (session-proof) | Same shape as eBay/Suno. |
+| ordertogo | ~/.config/ordertogo-pp-cli/config.toml, cookies.json, active-cart.json, carts/ subdir | toml + json + (json) | canonical TOML scaffold + Stripe customer ID + Mesh user metadata + customer name/phone + session cookies + active cart state with payment validation_body | safe-to-sync (most) + caution on customer_phone field (account identifier; redact in audit but bus carries) | This is the broadest single TOML on disk. `mesh_user_id`, `stripe_customer_id`, `customer_phone` are account-identity fields; bus replicates them since they bind the agent to the user's restaurant-ordering identity. |
+| podcast-goat | ~/.config/podcast-goat-pp-cli/config.toml | toml | canonical TOML scaffold + five third-party API key fields: `spoken_api_key`, `taddy_api_key`, `taddy_user_id`, `openai_api_key`, `deepgram_api_key`, `elevenlabs_api_key` | safe-to-sync | Aggregator CLI; bus must support arbitrary extra `*_api_key` fields beyond the scaffold seven. |
+| redfin | (no config dir present; binary supports `auth set-token`) | toml (canonical scaffold expected) | API token | safe-to-sync | Redfin listings; auth required for some endpoints. |
+| salesforce-headless-360 | ~/.config/salesforce-headless-360-pp-cli/ (not present; multi-org auth flow `auth login/list-orgs/switch-org`) | toml (per-org profile expected) + env vars `SALESFORCE_ACCESS_TOKEN`, `SALESFORCE_INSTANCE_URL` | OAuth bearer (per org), JWT private key (RSA), bundle signing public key via `trust register` | safe-to-sync (OAuth/JWT) + local-only (bundle signing private key on the device) | The CLI registers a per-device bundle-signing public key with the Salesforce Certificate trust chain; the *private* half stays on the device and must never sync. Strings include `SF360_HOST_FINGERPRINT` (per-host fingerprint also local). |
+| slack | ~/.slack/config.json, ~/.slack/credentials.json (non-XDG: `~/.slack/`, not `~/.config/slack-pp-cli/`) | json + json | system_id (machine identifier), credentials keyed by Slack team ID (e.g. T08C8AN2Z3R) | safe-to-sync (credentials per team) + caution on system_id (device identifier) | credentials.json is multi-tenant: one OAuth credential record per Slack workspace, keyed by team ID. Bus must preserve the team-ID keying. `SLACK_BOT_TOKEN` env var documented as an alternative. |
+| suno | ~/.config/suno-pp-cli/config.toml, ~/.config/suno-pp-cli/browser-session-proof.json | toml + json | canonical TOML scaffold + extra `token` + browser session proof | safe-to-sync (TOML) + device-bound-but-shippable (session-proof) | Same browser-session-proof shape as eBay/OpenArt. |
+| superhuman | ~/.config/superhuman-pp-cli/config.toml, ~/.config/superhuman-pp-cli/tokens.json, ~/.config/superhuman-pp-cli/send-queue.json | toml + json + json | canonical TOML scaffold + extra `jwt` + `active_email`; tokens.json has per-account map under `accounts`, each record holding `accessToken`, `deviceId`, `expires`, `lastUsedAt`, `refreshToken`, `superhumanToken`, `type`, `userExternalId`, `userId`, `userPrefix` | safe-to-sync (account tokens) + caution on `deviceId` (per-device identifier the server may bind to) | Multi-account is the hard case for the bus format. Account email is the keyspace; per-account credentials are first-class. send-queue.json is queued-send state, not auth (regenerable on sink). |
+| superhuman-mail | (no config dir present; binary supports `auth set-token`) | toml (canonical scaffold expected) | API token (presumed) | safe-to-sync | Separate library entry from superhuman; lighter scope (mail only). |
+| table-reservation-goat | ~/.config/table-reservation-goat-pp-cli/session.json | json | OpenTable cookies + Tock cookies (Chrome-harvested), updated_at, version | safe-to-sync (cookies are session-bound; sink is the intended consumer) | Two-vendor session in one file. No accompanying TOML. |
+| tesla | ~/.config/tesla-pp-cli/config.toml, ~/.config/tesla-pp-cli/auth.json, AND ~/.tesla/ with eight files (see Detailed notes) | toml + json + (PEM + raw text) | OAuth bearer, refresh token, fleet OAuth credentials, partner-app token, EC P-256 ECDSA signing keypair, vehicle command token | safe-to-sync (OAuth + refresh + partner creds + fleet token) + **local-only** (snowflake-private.pem) + safe-to-sync (snowflake-public.pem) | Worst-case in the inventory; see Detailed notes below. |
+| trendhunter | ~/.config/trendhunter-pp-cli/ (not present) | n/a (likely no auth; binary advertises "no API key" in help) | none | n/a | TrendHunter scraper. |
+| trigger-dev | ~/.config/trigger-dev-pp-cli/ (not present; binary supports `auth set-token`) | toml (canonical scaffold expected) | API token + waitpoint tokens (separate concept; resource state, not auth) | safe-to-sync | trigger.dev API key. |
+| trustpilot | ~/.config/trustpilot-pp-cli/ (not present; auth harvests `aws-waf-token` cookie via agent-browser Chrome wrapper) | toml or json (cookie + Next.js build IDs) | AWS WAF token cookie (~5-15 min TTL), Next.js build IDs | device-bound-but-shippable | Token is short-lived; sync useful only within the TTL window. |
+| yeswehack | ~/.config/yeswehack-pp-cli/ (not present; binary supports `auth login` "Import authentication from a browser session" + `auth set-token`) | toml + json (browser session expected) | session cookies / JWT (cookie-first per project memory) | safe-to-sync | YesWeHack researcher CLI must use cookie/JWT from browser session (PATs are program-manager-side per project memory). |
+
+Notes on coverage:
+
+- 34 unique PP CLIs in `~/printing-press/library/` (after filtering `*.bak.*` and `*.preserve-*` backup directories).
+- 15 have an active `~/.config/<name>-pp-cli/` directory with concrete files inspected.
+- 17 have a corresponding `~/.<name>-pp-cli/` dotdir under `$HOME`, but all observed contents were `feedback.jsonl` and at most `profiles.json` (no secrets).
+- The remaining CLIs either have no auth surface (archive-is, drudgereport, espn-pp-cli for public endpoints, agent-capture, trendhunter for public scrape) or the user has not yet authed (and thus the config dir does not exist; the binary's `auth set-token` or `auth login` would create the canonical scaffold).
+
+## Detailed notes for non-trivial cases
+
+### Tesla — `~/.tesla/` (the documented worst case)
+
+Eight files, two of which are signing-key bytes that must never leave the machine.
+
+| File | Format | What it holds | Sync-safety | Notes |
+| ---- | ------ | ------------- | ----------- | ----- |
+| token | Raw JWT (RS256) | Owner-API OAuth access token | safe-to-sync | Tesla's main API bearer for the legacy owner-api flow. |
+| fleet-token | Raw JWT (RS256) | Fleet API OAuth access token | safe-to-sync | New fleet-api flow. |
+| fleet-token.refresh | Opaque ASCII | Fleet API refresh token | safe-to-sync | Used to re-mint fleet-token. |
+| fleet-client-id | ASCII text | Fleet API OAuth client ID | safe-to-sync | Per developer.tesla.com app registration. Not user-bound. |
+| fleet-client-secret | ASCII text | Fleet API OAuth client secret | safe-to-sync | Long-lived; tied to the developer app, not the machine. |
+| fleet-partner-token | Long JWT/opaque | Partner-app authorization token used to enroll public-key host domain | safe-to-sync | Minted via `tesla auth fleet-register`. |
+| snowflake-private.pem | PEM EC PRIVATE KEY (P-256) | ECDSA signing private key for signed-command authorization to the vehicle | **local-only** | This is the device's enrolled identity to the car. The *public* half is registered with Tesla at `https://<host>/.well-known/appspecific/com.tesla.3p.public-key.pem` and bound to the host domain. Copying the private key to another machine would let that machine impersonate this host to the vehicle. Manifest must mark this `local-only` and excluded from sync. |
+| snowflake-public.pem | PEM PUBLIC KEY | Public half of the signing keypair | safe-to-sync | Public; sync is harmless. May be useful on the sink for verifying signatures locally. |
+
+Plus `~/.config/tesla-pp-cli/`:
+
+| File | Format | Holds | Sync-safety |
+| ---- | ------ | ----- | ----------- |
+| config.toml | TOML | canonical scaffold + `auth_token` (extra field) | safe-to-sync |
+| auth.json | JSON | `access_token`, `refresh_token`, `expires_at`, `issued_at` (a second copy of OAuth state distinct from the `~/.tesla/` files; this is the PP CLI's own auth, separate from the partner-app fleet creds) | safe-to-sync |
+
+The Tesla case proves three requirements for the secrets-bus format:
+
+1. The format must handle **multiple paths per CLI** (config.toml + auth.json + the entire ~/.tesla/ tree).
+2. The manifest must support **per-file or per-path `local-only` markers**, not just per-CLI.
+3. Public/private keypair handling must be granular: ship the public half, suppress the private half.
+
+### Superhuman — multi-account token store
+
+`tokens.json` shape (no values, keys only):
+
+```
+{
+  "accounts": {
+    "<account-email>": {
+      "accessToken": "...",
+      "deviceId": "...",
+      "expires": "...",
+      "lastUsedAt": "...",
+      "refreshToken": "...",
+      "superhumanToken": "...",
+      "type": "...",
+      "userExternalId": "...",
+      "userId": "...",
+      "userPrefix": "..."
+    },
+    "<another-account-email>": { ... }
+  },
+  "lastUpdated": "...",
+  "version": "..."
+}
+```
+
+The bus format must preserve account-keyed structure. Options:
+
+- One env file per account (`~/.agentcookie/secrets/superhuman-pp-cli/accounts/<account>.env`) — clean, but the CLI must know to enumerate.
+- One env file with namespaced keys (`ACCOUNT_<id>_ACCESS_TOKEN`) — flat, but loses ergonomics.
+- A second sidecar JSON next to `secrets.env` for structured data the dotenv shape cannot express — pragmatic; secrets.env carries the "default account" creds for hot-path agents, sidecar carries the multi-account tree.
+
+`deviceId` may be server-bound (Superhuman may pin the session to the device that issued it). Worth confirming with a test sync before promising agents the multi-account replication path.
+
+### ordertogo — broad identity-bound TOML
+
+The single broadest non-Tesla TOML in the inventory. Beyond the canonical scaffold, it carries:
+
+```
+default_restaurant = <redacted>
+default_max = <redacted>
+default_tip_pct = <redacted>
+stripe_customer_id = <redacted>
+stripe_default_card = <redacted>
+customer_firstname = <redacted>
+customer_lastname = <redacted>
+customer_phone = <redacted>
+mesh_user_id = <redacted>
+```
+
+These are account-identity fields: replicating them to the sink is the entire point of the bus (the agent should be able to place an order as the user), but they include PII and a phone number. The bus does not need special handling beyond the standard sealing — but operators should understand that these fields ARE in the bus payload.
+
+### Browser-session-proof JSON (eBay, OpenArt, Suno)
+
+All three share the same shape:
+
+```
+{
+  "api_name": ...,
+  "auth_source": ...,
+  "cookie_domain": ...,
+  "credential_fingerprint": ...,
+  "status_code": ...,
+  "validation_method": ...,
+  "validation_path": ...,
+  "verified_at": ...
+}
+```
+
+This is a verification record proving "I successfully made an authenticated request as this user against this domain at this time," not the cookie itself. The actual cookies live separately (Chrome's SQLite via agentcookie's existing cookie path, or the canonical TOML's `access_token`). The session-proof file's value is operational telemetry, not a secret per se — but it identifies the user. Classification: device-bound-but-shippable; flag for follow-up to confirm sites don't bind the credential_fingerprint to the device that minted it.
+
+### Slack — non-XDG `~/.slack/` plus multi-team credentials
+
+`~/.slack/config.json` shape:
+
+```
+{
+  "last_update_checked_at": ...,
+  "system_id": ...
+}
+```
+
+`system_id` is a per-machine identifier the CLI generates; replicating it to the sink would tell Slack the sink is the same install as the source. Whether that helps or hurts depends on Slack's anti-abuse posture; safe to sync but flag.
+
+`~/.slack/credentials.json` shape:
+
+```
+{
+  "<slack-team-id>": { ...credential record... }
+}
+```
+
+Multi-team like Superhuman is multi-account, but keyspace is the Slack workspace's team ID (e.g. `T...`). Bus format needs the same per-account/per-tenant key namespacing solution as Superhuman.
+
+### Salesforce — bundle signing key (local-only)
+
+`salesforce-headless-360-pp-cli trust register` enrolls a per-device bundle-signing public key with the Salesforce Certificate trust chain. The private half lives on the device (location not yet observed; the user has not run `trust register`). When it does land, it must be marked `local-only` like Tesla's snowflake-private.pem — same threat model (device-bound signing identity registered to a third party).
+
+`SF360_HOST_FINGERPRINT` is a host-bound integrity check value baked into strings; it would be regenerated per machine and should not sync.
+
+## Sync-safety classification rationale
+
+Three classes are sufficient for the bus design:
+
+**safe-to-sync.** Same identity on every machine; sharing the bytes does not break anything. Includes:
+- OAuth access tokens (the same Tesla account is the same on laptop and sink; the access token says "this user").
+- OAuth refresh tokens (same — used to re-mint access tokens for the same user).
+- API keys (Linear, HubSpot, Slack bot tokens, third-party LLM provider keys in podcast-goat). These are explicitly designed to be portable.
+- Vendor partner-app credentials (`client_id`, `client_secret`, fleet-client-id/-secret, Expensify partner_user_*, Tesla fleet-partner-token). These are tied to the developer-app registration, not the device.
+- Session cookies (Airbnb, OrderToGo, Instacart, Trustpilot, table-reservation-goat, YesWeHack, Contact Goat). The same browser-issued cookie identifies the same user from either machine, modulo fingerprint binding (see device-bound class below).
+- Account identifier fields (Superhuman `userId`, OrderToGo `mesh_user_id`, etc.) — these are user-bound, not device-bound.
+
+**local-only.** Must never leave the device that generated them. Includes:
+- ECDSA / RSA signing private keys whose public half is registered with a remote service AS the device's identity. The remote service treats the keypair as proof of "this specific device". Replicating the private key would let two machines impersonate one. Examples: Tesla `snowflake-private.pem`, Salesforce bundle-signing private key (when registered).
+- Per-machine derived integrity values (`SF360_HOST_FINGERPRINT`). Regenerated locally; syncing the source machine's value to the sink would defeat the check.
+- macOS Keychain items pinned by `-T` ACL to a specific binary's designated requirement (agentcookie's own master key falls in this class; this is a meta-concern, but the bus must not try to extract Keychain items into env files).
+
+**device-bound-but-shippable.** Today the value certifies a specific device, but the threat model would tolerate sync to the agent sink because the sink IS the intended secondary device. Includes:
+- Browser session proofs (eBay, OpenArt, Suno).
+- Superhuman `deviceId` (server may pin; needs verification).
+- Slack `system_id` (per-install identifier).
+- Trustpilot WAF cookie (short TTL; sync works inside the window).
+
+These are sync-by-default but flagged for follow-up review per site: if a destination site refuses requests after replication, the manifest can be tightened to `local-only` per-field without changing the format.
+
+The manifest convention (R5 in the plan) needs at least three knobs:
+
+- `local_only: ["path/to/file", "field_name"]` (file-level or field-level exclusion).
+- `account_keyspace: "email" | "team_id" | "user_id" | null` (how multi-account stores are keyed; lets the bus replicate one logical account or all).
+- `expires_after_seconds: <int>` (so the sink can drop stale device-bound-but-shippable artifacts like the Trustpilot WAF cookie without manual cleanup).
+
+## Spec gaps surfaced by this audit (input list for v1.1)
+
+The format spec at `docs/spec-agentcookie-secrets-bus-v1.md` was written before this audit ran. Three findings here should land as a v1.1 spec revision:
+
+1. **Multi-account namespacing.** Superhuman (account email keys) and Slack (team ID keys) hold one set of secrets per account in a single file. The v1 spec assumes one secret set per CLI. v1.1 needs either an `accounts/<account-id>/secrets.env` subdirectory convention or namespaced keys in a single file. Recommend the subdirectory convention so a friend can opt in/out of syncing specific accounts.
+2. **Per-file (not just per-key) `local-only` markers.** Tesla's `snowflake-private.pem` is local-only, but its `snowflake-public.pem` half is safe-to-sync. The v1 spec's `[sync.keys]` is per-key inside `secrets.env`; v1.1 needs a `[sync.files]` table for non-env-shaped artifacts like `.pem` files that live alongside the env file.
+3. **Third sync-safety classification: `device-bound-but-shippable`.** The browser-session-proof JSON used by eBay, OpenArt, and Suno is technically device-bound (it captures fingerprint timing) but the threat model would tolerate sync to a single trusted second machine. The v1 spec only has two buckets (safe-to-sync, local-only). v1.1 needs the middle category with a `caution` marker that warns but does not block.
+
+PII observation: ordertogo's `config.toml` carries customer name, phone, and Stripe customer ID alongside auth tokens. The bus replicates whatever's in the file, not just "secrets." Friends should know that. This is documentation territory, not a spec change; the v1 spec's security boundary statement may want a paragraph about PII-replication once v1.1 lands.

--- a/docs/plans/2026-05-22-002-feat-secrets-bus-plan.md
+++ b/docs/plans/2026-05-22-002-feat-secrets-bus-plan.md
@@ -1,0 +1,550 @@
+---
+title: "feat: agentcookie secrets bus (cross-CLI auth-token sync via .env-shaped sealed sidecar)"
+status: active
+type: feat
+created: 2026-05-22
+---
+
+# feat: agentcookie secrets bus (cross-CLI auth-token sync via .env-shaped sealed sidecar)
+
+## Problem Frame
+
+agentcookie solves the cookie half of the "your laptop is logged in, your sink isn't" problem. The auth-token half is still manual: every CLI that needs API tokens, OAuth refresh tokens, signing keys, or vendor API keys has its own bespoke storage layout under `~/.config/<cli>/`, and the friend has to either rerun every OAuth login on the sink or hand-copy each CLI's secrets via scp. Today, 36 PP CLIs are installed locally, and they store auth across at least nine distinct shapes (TOML, JSON, multi-file token bundles, sqlite blobs, browser-session-proof JSON, raw env vars, OS keychain items, .pem signing keys, and combinations). The Tesla case alone uses eight files across two directories.
+
+The same problem applies to CLIs that are not part of the Printing Press ecosystem at all. `tesla-control`, `gh`, `aws`, `gcloud`, third-party scripts a friend writes, all have the same "logged in on the laptop, needs to be logged in on the sink" gap. A solution scoped to PP CLIs only would leave that ecosystem unserved.
+
+This plan proposes agentcookie defines a standard, language-agnostic secrets-bus format (sealed-optional `.env` sidecars under a known path), syncs them source-to-sink via the existing AES-256-GCM Tailscale channel, and ships a tiny reader library so any CLI (PP or not) can opt in by reading one well-known file. It also commits to a concrete inventory of the 36 locally installed PP CLIs as the empirical baseline for the format design.
+
+## Summary
+
+Add a "secrets bus" to agentcookie that mirrors how cookies work today: friend authenticates a CLI once on the laptop, agentcookie watches a known path, ships a sealed payload to the sink, sink unseals and writes per-CLI `.env` files at predictable locations. PP CLIs (and any other CLI) opt in by reading those `.env` files at startup using whatever dotenv parser their language ships. Cryptographic signing keys that must not leave a single machine are marked local-only via a manifest convention and excluded from sync.
+
+Source of truth on the format and the directory layout lives in agentcookie. Adoption in each individual CLI is its own PR in its own repo and explicitly out of scope here, with a migration runbook for owners.
+
+## Audience
+
+Two readers in mind:
+
+- **Friends who use one or more PP CLIs from a sink machine**: they want "one login on the laptop, agent works on the sink" applied to API tokens the same way it already applies to cookies. They should not have to know about agentcookie internals; they should just see their tokens appear on the sink after they finish OAuth on the laptop.
+- **CLI maintainers (PP CLI authors + non-PP-CLI authors)**: they want a tiny stable contract: "read this file at this path, the variables you need will be there, you do not have to care about the encryption-at-rest story." The reader library should be ~20 lines for them to integrate.
+
+## Requirements
+
+- R1. agentcookie defines a public, documented format for storing per-CLI secrets that any CLI in any language can consume with a standard `.env` parser, without linking an agentcookie library.
+- R2. Standardized storage path: `~/.agentcookie/secrets/<cli-name>/secrets.env` (plus optional sealed twin `secrets.env.sealed` when the v0.12 master key is set up).
+- R3. agentcookie source-side watches the secrets path tree for changes and pushes the diff to the sink through the existing pair-derived AES-256-GCM channel, mirroring the cookies sync flow.
+- R4. Sink-side writes the secrets files at the same path layout on the sink machine, sealed under the v0.12 master key when sealing is enabled, plaintext otherwise.
+- R5. A manifest convention identifies secrets that must stay machine-local (signing keys, OS-provisioned credentials, anything whose threat model rules out serialization) and excludes them from sync. Manifest lives at `~/.agentcookie/secrets/<cli-name>/manifest.toml`.
+- R6. Reference reader libraries: a Go module under agentcookie that resolves the sealed-or-plaintext file and returns a `map[string]string` of env vars, and a Python equivalent that does the same for non-Go consumers.
+- R7. `agentcookie secret` subcommand: `list`, `get`, `set`, `rm`, `import-from` (one-shot ingestion from an existing `~/.config/<cli>/<file>` into the standard shape). Friend-facing tool for the cases agentcookie cannot auto-detect.
+- R8. `agentcookie doctor` reports the secrets-bus health: count of CLIs registered, count of secrets in the bus, sealed vs plaintext mode, sync state.
+- R9. Concrete audit deliverable: `docs/audits/2026-05-22-pp-cli-auth-inventory.md` documenting all 36 locally installed PP CLIs' current auth storage shapes (filename, encoding, secret types held, sync-safe vs local-only classification).
+- R10. Non-PP-CLI support proven by a worked example: at least one third-party CLI (candidate: `gh`) demonstrated reading from the secrets bus via a thin shim, documented in a runbook.
+- R11. Migration runbook for PP CLI authors: how to adopt the format in their existing CLI without breaking current users.
+- R12. Existing v0.12.0-beta.6 installs see no behavior change. The secrets bus is additive and opt-in per CLI.
+
+## Audit (Phase 1)
+
+Implementation Unit U1 produces the actual inventory. The plan-time audit below captures the variance I sampled across 13 of the 36 PP CLIs to shape the format design. None of these contain real secret values; the columns describe file shape and what kind of secret is being stored.
+
+| PP CLI | Files under ~/.config/<name>/ | Secret types observed |
+|---|---|---|
+| airbnb-pp-cli | config.toml, cookies.json | session cookies, account ID |
+| ebay-pp-cli | config.toml, browser-session-proof.json | session cookies, browser identity |
+| ordertogo-pp-cli | config.toml, cookies.json, active-cart.json | session cookies |
+| expensify-pp-cli | config.toml | OAuth bearer (assumed) |
+| espn-pp-cli | config.toml, watchlist.json | API key (presumed) |
+| openart-pp-cli | config.toml, browser-session-proof.json | OAuth bearer + browser identity |
+| suno-pp-cli | config.toml, browser-session-proof.json | OAuth bearer + browser identity |
+| tesla-pp-cli | config.toml, auth.json | OAuth bearer + refresh token (split between two files) |
+| booking-com-pp-cli | config.toml | account credentials |
+| superhuman-pp-cli | config.toml, tokens.json, send-queue.json | OAuth tokens (multi-file) |
+| linear-pp-cli | store.db | sqlite-stored token blob |
+| table-reservation-goat-pp-cli | session.json | session payload |
+| (Tesla extra) ~/.tesla/ | fleet-token, fleet-token.refresh, fleet-client-id, fleet-client-secret, fleet-partner-token, snowflake-private.pem, snowflake-public.pem | OAuth + refresh + partner-app creds + ECDSA signing keypair |
+
+Patterns visible across the sample:
+
+- `config.toml` is the most common shape (10 of 13), but its contents vary widely: some hold OAuth bearers, some hold API keys, some hold no secrets at all (just chrome cookie DB paths).
+- Refresh tokens often live in a separate file from the access bearer (Tesla: `auth.json` vs `config.toml`; Superhuman: `tokens.json` vs `config.toml`).
+- "Browser session proof" JSON is a recurring pattern for CLIs that present as a browser to an API: a snapshot of cookies, headers, and timing data used to look human.
+- SQLite (linear-pp-cli) is used when the CLI also caches issue data; auth and content share the file.
+- Outside `~/.config/`, Tesla also uses `~/.tesla/` for Fleet API artifacts and a signing keypair. This second location pattern (`~/.toolname/`) is common for CLIs that predate the XDG convention.
+
+The full inventory (U1) is what unblocks the per-CLI migration plan. The plan-time sample is sufficient to shape the format.
+
+## External reference standards
+
+Skimmed the conventions used by other CLI auth ecosystems to anchor the format choice:
+
+- **`.env` / dotenv**: line-oriented `KEY=VALUE`. Parsers exist for every mainstream language (Go: `joho/godotenv`, Python: `python-dotenv`, Node: `dotenv`, Ruby: `dotenv`). Universal, friend-editable, no encryption story by default. Used by last30days as observed in `~/last30days-digg-bridge/.env`. This is the format we adopt.
+- **`gh` (GitHub CLI)**: `~/.config/gh/hosts.yml`, YAML, OAuth bearer per host. Single tool reads it; not designed for external consumers.
+- **`aws`**: `~/.aws/credentials` (INI), `~/.aws/config` (INI), one shared layout that many tools (terraform, ansible, AWS SDKs) consume. INI with profile sections, no encryption at rest.
+- **`gcloud`**: complex SQLite at `~/.config/gcloud/credentials.db`. Single-tool internal.
+- **`stripe`**: `~/.config/stripe/config.toml`, TOML, single-tool.
+- **`vault`**: `~/.vault-token`, single token file, plain text.
+
+Takeaway: every successful "multi-consumer" auth convention (aws credentials being the strongest example) is plaintext at rest, line-oriented or section-oriented, has a documented schema, and trusts the OS file permissions for security. None of them encrypt at rest by default; encryption is left to disk-level encryption (FileVault, LUKS) or runtime secret stores (Vault, 1Password CLI).
+
+Our deviation from this pattern: we offer optional sealing under the agentcookie master key for friends who want at-rest encryption on the sink, while keeping the plaintext-by-default story so PP CLIs (and gh, aws, etc.) can read with their existing dotenv loaders.
+
+---
+
+## Scope Boundaries
+
+In scope:
+
+- Format spec + reference Go and Python reader libraries.
+- agentcookie source-side detection, sink-side write, sealed-optional storage.
+- `agentcookie secret` subcommand surface.
+- Doctor visibility.
+- Full inventory of 36 locally installed PP CLIs.
+- Migration runbook for CLI authors (PP and non-PP).
+- One worked example of a non-PP CLI (gh) reading from the bus via shim.
+
+### Deferred to Follow-Up Work
+
+- Implementing the reader in each individual PP CLI. That work lives in each CLI's repo and follows its own release cadence. The migration runbook is the bridge.
+- Web UI for managing secrets. Today: `agentcookie secret` CLI is the interface.
+- Cross-machine signing-key generation flow (multi-sink ECDSA key enrollment for Tesla-style flows). The local-only marker keeps these out of sync; multi-machine enrollment is a separate plan.
+- Backup/restore of the secrets bus (cloud sync, encrypted exports). Out of scope; FileVault + Time Machine cover the friend-side need today.
+- Secret rotation / expiry notifications. The bus stores what's written; rotation is each CLI's responsibility.
+
+---
+
+## Key Technical Decisions
+
+- **.env format, plaintext by default, sealed-optional under master key.** Plaintext .env is the lingua franca: every mainstream language has a parser, friends can $EDITOR the file, no agentcookie linkage required for adoption. Sealed-optional gives at-rest protection on the sink without breaking the plaintext contract for callers that just want env vars. Sealed mode requires either the reader library (which transparently unseals) or shelling out to `agentcookie secret get` (which prints to stdout).
+- **Path: `~/.agentcookie/secrets/<cli-name>/secrets.env`.** One agentcookie-owned tree, predictable, easy to back up, easy for the friend to inspect. Matches the per-cli-name pattern but lives under agentcookie's umbrella so the friend doesn't have to know about each CLI's idiosyncratic location.
+- **Sync mirrors cookies source-to-sink.** The friend authenticates once on the laptop. agentcookie source watches `~/.agentcookie/secrets/` via fsnotify, ships changes to the sink through the existing pair-derived channel, sink writes them at the same path. Same security boundary as cookies, same blocklist/allowlist semantics apply.
+- **Manifest file marks local-only secrets.** `~/.agentcookie/secrets/<cli-name>/manifest.toml` carries a `sync = true|false` boolean per file or per-key. Default is `sync = true`. ECDSA private keys, OS-provisioned credentials, anything with a single-machine threat model gets `sync = false` and stays out of the wire envelope.
+- **agentcookie owns the bus, CLIs own their integration.** agentcookie writes the file at the standard path. PP CLIs and non-PP CLIs each PR their own integration in their own repo. We do not vendor agentcookie code into individual CLIs; we publish a small reader module they can import. This matches how `aws-sdk` reads `~/.aws/credentials` without depending on the AWS CLI binary.
+- **Non-PP-CLI support is a first-class requirement, not an afterthought.** The format is documented as a public contract. The worked `gh` example proves the path. Future third-party adoption needs nothing more than the docs.
+- **Go reader is the canonical implementation; Python reader follows the same semantics.** Two languages cover ~all the PP CLI surface (most are Go) and the broader scripting use case. Other languages can implement the contract from the spec.
+- **No web UI, no remote API surface in v1.** `agentcookie secret` CLI plus direct file editing covers the workflows.
+
+---
+
+## High-Level Technical Design
+
+Data flow mirrors the existing cookies bus:
+
+```
+laptop                                              sink
+======                                              ====
+
+friend runs `tesla-pp-cli auth login`
+  CLI writes its own credentials to its own
+  config dir under ~/.config/tesla-pp-cli/
+  |
+  | (friend optionally runs `agentcookie secret import-from
+  |   ~/.config/tesla-pp-cli/auth.json --as tesla-pp-cli`,
+  |  OR the CLI writes directly to the standard path)
+  v
+~/.agentcookie/secrets/tesla-pp-cli/
+  ├── secrets.env          (plaintext, KEY=VALUE)
+  ├── manifest.toml        (sync = true/false per file or per-key)
+  └── secrets.env.sealed   (optional, sealed under master key)
+  |
+  | fsnotify catches the write
+  v
+agentcookie source --watch
+  |
+  | filters manifest (sync=false files dropped), seals payload
+  v
++----- HTTPS over Tailscale (AES-256-GCM, replay-defended) -----+
+                                                                |
+                                                                v
+                                              agentcookie sink (LaunchAgent)
+                                                |
+                                                | writes to ~/.agentcookie/secrets/tesla-pp-cli/
+                                                | optionally seals under master key
+                                                v
+                                              tesla-pp-cli on the sink reads
+                                              ~/.agentcookie/secrets/tesla-pp-cli/secrets.env
+                                              via godotenv at startup. Done.
+```
+
+This illustrates the intended approach and is directional guidance for review, not implementation specification.
+
+Format spec at a glance:
+
+```
+# ~/.agentcookie/secrets/<cli-name>/secrets.env
+# Lines starting with # are comments.
+# KEY=VALUE format. Values may be quoted with " or '.
+# Multi-line values supported via shell-style backslash continuation.
+
+TESLA_OAUTH_BEARER=eyJ...redacted...
+TESLA_OAUTH_REFRESH=eyJ...redacted...
+TESLA_FLEET_CLIENT_ID=redacted
+TESLA_FLEET_CLIENT_SECRET=redacted
+```
+
+```toml
+# ~/.agentcookie/secrets/<cli-name>/manifest.toml
+schema_version = 1
+display_name = "Tesla PP CLI"
+
+[sync]
+# Whole-file default. Individual keys can opt out via [sync.keys].
+default = true
+
+[sync.keys]
+# Per-key overrides. Anything ECDSA-signing-key-shaped stays local.
+TESLA_SNOWFLAKE_PRIVATE_KEY_PEM = false
+```
+
+Per-CLI side: the CLI links `pkg/agentcookiesecret` (Go) or `agentcookie_secret` (Python), calls `Load("tesla-pp-cli")`, gets a `map[string]string`. Library handles sealed-vs-plaintext detection, falls back to environment variables and the CLI's existing config file in priority order so the migration is non-breaking.
+
+---
+
+## Implementation Units
+
+### U1. Audit and inventory all 36 PP CLIs
+
+**Goal:** Walk every `~/.config/*-pp-cli/` dir and every `~/.<name>/` dir referenced by an installed PP CLI binary. Document the storage shape, file-by-file, plus the type of secret each holds and whether it is safe to sync (general OAuth bearer / refresh token) or must stay local (signing key, OS-provisioned cred).
+
+**Requirements:** R9.
+
+**Dependencies:** none.
+
+**Files:**
+- `docs/audits/2026-05-22-pp-cli-auth-inventory.md` (created)
+
+**Approach:** For each installed PP CLI, run a structured probe: list files, identify likely secret-bearing fields by name (token, key, secret, bearer, refresh, pem, credential), and classify each one. Cross-reference with each CLI's `--help` output to confirm what it expects to find. Do NOT capture secret values; the deliverable is structure only. Output is a single markdown table organized by CLI, with columns: file path, format (toml/json/sqlite/env/pem/other), secret kinds present, sync-safety classification, current secret-loading mechanism (read at startup, looked up in OS keychain, expects env var, etc.).
+
+**Patterns to follow:** the plan-time sample table above is the shape; expand it to all 36 CLIs and add any non-PP CLIs the friend cares about (tesla-control, gh, etc.) as a separate appendix.
+
+**Test scenarios:** Test expectation: none — research deliverable.
+
+**Verification:** The audit document exists, covers all 36 PP CLIs, and the sync-safety classification has explicit rationale for each "local-only" decision (not just a list).
+
+---
+
+### U2. Format specification document
+
+**Goal:** Write the public, versioned contract for the secrets bus: directory layout, `.env` line semantics, `manifest.toml` schema, sealed-file shape, file mode requirements, atomic-write requirements, reserved key names, error semantics.
+
+**Requirements:** R1, R2, R5.
+
+**Dependencies:** U1 (so the format absorbs the patterns observed).
+
+**Files:**
+- `docs/spec-agentcookie-secrets-bus-v1.md` (created)
+
+**Approach:** The spec is a single document, sectioned: scope, directory layout, file formats (.env grammar plus the existing v0.12 sealed-file format reused verbatim), manifest schema with examples, security boundary statement, versioning rule (schema_version field in manifest). Include a "what this is NOT" section: not a generic secret store, not a credential issuer, not a rotation system; it's a transport + format for secrets the CLI already has.
+
+The .env grammar follows the dotenv loose convention (KEY=VALUE per line, # comments, optional quotes, no interpolation, no nested objects). Explicitly forbid features that fragment across parsers: variable interpolation (`$OTHER`), multi-line block syntax beyond backslash continuation, JSON-in-value.
+
+**Patterns to follow:** the existing `docs/protocol.md` for the wire-format spec style. Same level of formality.
+
+**Test scenarios:** Test expectation: none — documentation deliverable, but every grammar rule must have at least one example in the spec doc.
+
+**Verification:** The spec doc covers every requirement R1, R2, R5 in named subsections. A reader who never touched agentcookie can read this spec and write a conforming reader in any language.
+
+---
+
+### U3. Source-side fsnotify watcher + push pipeline
+
+**Goal:** agentcookie source detects changes to `~/.agentcookie/secrets/**` and pushes filtered payloads to the sink through the existing transport.
+
+**Requirements:** R3, R5.
+
+**Dependencies:** U2.
+
+**Files:**
+- `internal/secretsbus/watcher.go` (created)
+- `internal/secretsbus/watcher_test.go` (created)
+- `internal/secretsbus/payload.go` (created, defines the on-wire secret-payload struct)
+- `internal/cli/source.go` (modified, registers the secrets watcher alongside the cookies watcher)
+- `internal/protocol/envelope.go` (modified if needed to carry an optional secrets payload alongside cookies; otherwise a new envelope type)
+
+**Approach:** Mirror `internal/watcher/` (the Chrome Cookies watcher). The secrets watcher subscribes to fsnotify events for the secrets root, debounces them (same 500ms debounce the cookies watcher uses), reads the affected `secrets.env` files plus their manifests, drops files / keys marked `sync = false`, and posts the payload through the existing protocol layer. Sealed source-side files are passed through opaque; the sink already has the same master key (via the pair-derived shared secret + the v0.12 sealing layer) so it can unseal where appropriate.
+
+**Patterns to follow:** the Chrome Cookies watcher in `internal/watcher/cookies.go` (debounce, fsnotify subscribe, push to source-state) is the closest analog. Reuse its debounce helpers.
+
+**Execution note:** Start with a failing integration test that drops a file at `~/.agentcookie/secrets/foo/secrets.env`, asserts the source's `last_push` count includes the new file's keys.
+
+**Test scenarios:**
+- happy path: write `secrets.env` containing 3 keys, source push includes those 3 keys, no other changes.
+- happy path: write `manifest.toml` with `[sync.keys] FOO = false`, source push omits `FOO` but includes other keys.
+- edge case: write a `secrets.env` over 256KB (size limit); source rejects with a clear error and drops the push, does not crash.
+- edge case: drop a `manifest.toml` only (no `secrets.env` yet); source treats as no-op until the env file appears.
+- edge case: rapid sequential writes (5 writes in 200ms); debounce coalesces to one push.
+- error path: corrupted manifest.toml; source logs error, does NOT push the malformed file, continues watching.
+- integration: combined with the existing cookies watcher, a Chrome-cookie change and a secrets change in the same second produce two distinct pushes (or one combined push) without dropping either.
+
+**Verification:** `agentcookie source --once` with a populated secrets dir produces a sink-state entry showing the secrets count and per-CLI breakdown.
+
+---
+
+### U4. Sink-side receive + write + sealed-optional storage
+
+**Goal:** The sink accepts the secrets payload from the source, writes it to `~/.agentcookie/secrets/<cli-name>/secrets.env` on the sink, optionally seals it under the master key.
+
+**Requirements:** R4, R12.
+
+**Dependencies:** U2, U3.
+
+**Files:**
+- `internal/secretsbus/writer.go` (created)
+- `internal/secretsbus/writer_test.go` (created)
+- `internal/cli/sink.go` (modified, dispatches secrets-bus payloads to the writer)
+
+**Approach:** Symmetric to the cookies sidecar writer. On `/sync`, after the existing cookies-sidecar + adapter pushes run, if the envelope carries a secrets payload, write each per-CLI file via atomic rename (write to `.tmp`, fsync, rename). Mode 0600 on every file. If the v0.12 master key is configured AND the operator opted into sealing at install time, additionally write a `.sealed` twin and remove the plaintext (the reader library knows to try `.sealed` first). The master key path mirrors the v0.12 sealed-sidecar pattern at `internal/chrome/sidecar.go`.
+
+R12 regression guard: when the source sends a payload with NO secrets section, the sink writes nothing new and the existing cookies / adapter behavior is byte-identical to v0.12.0-beta.6.
+
+**Patterns to follow:** `internal/chrome/sidecar.go` for the sealed write path; `applyEnvelopeToSink` in `internal/cli/sink.go` for the receive-and-route shape.
+
+**Test scenarios:**
+- happy path: sink receives payload with 2 CLIs, writes both files, file mode 0600, atomic.
+- happy path: master key present + sealing enabled, sink writes only `secrets.env.sealed`, no plaintext on disk.
+- happy path: master key present + sealing NOT enabled (the v0.12.0-beta.3 default), sink writes plaintext only. R12 regression guard.
+- edge case: payload contains a per-CLI dir name with `..` or `/`; sink refuses, logs the rejection, does not write outside the secrets root.
+- edge case: existing local file at the target path with NEWER mtime; sink writes anyway (source is authoritative, that's the sync model) but logs the conflict.
+- integration: round-trip: source writes secrets.env, source pushes, sink writes the file, sink-side reader library reads back the same KEY=VALUE pairs.
+- regression: payload without secrets-section produces zero new files; cookies and adapter writes proceed unchanged. R12.
+
+**Verification:** end-to-end on the Mac mini sink: source writes `~/.agentcookie/secrets/test-cli/secrets.env` with `FOO=bar`, sync runs, sink has the same file at the same path with the same content (or its sealed twin), file mode 0600.
+
+---
+
+### U5. Go reader library (`pkg/agentcookiesecret`)
+
+**Goal:** Importable Go module that resolves sealed-or-plaintext secrets for a given CLI name, falls back through a sensible priority chain, and exposes the result as a `map[string]string`.
+
+**Requirements:** R6.
+
+**Dependencies:** U2, U4.
+
+**Files:**
+- `pkg/agentcookiesecret/load.go` (created)
+- `pkg/agentcookiesecret/load_test.go` (created)
+- `pkg/agentcookiesecret/doc.go` (created — go doc for external consumers)
+
+**Approach:** Public function `Load(cliName string) (map[string]string, error)`. Resolution priority: 1) `~/.agentcookie/secrets/<cli-name>/secrets.env.sealed` if master key available; 2) `~/.agentcookie/secrets/<cli-name>/secrets.env` plaintext; 3) the caller's existing config dir at `~/.config/<cli-name>/<file>` if explicitly registered via `LoadWithFallback`; 4) process environment variables. Returns the merged result with later sources NOT overriding earlier (so the bus wins over env). Sealed-file unseal reuses `internal/keystore` from agentcookie via the public surface.
+
+Public surface is intentionally tiny: `Load`, `LoadWithFallback`, `WatchForChanges` (channel-based, optional for long-lived daemons that want to pick up rotated secrets without restart).
+
+**Patterns to follow:** the existing `pkg/sidecar` module shape in agentcookie. Same public-API minimalism. Same go-doc style.
+
+**Execution note:** Test-first. Write the public surface tests against a temp HOME before the implementation.
+
+**Test scenarios:**
+- happy path: only plaintext `secrets.env` present, Load returns the keys.
+- happy path: sealed-only mode, master key available, Load returns the unsealed keys.
+- happy path: sealed-only mode, master key NOT available, Load returns an error naming the missing key path.
+- edge case: both plaintext and sealed present (transitional); Load prefers sealed, plaintext ignored.
+- edge case: empty secrets.env (zero keys); Load returns an empty map and nil error.
+- edge case: CLI name with invalid characters (`..`, `/`); Load returns an error before touching the filesystem.
+- error path: malformed `.env` line (e.g. `KEY` without `=`); Load returns an error pointing at the line number.
+- integration: written by U4's sink-side writer, read by this library; round-trip is byte-identical for keys and values.
+
+**Verification:** Library can be `go get`'d in a separate test repo, imported, and used to read a manually-populated `~/.agentcookie/secrets/test-cli/secrets.env`. `go doc pkg/agentcookiesecret` renders cleanly.
+
+---
+
+### U6. Python reader library (`agentcookie_secret`)
+
+**Goal:** Python equivalent of U5 for non-Go consumers (scripts, ad-hoc tools, agent runtimes that ship Python).
+
+**Requirements:** R6.
+
+**Dependencies:** U2, U4, U5 (so semantics are pinned to the Go reference).
+
+**Files:**
+- `clients/python/agentcookie_secret/__init__.py` (created)
+- `clients/python/agentcookie_secret/load.py` (created)
+- `clients/python/agentcookie_secret/test_load.py` (created)
+- `clients/python/pyproject.toml` (created)
+- `clients/python/README.md` (created — install + use)
+
+**Approach:** Same resolution priority as the Go reader. Single public function `load(cli_name: str) -> dict[str, str]`. Sealed-file unseal calls out to `agentcookie secret get` (the U7 subcommand) so the Python module does not need to vendor the encryption layer. Falls back gracefully when the agentcookie binary is not on PATH (returns plaintext-only).
+
+**Patterns to follow:** the `python-dotenv` package as the parser dependency; same minimalist public surface as U5.
+
+**Execution note:** Test-first. Mirror the Go test scenarios where applicable.
+
+**Test scenarios:**
+- happy path: plaintext-only load returns dict with expected keys.
+- happy path: sealed-only mode, agentcookie binary on PATH, load shells out and returns the unsealed dict.
+- edge case: agentcookie binary not on PATH AND sealed-only; load raises a clear `AgentcookieSecretError` naming the missing binary.
+- error path: malformed `.env` value; raises with line number.
+- integration: write a file with U4's writer; read it with this library; values match.
+
+**Verification:** `pip install -e clients/python` works; `from agentcookie_secret import load` returns the expected dict for a manually populated path.
+
+---
+
+### U7. `agentcookie secret` CLI subcommand
+
+**Goal:** Friend-facing tool for managing secrets in the bus when auto-detection from a CLI's existing config dir is not possible (yet).
+
+**Requirements:** R7.
+
+**Dependencies:** U2, U5.
+
+**Files:**
+- `internal/cli/secret.go` (created)
+- `internal/cli/secret_test.go` (created)
+- `docs/quickstart.md` (modified, add a "Storing secrets for CLIs" subsection)
+
+**Approach:** Cobra subcommand with the standard verbs:
+- `agentcookie secret list` — print a tree of `<cli-name>` -> key list (no values).
+- `agentcookie secret get <cli-name> <key>` — print value to stdout (used by the Python reader's shell-out path).
+- `agentcookie secret set <cli-name> <key>` — prompt on stdin for the value (TTY) or read from stdin (pipe).
+- `agentcookie secret rm <cli-name> [<key>]` — remove one key or the whole CLI dir.
+- `agentcookie secret import-from <path> --as <cli-name>` — one-shot ingest from an existing config file (JSON, TOML, env-shaped) into the standard layout. Heuristic field-name mapping for the common shapes documented in U1's audit; unknown fields land under their original key name with a leading `_` to flag manual review.
+
+Mode 0600 on every write. Sealed-or-plaintext respected per the v0.12 sealing setting.
+
+**Patterns to follow:** the existing `agentcookie wizard ...` subcommand structure for shape; the `agentcookie doctor` subcommand for printable output.
+
+**Test scenarios:**
+- happy path: `set` then `get` round-trips a value.
+- happy path: `list` shows three CLIs with their key names but no values.
+- happy path: `import-from` reads `~/.config/tesla-pp-cli/auth.json`, maps `access_token` → `TESLA_OAUTH_BEARER` (per the audit's heuristic table), `refresh_token` → `TESLA_OAUTH_REFRESH`, writes the standard layout.
+- edge case: `import-from` encounters a JSON field it cannot map; writes `_unknown_field_name=value` with a warning printed to stderr.
+- error path: `set` to a malformed CLI name (`../foo`); rejects before touching the filesystem.
+- integration: `set` then read via the U5 Go library; values match.
+
+**Verification:** `agentcookie secret list` after a sync from the laptop shows the same CLI list and key names on the sink.
+
+---
+
+### U8. Doctor coverage
+
+**Goal:** `agentcookie doctor` reports secrets-bus health alongside the existing checks.
+
+**Requirements:** R8.
+
+**Dependencies:** U4.
+
+**Files:**
+- `internal/cli/doctor.go` (modified)
+- `internal/cli/doctor_test.go` (modified)
+
+**Approach:** Add a "Secrets bus" check that reports: registered CLI count, total key count, sealed vs plaintext mode, sync-state freshness (mtime of newest file in `~/.agentcookie/secrets/`). WARN when sealed mode is configured but no `.sealed` files exist (sync hasn't run yet). SKIPPED on source-only installs since the secrets bus is sink-side too.
+
+**Patterns to follow:** the v0.12.0-beta.3 "Adapter coverage" check shape at `internal/cli/doctor.go`.
+
+**Test scenarios:**
+- happy path: 3 CLIs in the bus, plaintext mode, OK reports the counts.
+- happy path: sealed mode configured + sealed files present, OK reports "sealed".
+- WARN path: sealed mode configured but no `.sealed` files yet, WARN with remediation pointer.
+- SKIPPED path: source-only install with no secrets bus dir, reports SKIPPED.
+- regression: existing 10 checks still present; new check raises the envelope count to 11. Update the existing doctor envelope test accordingly.
+
+**Verification:** `agentcookie doctor --json` on a sink with 3 CLIs in the bus produces a valid envelope with the new entry; doctor exit code stays 0 when all-green.
+
+---
+
+### U9. Worked example: gh CLI reads from the secrets bus
+
+**Goal:** Prove the non-PP-CLI case end-to-end with the GitHub CLI as the worked example. Friend stores `gh` OAuth token in the bus; `gh` reads it via a shim wrapper.
+
+**Requirements:** R10.
+
+**Dependencies:** U2, U4, U5 (or U6).
+
+**Files:**
+- `docs/runbook-secrets-bus-gh-example.md` (created)
+- `examples/gh-shim/gh-shim` (created, executable shell wrapper)
+- `examples/gh-shim/README.md` (created)
+
+**Approach:** The shim is a 10-line shell script: `agentcookie secret get gh GH_TOKEN | GH_TOKEN=$(cat) exec gh "$@"`. The runbook walks the friend through: 1) on laptop, `gh auth login` as today; 2) `agentcookie secret import-from ~/.config/gh/hosts.yml --as gh` ingests the OAuth bearer; 3) source pushes to sink; 4) on sink, the friend either calls the shim wrapper or `eval "$(agentcookie secret env gh)"` to load before invoking `gh`.
+
+Out-of-band note: a proper non-shim integration would require `gh` itself to read from the bus, which is upstream PR territory not in this plan. The shim demonstrates the format works for unmodified third-party CLIs today.
+
+**Patterns to follow:** `docs/runbook-v0.11-adapter-cookie-push.md` shape (short, concrete, command-by-command).
+
+**Test scenarios:** Test expectation: none — runbook + example artifact. Manual verification in U11.
+
+**Verification:** Following the runbook from scratch on a clean sink, `ssh sink 'gh-shim issue list -R mvanhorn/agentcookie'` returns the live issue list without any `gh auth login` on the sink.
+
+---
+
+### U10. Migration runbook for CLI authors
+
+**Goal:** Concrete recipe a PP CLI author (or any CLI author) can follow to adopt the secrets bus without breaking existing users.
+
+**Requirements:** R11.
+
+**Dependencies:** U2, U5, U6.
+
+**Files:**
+- `docs/runbook-secrets-bus-adoption.md` (created)
+
+**Approach:** The runbook covers the three integration patterns observed in the U1 audit: 1) Go CLIs that read a single config.toml or auth.json today (most PP CLIs); 2) Python or scripting CLIs that read env vars; 3) CLIs that store auth in their own dir outside `~/.config/` (Tesla-style). For each pattern, the recipe gives: a) the call into the reader library, b) the fallback priority that preserves existing behavior, c) a 5-line change diff template the author can paste into their CLI's startup code.
+
+Includes a "what NOT to do" section: do not seal at the CLI layer (let agentcookie own that), do not rewrite the file (the bus is source-of-truth, the CLI is read-only against the bus), do not interpolate values into other env vars (the format forbids it for parser compatibility).
+
+**Patterns to follow:** `docs/runbook-v0.11-adapter-cookie-push.md` for the "how to add an adapter" shape.
+
+**Test scenarios:** Test expectation: none — documentation deliverable, validated by U11.
+
+**Verification:** Pick one PP CLI from the U1 audit (candidate: `expensify-pp-cli`, simple TOML shape, single OAuth bearer) and walk the runbook against its source. The migration patch is under 20 lines and existing users see no behavior change.
+
+---
+
+### U11. End-to-end dry-run + cut release
+
+**Goal:** Validate the full secrets-bus flow end-to-end on a live source + sink pair; cut the release.
+
+**Requirements:** all.
+
+**Dependencies:** U1-U10.
+
+**Files:**
+- `CHANGELOG.md` (modified, new version section)
+- `docs/dry-run-2026-MM-DD.md` (created at dry-run time)
+
+**Approach:** Reset the Mac mini sink (same flow as the v0.12.0-beta.3/5/6 dry-runs). On the laptop, run `agentcookie secret import-from ~/.config/tesla-pp-cli/auth.json --as tesla-pp-cli`, watch the source push fire, verify the sink wrote the file at the standard path with mode 0600 and the values match. Run the gh shim from the sink to confirm the non-PP-CLI case. Capture friction in a dated dry-run doc; ship as the next v0.12.0-beta.N or, if the surface justifies it, cut v0.13.0-beta.1.
+
+**Execution note:** Capture the friction log inline, same pattern as the 2026-05-19 and 2026-05-21 dry-runs. Items the audit reveals after-the-fact go in the friction log, not back into this plan.
+
+**Test scenarios:** Test expectation: none — validation gate. Per-unit tests in U1-U10 carry the correctness load.
+
+**Verification:** dated dry-run doc committed; release tag published; sample CLI (expensify-pp-cli per U10) demonstrably reads its secrets from the bus on the sink with no manual config.
+
+---
+
+## System-Wide Impact
+
+- **Source side**: gains a new fsnotify watcher subscribing to `~/.agentcookie/secrets/`. Memory + CPU cost is the same shape as the existing cookies watcher (debounced, idle most of the time).
+- **Sink side**: gains a new writer path that fires per `/sync` when the payload carries a secrets section. Sealed writes reuse the v0.12 master key when sealing is enabled.
+- **PP CLI ecosystem**: gains an optional secrets source. Each CLI's adoption is its own PR and goes at its own pace. Non-adopters continue to work via their existing config dirs.
+- **Friend onboarding**: gets a new chapter (`Storing secrets for CLIs`) in the quickstart. One additional command (`agentcookie secret import-from ...`) per CLI that uses the bus.
+- **Existing v0.12.0-beta.6 installs**: no behavior change unless they create `~/.agentcookie/secrets/<cli-name>/` themselves. R12 regression guards live in U3 and U4 tests.
+
+## Risks and Mitigations
+
+- **Risk**: `.env` plaintext at rest is a real security regression vs OS keychain for some friends' threat models. Mitigation: sealed-optional mode under the v0.12 master key; default sealing posture documented in the spec; friends with stricter requirements opt in.
+- **Risk**: Sync overwrites a sink-side secret that's actually fresher (e.g. the sink ran an OAuth refresh and updated its token while the source hadn't yet). Mitigation: per-key manifest entry `sync = false` for keys the sink is allowed to mint (refresh tokens that rotate per-machine). Documented in the spec; default is `sync = true` since most secrets are one-source.
+- **Risk**: Heuristic field mapping in `import-from` produces wrong key names (e.g. mistakes a session ID for an API key). Mitigation: unknown fields write `_<original_name>` and print a stderr warning, so the friend can review and rename. The Tesla case in U7's test scenarios is the worst-case example.
+- **Risk**: The audit reveals a PP CLI whose secret-storage pattern fundamentally cannot fit the `.env` shape (e.g. binary blobs over 256KB, sqlite-only storage with constraints on the schema). Mitigation: U1 surfaces these explicitly; the format spec's "what this is NOT" section documents the boundary; affected CLIs can adopt later or stay manual.
+- **Risk**: Cross-repo coordination cost (each PP CLI adopting in its own PR). Mitigation: U10's runbook is the bridge; agentcookie does not gate on adoption; the bus is useful from day one for any single CLI that adopts.
+- **Risk**: Non-PP-CLI integration (e.g. `gh`) requires shim wrappers since upstream tools won't link our reader. Mitigation: documented limitation; the shim pattern is generic and one-line. Future upstream integration is out of scope here.
+
+## Acceptance Criteria
+
+- A friend who runs `agentcookie secret import-from ~/.config/tesla-pp-cli/auth.json --as tesla-pp-cli` on the laptop sees the secret payload land at `~/.agentcookie/secrets/tesla-pp-cli/secrets.env` on the sink within one sync interval, with mode 0600, with the OAuth bearer correctly mapped to a `TESLA_OAUTH_BEARER` key.
+- A Go PP CLI on the sink that imports `pkg/agentcookiesecret` and calls `Load("tesla-pp-cli")` sees the expected map.
+- A Python script on the sink that imports `agentcookie_secret` and calls `load("tesla-pp-cli")` sees the same map.
+- A non-PP CLI (`gh`) wrapped via the shim from U9 successfully runs `issue list` on the sink without `gh auth login` on the sink.
+- `agentcookie doctor` reports the bus health correctly across the three states (no bus, plaintext bus, sealed bus).
+- `docs/audits/2026-05-22-pp-cli-auth-inventory.md` lists all 36 installed PP CLIs with their current auth shapes and sync-safety classifications.
+- An existing v0.12.0-beta.6 install upgrading to this version sees no behavior change unless they explicitly create `~/.agentcookie/secrets/`.
+- The format spec is published in the repo and is sufficient for an external author to write a conforming reader without reading agentcookie source.
+
+## Deferred Questions
+
+- Should there be a daemon-mode reader-library variant that auto-reloads secrets on file change (for long-running agent processes that want zero-restart secret rotation)? Library exposes `WatchForChanges` channel in U5 as a hook; full daemon support deferred.
+- Should `agentcookie secret import-from` learn to read from the OS Keychain directly (`security find-generic-password ...`)? Useful for CLIs that store there today (`gh` on macOS does). Deferred to v2 of the bus.
+- Should the bus support secrets that are themselves binary (signed certificates, raw key bytes)? Today the format forbids it for parser compatibility. Friends with binary needs use the `agentcookie secret import-from --binary` path that base64-encodes into a `_BIN_<KEY>` env var with a marker. Documented in U2 spec.
+
+## Origin
+
+This plan was generated 2026-05-22 from a planning session where Matt asked for a feature in agentcookie that standardizes a format for PP CLIs to store secrets / auth tokens, with the Tesla CLI's eight-file auth layout as the worst-case example. The session also surfaced that the format must serve CLIs outside the Printing Press ecosystem, which shaped the format-spec-as-public-contract approach and the worked `gh` example.

--- a/docs/runbook-secrets-bus-adoption.md
+++ b/docs/runbook-secrets-bus-adoption.md
@@ -1,0 +1,183 @@
+# Adopting the agentcookie secrets bus in your CLI
+
+This runbook is for CLI authors who want their CLI to read auth tokens / API keys / OAuth bearers from the agentcookie secrets bus instead of from their own bespoke config file.
+
+You do not have to remove your existing config file. The pattern in this runbook layers the bus on top of your existing loader so users keep working through the transition and gradually opt into the bus.
+
+## The contract
+
+agentcookie writes one file per CLI at:
+
+```
+~/.agentcookie/secrets/<your-cli-name>/secrets.env
+```
+
+Plain `KEY=VALUE` lines, one per line. Mode 0600. When the v0.12 master key is set up on the machine, a sealed twin appears as `secrets.env.sealed` and the plaintext may be absent.
+
+Full grammar + lookup priority is in `docs/spec-agentcookie-secrets-bus-v1.md`.
+
+## Three integration patterns
+
+Pick the one that matches how your CLI is built.
+
+### Pattern A: Go CLI reads its own config TOML / JSON today
+
+Most PP CLIs are here. Add the agentcookie Go reader to your imports and call it at startup before your existing config loader. The bus values override env; your existing config still wins for keys not in the bus, so existing users see no change.
+
+```go
+import "github.com/mvanhorn/agentcookie/pkg/agentcookiesecret"
+
+func loadAuth() *Config {
+    // 1. Try the agentcookie bus first.
+    busEnv, err := agentcookiesecret.LoadWithFallback(
+        "my-pp-cli",                                            // your cli name
+        filepath.Join(os.Getenv("HOME"), ".config", "my-pp-cli", "config.toml"),
+    )
+    if err != nil && !errors.Is(err, agentcookiesecret.ErrInvalidCLIName) {
+        // sealed file present but master key missing, or similar -
+        // fall through to your existing loader
+        log.Printf("agentcookiesecret: %v; falling back", err)
+    }
+
+    // 2. Now invoke your existing TOML / JSON / env loader. Where it
+    //    reads from env vars, read from busEnv first.
+    cfg := &Config{
+        OAuthBearer:  busEnv["MY_OAUTH_BEARER"],
+        OAuthRefresh: busEnv["MY_OAUTH_REFRESH"],
+        // ... etc
+    }
+    if cfg.OAuthBearer == "" {
+        cfg.OAuthBearer = os.Getenv("MY_OAUTH_BEARER")
+    }
+    return cfg
+}
+```
+
+Key choices:
+
+- The fallback path argument to `LoadWithFallback` is your CLI's existing config file. The reader looks there for any key not in the bus.
+- Bus values win over env vars (per spec section 11.2). Do not invert this in your CLI; users who set both expect the bus to override.
+- Keep your existing OAuth-login command (`my-pp-cli auth login`). The bus is for delivery, not for issuance. After login, optionally call `agentcookie secret import-from` to mirror the new tokens into the bus.
+
+### Pattern B: Python (or scripting) CLI that reads env vars today
+
+Shell out to `agentcookie secret get` once per key, or eval an env dump:
+
+```bash
+#!/usr/bin/env bash
+# At the top of your script:
+eval "$(agentcookie secret env my-pp-cli 2>/dev/null)"
+
+# Now MY_OAUTH_BEARER and friends are exported. Your script keeps
+# reading them from env exactly as it does today.
+your-existing-logic
+```
+
+For long-running Python processes, do the equivalent once at startup:
+
+```python
+import subprocess, os
+
+try:
+    out = subprocess.run(
+        ["agentcookie", "secret", "env", "my-pp-cli"],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    for line in out.splitlines():
+        if "=" in line:
+            k, v = line.split("=", 1)
+            os.environ.setdefault(k, v)
+except Exception:
+    pass  # bus not installed or no entry; keep existing env-var behavior
+```
+
+`os.environ.setdefault` rather than direct assignment preserves any explicit env var the user set when invoking your CLI.
+
+### Pattern C: CLI that uses its own dotdir (`~/.toolname/`) outside `~/.config/`
+
+This is the Tesla pattern (one config dir for the CLI; a second dotdir for additional artifacts). Use the same Go reader call as Pattern A, but consume both surfaces:
+
+```go
+busEnv, _ := agentcookiesecret.Load("tesla-pp-cli")
+
+// File-shaped artifacts (e.g. signing keys) still come from the dotdir.
+// The bus carries the env-shaped half; the file-shaped half stays local.
+privateKeyPath := filepath.Join(os.Getenv("HOME"), ".tesla", "snowflake-private.pem")
+
+cfg := &Config{
+    OAuthBearer:    busEnv["TESLA_OAUTH_BEARER"],
+    FleetClientID:  busEnv["TESLA_FLEET_CLIENT_ID"],
+    SigningKeyPath: privateKeyPath,  // never in the bus
+}
+```
+
+The bus replaces the env-shaped half. The file-shaped half (PEMs, certs, etc.) stays under your dotdir and is marked `sync = false` in the manifest if the user wants to keep it local.
+
+## What NOT to do
+
+- **Do not seal at the CLI layer.** Let agentcookie own that. Your CLI reads plaintext + sealed transparently via the reader library; it never touches the master key directly.
+- **Do not rewrite the bus file.** The bus is source-of-truth; your CLI is read-only against it. If your CLI rotates a token (e.g. via OAuth refresh), write the new value to your existing config file and let agentcookie's import flow pick it up.
+- **Do not interpolate values into other env vars.** The v1 spec forbids `$OTHER` substitution because not every dotenv parser supports it. Your CLI reads keys literally.
+- **Do not assume the bus is present.** It is opt-in. Your fallback path (your existing config loader) must continue to work when the bus is empty or absent.
+- **Do not name your bus directory with uppercase, dots, or underscores.** Use lowercase letters, digits, and hyphens. `my-pp-cli` good. `my_pp_cli`, `MyPPCli`, `pp.cli` rejected by the reader.
+
+## Five-line diff template
+
+If your CLI currently does:
+
+```go
+cfg := loadConfigFromFile("~/.config/my-pp-cli/config.toml")
+```
+
+Adopt the bus with three additions:
+
+```go
+// (1) Read the bus first.
+busEnv, _ := agentcookiesecret.Load("my-pp-cli")
+
+cfg := loadConfigFromFile("~/.config/my-pp-cli/config.toml")
+
+// (2) Let bus values override the file's matching env-shaped fields.
+if v := busEnv["MY_OAUTH_BEARER"]; v != "" { cfg.OAuthBearer = v }
+if v := busEnv["MY_OAUTH_REFRESH"]; v != "" { cfg.OAuthRefresh = v }
+// (3) ... etc per field
+```
+
+Compatible with users who haven't adopted the bus (`busEnv` is mostly empty for them) and with users who already use the bus (their tokens win).
+
+## Marking secrets local-only
+
+If your CLI has a secret type that must NOT be synced between machines (per-device signing key, machine-bound credential, anything generated locally and tied to hardware), drop a manifest at:
+
+```
+~/.agentcookie/secrets/<your-cli>/manifest.toml
+```
+
+with:
+
+```toml
+schema_version = 1
+display_name = "My PP CLI"
+
+[sync.keys]
+MY_LOCAL_SIGNING_KEY_PEM = false
+```
+
+Per-key `false` overrides the default. agentcookie's source will exclude that key from sync. The friend can also opt entire categories out via `[sync] default = false`; see section 4.3 of the spec.
+
+## Letting your existing user adopt without re-login
+
+The smoothest migration is:
+
+1. User installs your CLI v2 with bus support. Your CLI's fallback chain still reads the legacy config file.
+2. User authenticates as today (`my-pp-cli auth login`). Tokens write to your legacy config file.
+3. User runs `agentcookie secret import-from ~/.config/my-pp-cli/config.toml --as my-pp-cli`. The import heuristic maps known field names to canonical UPPER_SNAKE_CASE; unknown fields land under `_unknown_<orig>` so the user can review.
+4. Source machine pushes; sink receives. Your CLI on the sink reads from the bus first, falls back to the file (still present from the import source) when keys are missing.
+5. Once the user is confident, they can delete the legacy file or leave it alone; the bus takes precedence either way.
+
+## Reference
+
+- Format spec: `docs/spec-agentcookie-secrets-bus-v1.md`
+- Audit of how PP CLIs store auth today: `docs/audits/2026-05-22-pp-cli-auth-inventory.md`
+- Go reader package: `github.com/mvanhorn/agentcookie/pkg/agentcookiesecret`
+- Worked example for non-PP CLIs (gh): `docs/runbook-secrets-bus-gh-example.md`

--- a/docs/runbook-secrets-bus-gh-example.md
+++ b/docs/runbook-secrets-bus-gh-example.md
@@ -1,0 +1,119 @@
+# Worked example: feeding GitHub CLI from the secrets bus
+
+This runbook walks through end-to-end adoption of the agentcookie secrets bus for a real non-PP CLI: GitHub's `gh`. The goal is to show that the bus is a publicly consumable contract, not a PP-CLI-only mechanism.
+
+The full shim + per-shim README lives at `examples/gh-shim/`. This document is the narrative version: what happens, in what order, why.
+
+## The setup
+
+- Two Macs on Tailscale, with cookie sync already working.
+- `gh` installed on both via Homebrew at `/opt/homebrew/bin/gh`.
+- Source Mac is logged into GitHub via `gh auth login` (creates `~/.config/gh/hosts.yml` with a token).
+- Sink Mac has no `hosts.yml` and `gh auth status` reports "not logged in."
+
+We want sink to use the same token without re-running browser-flow login.
+
+## Step 1: capture the source token into the bus
+
+`gh` stores its OAuth bearer at `~/.config/gh/hosts.yml`:
+
+```yaml
+github.com:
+    user: mvanhorn
+    oauth_token: ghu_xxxxxxxxxxxxxxxxxxxx
+    git_protocol: ssh
+```
+
+We can either:
+
+- (a) Extract the token by hand and `agentcookie secret set gh GH_TOKEN`, or
+- (b) Use `agentcookie secret import-from ~/.config/gh/hosts.yml --as gh` and let the heuristic canonicalize.
+
+The import heuristic does not yet recognize gh's specific YAML shape (it's tuned for JSON + TOML), so (a) is the path of least friction. One line:
+
+```bash
+yq -r '."github.com".oauth_token' ~/.config/gh/hosts.yml | agentcookie secret set gh GH_TOKEN
+```
+
+Verify it landed:
+
+```bash
+agentcookie secret list
+# gh
+#   GH_TOKEN
+```
+
+The bus now holds the gh token at `~/.agentcookie/secrets/gh/secrets.env`, mode 0600, single line `GH_TOKEN=ghu_xxxx...`.
+
+## Step 2: install the shim on sink
+
+The shim is a 50-line bash script that sits ahead of `gh` on `$PATH`. On invocation it reads `agentcookie secret env gh` and exports `GH_TOKEN` before `exec`ing the real binary.
+
+```bash
+mkdir -p ~/.local/bin
+cp examples/gh-shim/gh ~/.local/bin/gh
+chmod +x ~/.local/bin/gh
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc
+```
+
+After a new shell, `which gh` should print `~/.local/bin/gh` rather than `/opt/homebrew/bin/gh`.
+
+## Step 3: let sync happen
+
+On source, run agentcookie's source (or wait for the watcher). The push includes both cookies AND the bus payload for the `gh` CLI. The sink writes `~/.agentcookie/secrets/gh/secrets.env` with the same `GH_TOKEN=...` line.
+
+## Step 4: verify on sink
+
+```bash
+gh auth status
+# github.com
+#   Logged in to github.com account mvanhorn (~/.agentcookie/secrets/gh/secrets.env)
+#   Active account: true
+#   Git operations protocol: https
+#   Token: ghu_************************
+```
+
+The shim sourced GH_TOKEN; `gh` saw a populated env var; the binary trusted it without checking `hosts.yml`.
+
+```bash
+gh pr list --limit 5
+# real PRs from the source's GitHub account
+```
+
+## What this proves
+
+1. The bus is a real, publicly consumable contract. A third-party CLI we do not control consumed it via a tiny shim, with no changes to its codebase.
+2. Resolution priority works as specified: shim respects pre-set GH_TOKEN, falls back to bus, falls back to gh's own keystore.
+3. Sync is atomic: cookies and secrets ship in the same envelope, so a friend gets logged-in browser + logged-in `gh` from a single source push.
+
+## Failure modes worth knowing
+
+- **Bus is empty on sink.** The shim's `agentcookie secret env gh` returns nothing; the shim exports nothing; the real `gh` falls through to its own `hosts.yml` (which on a fresh sink doesn't exist). `gh auth status` reports "not logged in." This is the correct degraded behavior; no surprise auth.
+- **PATH order wrong.** If `/opt/homebrew/bin/gh` precedes `~/.local/bin/gh`, the shim never runs and the bus is silently ignored. `which gh` is the diagnostic.
+- **Token expired or revoked.** The shim cannot detect this; it just exports whatever the bus says. `gh auth status` will return 401. Recovery: re-run `gh auth login` on source, then `agentcookie secret import-from` again.
+- **Shim conflicts with `gh extension` machinery.** gh's extension subsystem also lives under `~/.local/share/gh/`. The shim doesn't touch that. Tested with `gh extension list` and `gh copilot`.
+
+## Adapting to other CLIs
+
+The shim template generalizes to anything that:
+- Reads auth from a single env var, AND
+- Is distributed as a binary you don't want to modify.
+
+Examples this would work for, with the same ~50 lines:
+
+| CLI | Env var | Bus directory |
+|-----|---------|--------------|
+| `gh` | `GH_TOKEN` | `gh` |
+| `glab` | `GITLAB_TOKEN` | `glab` |
+| `aws` | `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` | `aws` |
+| `op` (1Password CLI) | `OP_SESSION_<acct>` | `op-<acct>` |
+| `vault` | `VAULT_TOKEN` | `vault` |
+
+For tools that don't read an env var (some CLIs only read their own config file), the Tesla pattern in `docs/runbook-secrets-bus-adoption.md` Pattern C is the right reference instead.
+
+## Reference
+
+- The shim itself: `examples/gh-shim/gh`
+- Installation walkthrough: `examples/gh-shim/README.md`
+- Format spec: `docs/spec-agentcookie-secrets-bus-v1.md`
+- General CLI-author runbook: `docs/runbook-secrets-bus-adoption.md`

--- a/docs/spec-agentcookie-secrets-bus-v1.md
+++ b/docs/spec-agentcookie-secrets-bus-v1.md
@@ -1,0 +1,546 @@
+---
+title: agentcookie secrets bus format specification
+schema_version: 1
+status: v1 draft
+created: 2026-05-22
+---
+
+# agentcookie secrets bus v1
+
+This document specifies the on-disk and transport-visible format of the agentcookie secrets bus. The format is a public contract. An external author should be able to read this document and write a conforming reader in any language without consulting agentcookie source.
+
+The two roles named in this document are:
+
+- **The agentcookie source.** The actor that owns the laptop side of the bus. It observes the laptop filesystem, applies sync policy, and ships secrets through the agentcookie transport to the sink.
+- **The agentcookie sink.** The actor that owns the sink-machine side of the bus. It receives payloads from the source and materializes them at the standard paths on the sink filesystem.
+
+A consumer is any CLI (or other program) that reads from the bus at runtime. Consumers see only the on-disk file shape described below. They do not need to participate in the transport protocol.
+
+## 1. Scope and non-scope
+
+### 1.1 What this format is
+
+- A transport-visible and on-disk shape for per-CLI secrets.
+- A directory layout under a single well-known root, addressable by CLI name.
+- A line-oriented value file in the `.env` family that any mainstream dotenv parser can consume.
+- A small TOML manifest that describes the per-CLI dataset and carries sync-policy hints.
+- An optional sealed-twin file for at-rest encryption on the sink. The sealed twin is opaque to consumers; the only public-visible properties are its filename and the rule that it shadows its plaintext sibling.
+
+### 1.2 What this format is not
+
+- It is not a secret store. agentcookie does not generate secrets, prompt for new credentials, or surface a vault interface. It moves and stores values that a CLI already has.
+- It is not a credential issuer. Logging in, completing OAuth, minting API keys, and refresh-token rotation are entirely the CLI's responsibility. The bus carries the result.
+- It is not a rotation system. If a secret expires or is revoked, the next write from the authoritative side propagates the replacement. The bus has no concept of expiry, validity windows, or revocation lists.
+- It is not a remote API. There is no network surface defined here. The transport that moves payloads between source and sink is specified in `docs/protocol.md`; this document covers only the file shape carried inside that transport and materialized on each side.
+- It is not a key-management protocol. The sealed twin reuses the existing agentcookie at-rest sealing layer; this document does not redefine that layer.
+
+## 2. Directory layout
+
+### 2.1 Root path
+
+All secrets live under a single root directory:
+
+```
+~/.agentcookie/secrets/
+```
+
+The root is owned by the user that runs agentcookie. The root directory itself has mode `0700`.
+
+### 2.2 Per-CLI subdirectory
+
+Each consumer that participates in the bus has its own subdirectory directly under the root:
+
+```
+~/.agentcookie/secrets/<cli-name>/
+```
+
+The subdirectory has mode `0700`.
+
+### 2.3 CLI name rules
+
+The `<cli-name>` segment is a stable identifier chosen by the consumer's author. It MUST follow these rules:
+
+- Lowercase only. The set of permitted characters is `a` through `z`, `0` through `9`, and the ASCII hyphen `-`.
+- It MUST NOT begin or end with a hyphen.
+- It MUST NOT contain two consecutive hyphens.
+- It MUST NOT contain a dot, a slash, a backslash, whitespace, or any other punctuation.
+- It MUST NOT be `.` or `..` or any other path-traversal token.
+- Length is at least one character and at most sixty-four characters.
+
+A reader that encounters a path component that fails any of these rules MUST refuse to open the directory and MUST report an error naming the violating component. Readers MUST NOT silently normalize names (no case folding, no underscore-to-hyphen rewriting).
+
+The agentcookie sink applies these same rules before materializing a payload. A payload that names an invalid CLI is rejected; the sink logs the rejection and writes nothing outside the secrets root.
+
+### 2.4 Files inside a per-CLI directory
+
+A conforming per-CLI directory contains the following files. All of them are optional except where noted; a directory with only a manifest and no value file is legal and represents a registered consumer with no current secrets.
+
+| Filename               | Required | Contents                                                                                                                                                |
+| ---------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `secrets.env`          | No       | Plaintext line-oriented `KEY=VALUE` pairs. Defined in section 3.                                                                                       |
+| `manifest.toml`        | Yes      | TOML metadata describing the dataset and sync policy. Defined in section 4.                                                                            |
+| `secrets.env.sealed`   | No       | Opaque sealed twin of `secrets.env`. Defined in section 5.                                                                                             |
+
+Any other file in the per-CLI directory is ignored by conforming readers. The bus does not reserve names for future use beyond the three listed above; new file kinds will be introduced through a manifest schema bump (section 10).
+
+### 2.5 No nesting
+
+The per-CLI directory has no subdirectories. A reader MUST NOT descend into nested directories under a CLI name. If one is present, it is ignored.
+
+## 3. The `secrets.env` line format
+
+`secrets.env` is a plaintext UTF-8 file. Each non-empty, non-comment line carries one `KEY=VALUE` pair. The grammar below is intentionally a strict subset of the broader "dotenv" family, so that values written by one mainstream parser are read back identically by any other.
+
+### 3.1 Grammar
+
+In ABNF-flavored form:
+
+```
+file        = *line
+line        = blank / comment / entry
+blank       = *WSP NEWLINE
+comment     = *WSP "#" *VCHAR NEWLINE
+entry       = key "=" value NEWLINE
+key         = ALPHA / "_" *( ALPHA / DIGIT / "_" )
+value       = bare-value / dq-value / sq-value
+bare-value  = *( safe-char / "\" continuation )
+safe-char   = %x21-22 / %x24-3D / %x3F-5B / %x5D-7E   ; printable, no whitespace, no #, no =, no \, no "
+dq-value    = DQUOTE *( dq-char / "\" dq-escape ) DQUOTE
+dq-char     = %x20-21 / %x23-5B / %x5D-7E             ; printable except " and \
+dq-escape   = DQUOTE / "\" / "n" / "r" / "t"
+sq-value    = SQUOTE *sq-char SQUOTE
+sq-char     = %x20-26 / %x28-7E                       ; printable except '
+continuation= NEWLINE                                 ; only when last char of line is "\"
+```
+
+Plain English summary:
+
+- Lines that start with optional whitespace and then `#` are comments. Comments occupy the whole line; trailing comments after a value are not supported.
+- Blank lines are allowed and have no effect.
+- A key starts with an ASCII letter or underscore and continues with letters, digits, or underscores. Keys are case-sensitive.
+- The single `=` between key and value is required. There is no whitespace allowed around the `=`. `KEY = value` is invalid; the equals sign must be flush.
+- A value is one of three shapes: bare, double-quoted, or single-quoted.
+  - A bare value runs from immediately after the `=` to the end of the line. It MUST NOT contain whitespace, `#`, `=`, `\`, or `"`.
+  - A double-quoted value supports the escape sequences `\"`, `\\`, `\n`, `\r`, `\t`. No other backslash escape is defined.
+  - A single-quoted value is taken verbatim. No escape sequences are recognized; the value continues until the next `'`.
+- Multi-line values are supported only via backslash continuation. A backslash as the last character of a line joins the next line into the current value. The backslash and the newline are both removed; the next line's leading whitespace, if any, is preserved.
+- The file MUST be UTF-8. A byte order mark (BOM) at the start of the file is permitted and ignored by conforming readers.
+
+### 3.2 Explicit forbiddens
+
+The following dotenv-family features are explicitly excluded. Writers MUST NOT emit them. Readers MUST treat them as syntax errors.
+
+- Variable interpolation. `KEY=$OTHER` is a literal value `$OTHER`, not a reference. There is no `${OTHER}` form.
+- Command substitution. `KEY=$(cmd)` is a literal value.
+- `export KEY=...` prefix. The bare `export` keyword is not recognized; a line that begins with it is a syntax error.
+- Bare JSON, YAML, TOML, or other structured values without explicit string quoting. A value that begins with `{` or `[` is permitted only when it appears inside double quotes or single quotes.
+- Heredoc or triple-quoted block syntax. The only multi-line mechanism is backslash continuation.
+- Trailing comments on the same line as a value. `KEY=foo # comment` parses `foo # comment` as the value.
+
+Excluding these features keeps the format portable across the major dotenv libraries (Go `joho/godotenv`, Python `python-dotenv`, Node `dotenv`, Ruby `dotenv`) without depending on any parser-specific extension.
+
+### 3.3 Valid examples
+
+```
+# OAuth bearer with a long opaque value.
+TESLA_OAUTH_BEARER=eyJraWQiOiI4Y0w1RXVqaXN6dmJrUm9PUEFlSzNNYW1kRmM4dG5oVDB6
+```
+
+```
+# Quoted value, because the value contains a hash character.
+SUNO_SESSION_TAG="abc#123"
+```
+
+```
+# Single-quoted value preserves a literal dollar sign.
+GOAT_NOTE='take $5 off next order'
+```
+
+```
+# Backslash continuation joins two lines into one logical value.
+SUPERHUMAN_REFRESH=eyJhbGciOi...firstpart...\
+secondpart...AwIA
+```
+
+```
+# Empty value is legal. Useful for "key exists but is intentionally blank".
+EBAY_ACCOUNT_TAG=
+```
+
+### 3.4 Invalid examples
+
+```
+# Whitespace around = is not allowed.
+GH_TOKEN = ghp_xxx
+```
+
+Reason: the grammar requires the `=` to be flush against both key and value. A reader MUST reject this line and report the line number.
+
+```
+# Trailing comment on a value line is not allowed.
+LINEAR_TOKEN=lin_api_xxx # leave room to rotate
+```
+
+Reason: comments occupy the whole line. The value here parses as `lin_api_xxx # leave room to rotate`, which is almost never what the author intended. To avoid silent capture of comment-shaped suffixes, conforming readers MUST treat the resulting value as legal but writers SHOULD NOT emit values that look like a trailing comment. (This particular case is a SHOULD-NOT for writers, MUST-accept for readers; the line is grammatically valid because `#` is a `safe-char` inside `bare-value`.)
+
+```
+# Variable interpolation is not honored.
+DERIVED_TOKEN=$BASE_TOKEN
+```
+
+Reason: `$BASE_TOKEN` is a literal value. A reader returns the string `$BASE_TOKEN`, not the resolved value of `BASE_TOKEN`. This is legal and parses cleanly; it is included here as an "invalid intent" example. Writers that meant to reference another key MUST resolve the value before writing.
+
+```
+# Heredoc syntax is not part of this grammar.
+MULTI<<EOF
+line one
+line two
+EOF
+```
+
+Reason: the only multi-line mechanism is backslash continuation. The first line is a syntax error because `MULTI<<EOF` does not contain a flush `=`.
+
+## 4. The `manifest.toml` schema
+
+`manifest.toml` is a TOML 1.0 document. It describes the per-CLI dataset and carries the sync-policy hints that the agentcookie source consults before transmitting a payload.
+
+### 4.1 Required fields
+
+```
+schema_version = 1
+display_name = "Tesla PP CLI"
+```
+
+- `schema_version` (integer, required). The version of this manifest schema. The current value is `1`. Writers MUST set it; readers MUST inspect it (see section 10).
+- `display_name` (string, required). A human-readable label for the consumer. Used in `agentcookie secret list`, doctor output, and any future UI. UTF-8, between one and one hundred and twenty-eight characters.
+
+### 4.2 Optional `[sync]` table
+
+```
+[sync]
+default = true
+```
+
+- `default` (boolean, optional, default `true`). The default sync policy for the dataset. When `true`, every key in `secrets.env` is shipped to the sink unless overridden in `[sync.keys]`. When `false`, no key is shipped unless explicitly overridden to `true` in `[sync.keys]`.
+
+When `[sync]` is absent entirely, the default is equivalent to `[sync] default = true`.
+
+### 4.3 Optional `[sync.keys]` table
+
+```
+[sync.keys]
+TESLA_SNOWFLAKE_PRIVATE_KEY_PEM = false
+TESLA_FLEET_PARTNER_TOKEN = true
+```
+
+`[sync.keys]` is a flat TOML table whose keys are the same names that appear in `secrets.env`, and whose values are booleans.
+
+- A key set to `true` is always shipped to the sink, regardless of `[sync] default`.
+- A key set to `false` is never shipped to the sink, regardless of `[sync] default`.
+- A key absent from `[sync.keys]` inherits `[sync] default`.
+
+Keys listed in `[sync.keys]` that do not appear in `secrets.env` are ignored (forward-compatible: a manifest can pre-declare policy for keys a future version of the consumer will write).
+
+### 4.4 Reserved fields
+
+The `[meta]` table and any field whose name begins with an underscore (`_*`) are reserved for future agentcookie use. Writers SHOULD NOT set them; readers MUST ignore them. See section 8.
+
+### 4.5 A fully worked manifest example
+
+Consider a hypothetical consumer named `example-pp-cli` whose secrets include a long-lived API key (safe to sync), a per-machine OAuth refresh token that each side mints on its own (must not be overwritten by the source), and a binary signing key that exists only on the laptop:
+
+```
+schema_version = 1
+display_name = "Example PP CLI"
+
+[sync]
+# Most keys are safe to ship to the sink.
+default = true
+
+[sync.keys]
+# This refresh token is rotated independently on each machine.
+# Sink must keep its own copy, never receive the source's value.
+EXAMPLE_OAUTH_REFRESH = false
+
+# This signing key is bound to the laptop's secure enclave.
+# It does not leave the laptop under any circumstance.
+_BIN_EXAMPLE_SIGNING_PRIVATE_KEY = false
+```
+
+Effect on the wire payload: the agentcookie source reads `secrets.env`, drops the two keys with `sync = false`, and ships only the remaining keys to the sink.
+
+## 5. The sealed-twin file `secrets.env.sealed`
+
+### 5.1 Purpose and visibility
+
+`secrets.env.sealed` is an at-rest encryption of the same key/value content that `secrets.env` would carry. Its body is opaque to consumers and to readers in other languages. The format internals are owned by agentcookie and may evolve without bumping the schema version of this document, because no consumer needs to interpret the bytes directly.
+
+What this specification defines about the sealed twin:
+
+- The filename. It is always `secrets.env.sealed` in the same per-CLI directory as the plaintext sibling. No other suffix is recognized.
+- When it appears. The sealed twin is present whenever the agentcookie sink (or, optionally, the source) has been configured to keep at-rest sealing on for that machine.
+- How consumers detect and use it. Defined in section 5.2.
+
+### 5.2 Reader behavior in the presence of a sealed twin
+
+A reader that supports sealed values MUST resolve a per-CLI dataset by checking, in this order:
+
+1. `secrets.env.sealed`. If present, the reader decrypts it (via the agentcookie reader library or by shelling out to `agentcookie secret get`). On success, the resulting key/value map is the dataset. The plaintext sibling, if it also exists, is ignored.
+2. `secrets.env`. If the sealed twin is absent (or sealing is not configured on this machine), the reader parses the plaintext file directly.
+
+A reader that does not support sealed values (for example, a third-party CLI loaded purely via its native dotenv parser) sees only `secrets.env`. On a sealed-only sink, that consumer must either acquire sealing support (via the agentcookie reader library) or be invoked through a small shim that calls `agentcookie secret get`.
+
+Conforming writers MUST NOT leave both files present in a state where they disagree. The agentcookie sink, when sealing is on, writes the sealed twin first and then removes the plaintext file in the same atomic-rename window. Writers that produce only plaintext MUST NOT touch an existing sealed twin.
+
+### 5.3 What consumers MUST NOT assume about the sealed twin
+
+Consumers MUST NOT:
+
+- Attempt to read the sealed file with a dotenv parser. The body is not parseable as `KEY=VALUE`.
+- Assume that the presence of `secrets.env.sealed` implies the absence of `secrets.env`. During a brief atomic-rename window the two may coexist; the order in section 5.2 makes that case unambiguous.
+- Depend on any specific size, header, or magic bytes in the sealed file.
+
+## 6. File modes and atomic writes
+
+### 6.1 Mode
+
+Every file under `~/.agentcookie/secrets/` is mode `0600`. Every directory under it is mode `0700`. Writers MUST set these modes at creation time, MUST NOT widen them later, and SHOULD verify them on open.
+
+A reader that encounters a file with mode other than `0600` SHOULD log a warning. It MUST NOT refuse to read on that basis alone (a misconfigured umask is a common cause and the value may still be authoritative), but the warning surfaces the misconfiguration.
+
+### 6.2 Atomic writes
+
+All writes to files in the bus MUST be atomic with respect to readers running concurrently. The standard recipe:
+
+1. Write the new content to a temporary file in the same directory, named `<final-name>.tmp.<random-suffix>`. The temporary file is created with mode `0600`.
+2. `fsync` the temporary file.
+3. `rename` the temporary file over the final name.
+4. (Recommended) `fsync` the containing directory.
+
+Readers that follow the section 5.2 priority chain will see either the previous value or the new value, never a torn read. Writers that fail to follow this discipline are non-conforming.
+
+### 6.3 Concurrent writers
+
+The bus assumes a single writer at a time per per-CLI directory. The two writers in practice are the agentcookie sink (during a `/sync`) and `agentcookie secret set` invoked manually. These two paths coordinate via the same atomic-rename discipline; concurrent invocations are race-safe at the filesystem level but a value written by one may be replaced moments later by the other. There is no locking protocol beyond atomic rename.
+
+## 7. Reserved key names
+
+The bus reserves a small prefix space for agentcookie-internal markers. Consumer code MUST tolerate seeing these keys in the map returned by a reader, even if it ignores them.
+
+### 7.1 Single leading underscore
+
+Any key in `secrets.env` whose name begins with a single underscore is reserved. The current reservations:
+
+- `_unknown_<field>`. Written by `agentcookie secret import-from` when it cannot map a field name from a source file (TOML, JSON, etc.) onto a known canonical key. The value is the original field's value verbatim. The friend is expected to inspect, rename, and remove the `_unknown_` prefix. Conforming readers SHOULD surface these to the consumer as ordinary entries; consumers SHOULD treat them as a signal that the import is incomplete.
+- `_BIN_<KEY>`. Marks a value that was originally binary (raw bytes that did not survive UTF-8 encoding intact). The value is base64-encoded with standard alphabet and no line wrapping. Consumers that recognize the prefix MAY decode the value; consumers that do not recognize it see a base64 string. The original key name is the suffix after `_BIN_`. The marker exists because the `.env` grammar (section 3) forbids non-printable bytes in values, and binary signing keys, certificates, and similar are common enough to need a defined fallback.
+- `_meta_<field>`. Reserved for future agentcookie metadata that travels with the value file (last-import-source, last-import-time, etc.). v1 does not define any concrete `_meta_*` names.
+
+### 7.2 Double leading underscore
+
+Keys beginning with `__` are reserved for future use. Writers MUST NOT emit them. Readers MUST ignore them silently.
+
+### 7.3 Non-reserved underscored names
+
+A single underscore inside a key (e.g. `MY_API_KEY`) carries no special meaning and is unaffected by these reservations. Only the leading character pattern is significant.
+
+## 8. Security boundary
+
+This section is a precise statement of what the format is designed to protect and what it deliberately leaves to other layers.
+
+### 8.1 What the format protects against
+
+- **Over-the-wire interception of secrets between source and sink.** The transport (specified in `docs/protocol.md`) wraps the payload in an authenticated-encryption envelope keyed by a paired secret. A passive observer on the network between the two machines cannot recover any secret values from the wire.
+- **Opportunistic local reads on the sink when sealed mode is enabled.** When the sink writes a `secrets.env.sealed` twin instead of a plaintext file, a process running as the user but without access to the at-rest sealing key cannot recover values from the file alone.
+- **Cross-CLI bleed.** Each consumer has its own directory and its own value file. A consumer that reads `Load("foo-pp-cli")` cannot accidentally observe `bar-pp-cli`'s secrets through this format. (Filesystem-level read permission on `~/.agentcookie/secrets/` is the same for all consumers running as the user; the directory layout enforces a logical, not adversarial, boundary.)
+- **Sync of secrets the friend marked local-only.** The `[sync.keys]` `false` policy keeps a key off the wire entirely. A laptop-only signing key, marked `sync = false`, is never shipped to the sink under any payload.
+
+### 8.2 What the format does not protect against
+
+- **Root user on the machine.** A process running as root (or, on macOS, as the same user with full disk access) can read `~/.agentcookie/secrets/` directly. The bus relies on filesystem permissions for in-user-session boundaries; it offers no defense against privilege escalation.
+- **Disk-level encryption disabled.** When the host disk is unencrypted (no FileVault on macOS, no LUKS on Linux), the plaintext `secrets.env` is recoverable from a stolen machine. Sealed mode adds a layer here but does not substitute for full-disk encryption.
+- **Physical theft of an unlocked machine.** No file-format choice protects a logged-in session from an attacker with hands on the keyboard.
+- **Compromise of the source.** A laptop that ships malicious payloads to the sink can write any secret value at any path the sink permits. The transport's allowlist + paired-key model is the relevant defense (see `docs/protocol.md`); this format trusts whatever the transport delivers.
+- **Side-channel leakage by the consumer.** Once a consumer reads a value, what it does with that value (logging, transmitting to its own backend, writing to an unencrypted file elsewhere) is entirely outside this format's scope.
+
+## 9. Backward compatibility and the protected-extension contract
+
+This document is `schema_version = 1`. The contract for future versions is described in section 10. For v1, the compatibility guarantees are:
+
+- Files written by a v1-compliant writer are readable by every v1-compliant reader.
+- A v1 reader that encounters an additional, unrecognized file in a per-CLI directory ignores it (section 2.4).
+- A v1 reader that encounters an additional, unrecognized table or field in `manifest.toml` ignores it (section 4.4).
+- A v1 reader does not attempt to repair non-conforming files (e.g. mode `0644`). It surfaces them as warnings.
+
+## 10. Versioning policy
+
+### 10.1 The `schema_version` field
+
+The single `schema_version` integer in `manifest.toml` (section 4.1) is the version of the entire format described by this document, including the `.env` grammar and the directory layout, not just the manifest itself.
+
+### 10.2 Reader behavior on a higher version
+
+A reader compiled against `schema_version = N` that encounters a file with `schema_version = M` where `M > N` MUST behave as follows:
+
+- It MUST NOT crash.
+- It MUST NOT silently downgrade or rewrite the manifest.
+- It SHOULD log a warning that includes the observed `schema_version` and the reader's known maximum.
+- It MAY attempt to parse the file under v1 rules and return whatever portion is intelligible, on the assumption that future schemas are deliberately compatible with the v1 baseline. This is best-effort; a reader that prefers safety MAY instead return an error.
+
+Either choice (best-effort parse or error) is conforming. A library SHOULD document which it does and SHOULD make the choice configurable.
+
+### 10.3 Writer behavior
+
+Writers stamp `schema_version` with the highest version they emit. They MUST NOT emit a higher version than they actually conform to.
+
+### 10.4 Breaking-change policy
+
+A breaking change to this document increments `schema_version`. Examples of breaking changes:
+
+- Adding a new required field to `manifest.toml`.
+- Changing the meaning of an existing key or table.
+- Introducing a new file that consumers MUST read for correctness.
+
+Non-breaking changes (new optional tables, new reserved-prefix key names, new `_meta_*` entries) do not require a version bump. They are added to a successor of this document at the same `schema_version = 1`.
+
+A v2 of the format, when it ships, will define its own migration story including whether v1 readers can continue to operate against v2 manifests.
+
+## 11. Reference reader behavior
+
+A reference reader takes a CLI name and returns a string-to-string map of resolved keys. The reader applies the following priority chain when populating that map. Each step contributes keys; later steps fill in keys that earlier steps did not provide. Keys that earlier steps did provide are NOT overwritten by later steps.
+
+### 11.1 The four sources, highest priority first
+
+1. **Sealed file.** `~/.agentcookie/secrets/<cli-name>/secrets.env.sealed`. Resolved per section 5.2. Provides the canonical bus dataset when sealing is in use.
+2. **Plaintext file.** `~/.agentcookie/secrets/<cli-name>/secrets.env`. The fallback bus dataset when no sealed twin is present.
+3. **Caller-registered fallback file.** Some readers accept an optional second argument naming the consumer's pre-existing config file (for example, the CLI's own `config.toml` under `~/.config/<cli-name>/`). When provided and present, this file's recognized keys feed the map. The reader is free to apply a field-name heuristic mapping (e.g. `access_token` -> `<CLI>_OAUTH_BEARER`); the mapping is reader-defined and out of scope for this document.
+4. **Process environment.** Environment variables that match the consumer's expected key names. This is the source of last resort. It exists so that adopting the bus does not break consumers whose users set env vars directly today.
+
+### 11.2 Why bus wins over env
+
+A user who has adopted the bus may still have a leftover env var from a previous workflow. If env were higher-priority, the bus would be silently ignored on every machine that still exports the old name, and the user would conclude that sync is broken. Putting bus above env makes the bus the authoritative source whenever it is populated; the env var is the fallback for machines that have not yet adopted the bus.
+
+This is the single most important non-obvious rule in this document. Consumers MUST follow it.
+
+### 11.3 Empty values
+
+An empty value (e.g. `KEY=` with nothing after the equals sign) is a legal entry. It SHOULD be returned in the map as the empty string and SHOULD NOT be treated as if the key were absent. Treating an empty value as absent would cause the next-priority source to leak in, which inverts the bus-over-env rule.
+
+### 11.4 Errors
+
+A reader that encounters a syntax error in `secrets.env` MUST return an error that names the file path and the offending line number. It MUST NOT silently skip the line, because a value the consumer needs may follow it and the consumer will then operate on a half-populated map.
+
+A reader that encounters an invalid CLI name (section 2.3) MUST return an error before touching the filesystem.
+
+A reader that encounters an unreachable sealed file (sealed mode is in use but the at-rest sealing key is not available) MUST return an error naming the sealed file path. It MUST NOT silently fall back to the plaintext sibling on a sealed-mode machine, because the plaintext sibling on a sealed machine is normally not present, and silent fallback would mask a real misconfiguration.
+
+## 12. Worked end-to-end example
+
+This section runs a hypothetical consumer named `example-pp-cli` through the format end-to-end. The consumer needs three secrets:
+
+- `EXAMPLE_API_KEY`. A long-lived API key. Safe to sync.
+- `EXAMPLE_OAUTH_REFRESH`. An OAuth refresh token that the consumer rotates independently on each machine. Must not be overwritten by the source; therefore not synced.
+- `EXAMPLE_SIGNING_PRIVATE_KEY`. A raw-bytes signing private key. Binary, so it travels under the `_BIN_*` reserved prefix. Must not leave the laptop.
+
+### 12.1 On the laptop (source)
+
+The friend completes whatever login flow `example-pp-cli` requires. They then either (a) point the consumer's own login flow at the bus directly so it writes the standard paths, or (b) invoke `agentcookie secret import-from` to translate the consumer's native config into the bus shape. Either way, the resulting per-CLI directory looks like this:
+
+```
+~/.agentcookie/secrets/example-pp-cli/
+  manifest.toml
+  secrets.env
+```
+
+`manifest.toml`:
+
+```
+schema_version = 1
+display_name = "Example PP CLI"
+
+[sync]
+default = true
+
+[sync.keys]
+EXAMPLE_OAUTH_REFRESH = false
+_BIN_EXAMPLE_SIGNING_PRIVATE_KEY = false
+```
+
+`secrets.env`:
+
+```
+# Long-lived API key. Safe to ship to any machine that runs the CLI.
+EXAMPLE_API_KEY=ex_live_3f4a2c91d8e6b5a07c1f9e4b6d0a8c2e
+
+# OAuth refresh token. Each machine rotates its own; do not overwrite.
+EXAMPLE_OAUTH_REFRESH=eyJhbGciOi...laptop-version...AwIA
+
+# Binary signing key, base64-encoded. Local-only.
+_BIN_EXAMPLE_SIGNING_PRIVATE_KEY=MIIEvQIBADANBgkqhkiG9w0BAQEFAASC...
+```
+
+Both files are mode `0600`. The directory itself is mode `0700`.
+
+### 12.2 What the agentcookie source ships
+
+The source reads `manifest.toml` and applies the sync policy. For this dataset:
+
+- `EXAMPLE_API_KEY` inherits `[sync] default = true`. Shipped.
+- `EXAMPLE_OAUTH_REFRESH` is overridden to `false`. Dropped.
+- `_BIN_EXAMPLE_SIGNING_PRIVATE_KEY` is overridden to `false`. Dropped.
+
+The wire payload (inside the agentcookie transport's authenticated-encryption envelope) carries one consumer entry, `example-pp-cli`, with one key, `EXAMPLE_API_KEY`. The manifest's `[sync] default = true` is also carried; the `[sync.keys]` table is not (it is source-side policy, not sink-side state).
+
+### 12.3 On the sink
+
+The agentcookie sink receives the payload and materializes it at the same standard path:
+
+```
+~/.agentcookie/secrets/example-pp-cli/
+  manifest.toml
+  secrets.env          (or secrets.env.sealed if sealed mode is on)
+```
+
+`manifest.toml` on the sink:
+
+```
+schema_version = 1
+display_name = "Example PP CLI"
+
+[sync]
+default = true
+```
+
+(The sink does not synthesize a `[sync.keys]` table on the receive side; the source's policy has already been applied.)
+
+`secrets.env` on the sink:
+
+```
+EXAMPLE_API_KEY=ex_live_3f4a2c91d8e6b5a07c1f9e4b6d0a8c2e
+```
+
+The sink does NOT see `EXAMPLE_OAUTH_REFRESH` or `_BIN_EXAMPLE_SIGNING_PRIVATE_KEY`. If the consumer on the sink needs a refresh token, it will perform its own OAuth refresh on first call and write the result into the sink's own `secrets.env` (the consumer's adoption of the bus may include writing back to it, depending on the consumer's design; that is the consumer's choice, not a format requirement).
+
+### 12.4 What the consumer sees at runtime
+
+When `example-pp-cli` runs on the sink and calls a reference reader for `example-pp-cli`, the reader applies the section 11 priority chain:
+
+1. Sealed file: if sealed mode is on, the sealed twin is decrypted and the dataset is `{ EXAMPLE_API_KEY: ex_live_... }`.
+2. Plaintext file: if sealed mode is off, the plaintext file yields the same dataset.
+3. Caller-registered fallback: if the consumer's reader was invoked with a fallback path, any keys not already present (in this case, `EXAMPLE_OAUTH_REFRESH` and `_BIN_EXAMPLE_SIGNING_PRIVATE_KEY`) may be filled in from the consumer's local config file on the sink.
+4. Process environment: any remaining keys are populated from the process environment, if set.
+
+The consumer ends up with a complete-enough map to operate: a synced API key (from the bus) and a machine-local refresh token (from its own config file or from a freshly minted OAuth flow). The binary signing key is absent on the sink, by design.
+
+### 12.5 What changes when the friend rotates the API key
+
+The friend rotates `EXAMPLE_API_KEY` on the laptop. Whatever workflow they use (the consumer's native CLI, or `agentcookie secret set example-pp-cli EXAMPLE_API_KEY`) writes the new value to `~/.agentcookie/secrets/example-pp-cli/secrets.env` via atomic rename. The agentcookie source observes the file change, applies sync policy again, and ships the new payload. The sink writes the new value at the same path on the sink, also via atomic rename. The consumer on the sink picks up the new value on its next read (or, if it uses a long-running daemon that watches for file changes, on the next reload event).
+
+No additional action is required from the friend on the sink. That is the whole point of the bus.
+
+## 13. Open questions
+
+These are items that the implementation will need to settle and the spec will need to revisit. They are listed here for transparency.
+
+- **Sealed-twin format internals.** This v1 spec deliberately treats the sealed file as opaque and delegates the format to the agentcookie at-rest sealing layer. If a future need arises for a non-agentcookie tool to produce or consume a sealed twin, the internals will need to be promoted into this document or into a sibling spec.
+- **Per-key vs whole-file sealing.** v1 seals the entire `secrets.env`. A future version may want to seal individual values (so a partial dataset can be loaded without the at-rest key, while sensitive keys remain protected). The format above is shaped so a `_meta_sealed_keys` array could be added without breaking v1 readers, but the actual design is deferred.
+- **Cross-machine identity for `[sync.keys]`.** The policy `EXAMPLE_OAUTH_REFRESH = false` is applied symmetrically: the source does not ship it, and the sink does not ship its own copy back to the source either. The format does not currently distinguish "do not leave this machine" from "do not arrive at this machine"; both cases are covered by `false`. If a future use case needs directional policy, it will be added as an explicit field rather than overloading the existing boolean.

--- a/examples/gh-shim/README.md
+++ b/examples/gh-shim/README.md
@@ -1,0 +1,57 @@
+# gh-shim
+
+Worked example: feed GitHub CLI (`gh`) its auth token from the agentcookie secrets bus.
+
+`gh` is not a printing-press CLI. It's upstream-maintained, distributed via Homebrew, and stores its own auth in `~/.config/gh/hosts.yml`. We do not modify it. Instead, we put a small shim ahead of it on `$PATH` that sources `GH_TOKEN` from the bus and `exec`s the real binary.
+
+## Install
+
+```bash
+# 1. Copy the shim somewhere ahead of Homebrew on PATH.
+mkdir -p ~/.local/bin
+cp examples/gh-shim/gh ~/.local/bin/gh
+chmod +x ~/.local/bin/gh
+
+# 2. Make sure ~/.local/bin precedes /opt/homebrew/bin in PATH.
+#    (Add this to ~/.zshrc if it isn't already.)
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc
+
+# 3. Stage a token in the bus.
+echo -n "ghp_xxxxxxxxxxxxxxxxxxxx" | agentcookie secret set gh GH_TOKEN
+
+# 4. Verify.
+which gh                  # should print ~/.local/bin/gh, not /opt/homebrew/bin/gh
+gh auth status            # should report logged in as the bus-supplied user
+```
+
+## How it works
+
+The shim is ~50 lines of bash. On every invocation it:
+
+1. Finds the real `gh` binary at `/opt/homebrew/bin/gh` (or `/usr/local/bin/gh`, `/usr/bin/gh`).
+2. If `$GH_TOKEN` is already set in the caller's env, leaves it alone.
+3. Otherwise runs `agentcookie secret env gh`, which prints `KEY=VALUE` lines from `~/.agentcookie/secrets/gh/secrets.env`.
+4. Exports the gh-relevant keys (`GH_TOKEN`, `GITHUB_TOKEN`, `GH_HOST`, `GH_ENTERPRISE_TOKEN`).
+5. `exec`s the real `gh` with the same arguments.
+
+The shim does NOT:
+- Read or write `~/.config/gh/hosts.yml`. That's gh's own keystore; we never touch it.
+- Filter or transform gh's output. It just prepends env, then gets out of the way.
+- Hold the bus open. `agentcookie secret env` is a one-shot read.
+
+## When this matters
+
+Two sink Macs that both want `gh pr list` working without re-running `gh auth login`. The friend stages `GH_TOKEN` once on the source. Both sinks pull it down via the standard cookie+secrets sync. Both sinks have the shim installed. Both sinks now answer `gh auth status` as the source user.
+
+## Removing
+
+```bash
+rm ~/.local/bin/gh
+agentcookie secret rm gh
+```
+
+PATH precedence reverts to `/opt/homebrew/bin/gh`, which uses its own `hosts.yml` again.
+
+## Adapting the shim to another CLI
+
+The same pattern works for any tool that reads an env var for auth. Copy `gh`, rename it to whatever binary you want to wrap, change the `real_*` search paths to point at the real binary, and update the `case` block to whitelist the env vars that CLI cares about. Keep the whitelist tight - exporting unrelated bus values into a third-party process leaks more than it has to.

--- a/examples/gh-shim/gh
+++ b/examples/gh-shim/gh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# gh-shim: a worked example of consuming the agentcookie secrets bus from a
+# non-PP CLI. Place this on $PATH ahead of /opt/homebrew/bin/gh and it will
+# transparently feed the real gh binary the GH_TOKEN it needs.
+#
+# Why a shim and not a wrapper inside gh? gh is upstream-maintained. We do
+# not modify it. The shim intercepts invocation, sources the bus, and exec's
+# the real binary - so users keep typing `gh pr list` exactly as before.
+#
+# Resolution order (highest precedence first):
+#   1. GH_TOKEN already set in caller env (no-op for shim)
+#   2. agentcookie secrets bus under ~/.agentcookie/secrets/gh/secrets.env
+#   3. gh's own keyring/hosts.yml (the binary handles this itself)
+#
+# See docs/runbook-secrets-bus-gh-example.md for the narrative.
+
+set -euo pipefail
+
+# Find the real gh binary. We use `command -v` against a sentinel name so
+# this shim doesn't infinitely re-exec itself.
+real_gh=""
+for candidate in /opt/homebrew/bin/gh /usr/local/bin/gh /usr/bin/gh; do
+    if [[ -x "$candidate" ]]; then
+        real_gh="$candidate"
+        break
+    fi
+done
+
+if [[ -z "$real_gh" ]]; then
+    echo "gh-shim: could not find real gh binary on standard paths" >&2
+    exit 127
+fi
+
+# Only consult the bus if caller hasn't already set GH_TOKEN.
+if [[ -z "${GH_TOKEN:-}" ]]; then
+    # `agentcookie secret env gh` prints KEY=VALUE lines for the gh CLI.
+    # Silent on empty bus; we fall through to gh's own auth in that case.
+    if command -v agentcookie >/dev/null 2>&1; then
+        if bus_env="$(agentcookie secret env gh 2>/dev/null)"; then
+            while IFS= read -r line; do
+                # Skip comment + blank lines.
+                [[ -z "$line" || "$line" == \#* ]] && continue
+                # Only export keys the shim cares about. Adding more here is
+                # a one-line change; we deliberately keep the surface tight
+                # to avoid leaking unrelated bus values into gh's env.
+                case "$line" in
+                    GH_TOKEN=*|GITHUB_TOKEN=*|GH_HOST=*|GH_ENTERPRISE_TOKEN=*)
+                        export "${line?}"
+                        ;;
+                esac
+            done <<< "$bus_env"
+        fi
+    fi
+
+    # GITHUB_TOKEN is also accepted by gh. If the bus stored it under that
+    # name, promote it to GH_TOKEN so gh's own precedence stays predictable.
+    if [[ -z "${GH_TOKEN:-}" && -n "${GITHUB_TOKEN:-}" ]]; then
+        export GH_TOKEN="$GITHUB_TOKEN"
+    fi
+fi
+
+exec "$real_gh" "$@"

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 )
 
 require (
+	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/chromedp/sysutil v1.1.0 // indirect
 	github.com/go-json-experiment/json v0.0.0-20260214004413-d219187c3433 // indirect
 	github.com/gobwas/httphead v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/chromedp/cdproto v0.0.0-20260321001828-e3e3800016bc h1:wkN/LMi5vc60pBRWx6qpbk/aEvq3/ZVNpnMvsw8PVVU=
 github.com/chromedp/cdproto v0.0.0-20260321001828-e3e3800016bc/go.mod h1:cbyjALe67vDvlvdiG9369P8w5U2w6IshwtyD2f2Tvag=
 github.com/chromedp/chromedp v0.15.1 h1:EJWiPm7BNqDqjYy6U0lTSL5wNH+iNt9GjC3a4gfjNyQ=

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -224,6 +224,13 @@ func buildReport(d doctorDeps) DoctorReport {
 		})
 	}
 
+	// 11. Secrets bus (v0.13). Reports how many CLIs are registered,
+	// total key count, sealed-vs-plaintext mode, sync freshness.
+	// Reads from the secrets root on whichever machine is running
+	// doctor (both source and sink populate the same path; source
+	// writes via `agentcookie secret`, sink writes via U4's writer).
+	checks = append(checks, checkSecretsBus())
+
 	exit := 0
 	for _, c := range checks {
 		if c.Severity == SeverityFail {
@@ -738,3 +745,139 @@ func severityTag(s Severity) string {
 }
 
 // (fileExists lives in wizard.go and is reused here.)
+
+// checkSecretsBus (v0.13) reports the state of the agentcookie secrets
+// bus: how many CLIs are registered, how many keys total, whether
+// sealing is in effect (sealed twins present), and how recently any
+// file in the tree was touched.
+//
+// Reports SKIPPED when the secrets root doesn't exist (most installs
+// today; the bus is opt-in). OK when populated and reasonably fresh.
+// WARN when sealed twins exist but the master key is missing (the
+// inverse warning of "sealing requested but master key absent" we
+// surface at write time, so a reader hitting a sealed file later knows
+// what they're looking at).
+func checkSecretsBus() Check {
+	home, _ := os.UserHomeDir()
+	root := filepath.Join(home, ".agentcookie", "secrets")
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return Check{
+				Name:     "Secrets bus",
+				Severity: SeveritySkipped,
+				Detail:   "no secrets bus configured (~/.agentcookie/secrets/ is empty or absent)",
+			}
+		}
+		return Check{
+			Name:        "Secrets bus",
+			Severity:    SeverityFail,
+			Detail:      "read secrets root: " + err.Error(),
+			Remediation: "check ~/.agentcookie/secrets/ permissions",
+		}
+	}
+
+	var (
+		cliCount   int
+		keyCount   int
+		sealedCLIs int
+		newestMod  time.Time
+	)
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		cliDir := filepath.Join(root, e.Name())
+		envPath := filepath.Join(cliDir, "secrets.env")
+		sealedPath := filepath.Join(cliDir, "secrets.env.sealed")
+		envInfo, envErr := os.Stat(envPath)
+		sealedInfo, sealedErr := os.Stat(sealedPath)
+		if envErr != nil && sealedErr != nil {
+			continue
+		}
+		cliCount++
+		if sealedErr == nil {
+			sealedCLIs++
+			if sealedInfo.ModTime().After(newestMod) {
+				newestMod = sealedInfo.ModTime()
+			}
+		}
+		if envErr == nil {
+			if data, readErr := os.ReadFile(envPath); readErr == nil {
+				keyCount += countEnvKeys(data)
+			}
+			if envInfo.ModTime().After(newestMod) {
+				newestMod = envInfo.ModTime()
+			}
+		}
+	}
+	if cliCount == 0 {
+		return Check{
+			Name:     "Secrets bus",
+			Severity: SeveritySkipped,
+			Detail:   "secrets root exists but contains no CLIs yet",
+		}
+	}
+
+	mode := "plaintext"
+	if sealedCLIs == cliCount {
+		mode = "sealed"
+	} else if sealedCLIs > 0 {
+		mode = fmt.Sprintf("mixed (%d sealed / %d plaintext)", sealedCLIs, cliCount-sealedCLIs)
+	}
+	freshness := "never"
+	if !newestMod.IsZero() {
+		freshness = time.Since(newestMod).Round(time.Second).String() + " ago"
+	}
+	return Check{
+		Name:     "Secrets bus",
+		Severity: SeverityOK,
+		Detail:   fmt.Sprintf("%d cli(s), %d key(s), mode=%s, newest %s", cliCount, keyCount, mode, freshness),
+	}
+}
+
+// countEnvKeys counts non-comment non-blank lines containing '='.
+// Cheap proxy for the key count without parsing every value.
+func countEnvKeys(data []byte) int {
+	n := 0
+	for _, line := range bytesSplitLines(data) {
+		trim := bytesTrimSpace(line)
+		if len(trim) == 0 || trim[0] == '#' {
+			continue
+		}
+		for _, b := range trim {
+			if b == '=' {
+				n++
+				break
+			}
+		}
+	}
+	return n
+}
+
+func bytesSplitLines(data []byte) [][]byte {
+	var out [][]byte
+	start := 0
+	for i, b := range data {
+		if b == '\n' {
+			out = append(out, data[start:i])
+			start = i + 1
+		}
+	}
+	if start < len(data) {
+		out = append(out, data[start:])
+	}
+	return out
+}
+
+func bytesTrimSpace(b []byte) []byte {
+	i := 0
+	for i < len(b) && (b[i] == ' ' || b[i] == '\t') {
+		i++
+	}
+	j := len(b)
+	for j > i && (b[j-1] == ' ' || b[j-1] == '\t' || b[j-1] == '\r') {
+		j--
+	}
+	return b[i:j]
+}

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -381,8 +381,9 @@ peer:
 	})
 
 	// v0.12.0-beta.3 added two checks: Adapter coverage + CDP injector.
-	if got := len(report.Checks); got != 10 {
-		t.Fatalf("got %d checks, want 10", got)
+	// v0.13 added the Secrets bus check.
+	if got := len(report.Checks); got != 11 {
+		t.Fatalf("got %d checks, want 11", got)
 	}
 
 	// Serialize the envelope and confirm it round-trips.

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -46,7 +46,7 @@ func Execute() {
 	rootCmd.PersistentFlags().StringVar(&common.ConfigDir, "config-dir", defaultConfigDir(), "directory holding source.yaml, sink.yaml, allowlist.yaml")
 	rootCmd.PersistentFlags().BoolVar(&common.JSON, "json", false, "emit machine-readable JSON output where the subcommand supports it")
 
-	rootCmd.AddCommand(sourceCmd, sinkCmd, pairCmd, statusCmd, versionCmd, wizardCmd, doctorCmd)
+	rootCmd.AddCommand(sourceCmd, sinkCmd, pairCmd, statusCmd, versionCmd, wizardCmd, doctorCmd, secretCmd)
 
 	if err := rootCmd.Execute(); err != nil {
 		// Cobra already prints usage on flag errors; surface RunE errors here.

--- a/internal/cli/secret.go
+++ b/internal/cli/secret.go
@@ -72,8 +72,15 @@ var secretImportFromCmd = &cobra.Command{
 	RunE:  runSecretImportFrom,
 }
 
+var secretEnvCmd = &cobra.Command{
+	Use:   "env <cli-name>",
+	Short: "Print all keys for a CLI as shell-friendly export lines (for `eval $(...)`)",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runSecretEnv,
+}
+
 func init() {
-	secretCmd.AddCommand(secretListCmd, secretGetCmd, secretSetCmd, secretRmCmd, secretImportFromCmd)
+	secretCmd.AddCommand(secretListCmd, secretGetCmd, secretSetCmd, secretRmCmd, secretImportFromCmd, secretEnvCmd)
 	secretImportFromCmd.Flags().StringVar(&secretImportAs, "as", "", "cli-name to file the imported secrets under (required)")
 }
 
@@ -552,6 +559,56 @@ func parseEnvBytesShim(data []byte) (map[string]string, error) {
 // command's TOML branch.
 func decodeTOML(data []byte, out *map[string]any) error {
 	return toml.Unmarshal(data, out)
+}
+
+// runSecretEnv prints all keys for a CLI in `KEY=VALUE` form, one per line,
+// suitable for `eval $(agentcookie secret env <cli>)`. Sealed twin wins over
+// plaintext when both exist.
+func runSecretEnv(cmd *cobra.Command, args []string) error {
+	cliName := args[0]
+	if !validBusName(cliName) {
+		return fmt.Errorf("invalid cli-name %q", cliName)
+	}
+	sealedPath := filepath.Join(secretsRoot(), cliName, "secrets.env.sealed")
+	plainPath := filepath.Join(secretsRoot(), cliName, "secrets.env")
+
+	var kv map[string]string
+	if _, err := os.Stat(sealedPath); err == nil {
+		mk, err := keystore.ReadMasterKey()
+		if err != nil {
+			return fmt.Errorf("read master key for sealed file: %w", err)
+		}
+		raw, err := os.ReadFile(sealedPath)
+		if err != nil {
+			return err
+		}
+		plain, err := keystore.Unseal(mk, raw)
+		if err != nil {
+			return fmt.Errorf("unseal: %w", err)
+		}
+		kv, err = parseEnvBytesShim(plain)
+		if err != nil {
+			return err
+		}
+	} else {
+		var err error
+		kv, err = readEnvAll(plainPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return fmt.Errorf("read %s: %w", plainPath, err)
+		}
+	}
+	keys := make([]string, 0, len(kv))
+	for k := range kv {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		fmt.Fprintf(cmd.OutOrStdout(), "%s=%s\n", k, kv[k])
+	}
+	return nil
 }
 
 // isTerminal reports whether stdin is a TTY. Crude check; used to decide

--- a/internal/cli/secret.go
+++ b/internal/cli/secret.go
@@ -1,0 +1,565 @@
+package cli
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+	"github.com/spf13/cobra"
+
+	"github.com/mvanhorn/agentcookie/internal/keystore"
+)
+
+var secretCmd = &cobra.Command{
+	Use:   "secret",
+	Short: "Manage per-CLI secrets in the agentcookie secrets bus",
+	Long: `agentcookie secret manages per-CLI secrets/auth-tokens that sync from
+the laptop to the sink alongside cookies. Each CLI gets its own
+secrets.env under ~/.agentcookie/secrets/<cli>/.
+
+Friend-facing workflow:
+
+  agentcookie secret set tesla-pp-cli TESLA_OAUTH_BEARER
+  agentcookie secret list
+  agentcookie secret get tesla-pp-cli TESLA_OAUTH_BEARER
+  agentcookie secret import-from ~/.config/tesla-pp-cli/auth.json --as tesla-pp-cli
+  agentcookie secret rm tesla-pp-cli TESLA_OAUTH_BEARER
+
+See docs/spec-agentcookie-secrets-bus-v1.md for the format.`,
+}
+
+var secretListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List CLIs registered in the bus and their key names (no values)",
+	RunE:  runSecretList,
+}
+
+var secretGetCmd = &cobra.Command{
+	Use:   "get <cli-name> <key>",
+	Short: "Print the value of a single key to stdout",
+	Args:  cobra.ExactArgs(2),
+	RunE:  runSecretGet,
+}
+
+var secretSetCmd = &cobra.Command{
+	Use:   "set <cli-name> <key>",
+	Short: "Set a key; reads the value from stdin (pipe) or prompts (TTY)",
+	Args:  cobra.ExactArgs(2),
+	RunE:  runSecretSet,
+}
+
+var secretRmCmd = &cobra.Command{
+	Use:   "rm <cli-name> [<key>]",
+	Short: "Remove a key or the entire CLI directory",
+	Args:  cobra.RangeArgs(1, 2),
+	RunE:  runSecretRm,
+}
+
+var (
+	secretImportAs string
+)
+
+var secretImportFromCmd = &cobra.Command{
+	Use:   "import-from <path>",
+	Short: "Ingest an existing config file (JSON, TOML, env) into the standard layout",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runSecretImportFrom,
+}
+
+func init() {
+	secretCmd.AddCommand(secretListCmd, secretGetCmd, secretSetCmd, secretRmCmd, secretImportFromCmd)
+	secretImportFromCmd.Flags().StringVar(&secretImportAs, "as", "", "cli-name to file the imported secrets under (required)")
+}
+
+// secretsRoot resolves to the v1 standard path. Kept as a helper for tests.
+func secretsRoot() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".agentcookie", "secrets")
+}
+
+func runSecretList(cmd *cobra.Command, _ []string) error {
+	root := secretsRoot()
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			fmt.Fprintln(cmd.OutOrStdout(), "secrets bus is empty (no CLIs registered)")
+			return nil
+		}
+		return fmt.Errorf("read secrets root %s: %w", root, err)
+	}
+	type entry struct {
+		Name string   `json:"name"`
+		Keys []string `json:"keys"`
+	}
+	var out []entry
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		envPath := filepath.Join(root, e.Name(), "secrets.env")
+		kv, err := readEnvKeysOnly(envPath)
+		if err != nil {
+			continue
+		}
+		sort.Strings(kv)
+		out = append(out, entry{Name: e.Name(), Keys: kv})
+	}
+	if common.JSON {
+		return json.NewEncoder(cmd.OutOrStdout()).Encode(out)
+	}
+	if len(out) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "secrets bus is empty (no CLIs registered)")
+		return nil
+	}
+	for _, e := range out {
+		fmt.Fprintf(cmd.OutOrStdout(), "%s\n", e.Name)
+		for _, k := range e.Keys {
+			fmt.Fprintf(cmd.OutOrStdout(), "  %s\n", k)
+		}
+	}
+	return nil
+}
+
+func runSecretGet(cmd *cobra.Command, args []string) error {
+	cliName, key := args[0], args[1]
+	if !validBusName(cliName) {
+		return fmt.Errorf("invalid cli-name %q", cliName)
+	}
+	// First check sealed, then plaintext.
+	sealedPath := filepath.Join(secretsRoot(), cliName, "secrets.env.sealed")
+	plainPath := filepath.Join(secretsRoot(), cliName, "secrets.env")
+
+	if _, err := os.Stat(sealedPath); err == nil {
+		mk, err := keystore.ReadMasterKey()
+		if err != nil {
+			return fmt.Errorf("read master key for sealed file: %w", err)
+		}
+		raw, err := os.ReadFile(sealedPath)
+		if err != nil {
+			return err
+		}
+		plain, err := keystore.Unseal(mk, raw)
+		if err != nil {
+			return fmt.Errorf("unseal: %w", err)
+		}
+		kv, err := parseEnvBytesShim(plain)
+		if err != nil {
+			return err
+		}
+		if v, ok := kv[key]; ok {
+			fmt.Fprint(cmd.OutOrStdout(), v)
+			return nil
+		}
+		return fmt.Errorf("key %q not found in sealed bus for %s", key, cliName)
+	}
+
+	kv, err := readEnvAll(plainPath)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", plainPath, err)
+	}
+	if v, ok := kv[key]; ok {
+		fmt.Fprint(cmd.OutOrStdout(), v)
+		return nil
+	}
+	return fmt.Errorf("key %q not found for %s", key, cliName)
+}
+
+func runSecretSet(cmd *cobra.Command, args []string) error {
+	cliName, key := args[0], args[1]
+	if !validBusName(cliName) {
+		return fmt.Errorf("invalid cli-name %q", cliName)
+	}
+	if !validBusKey(key) {
+		return fmt.Errorf("invalid key name %q", key)
+	}
+
+	var value string
+	if isTerminal(os.Stdin) {
+		fmt.Fprintf(cmd.ErrOrStderr(), "value for %s/%s: ", cliName, key)
+		reader := bufio.NewReader(os.Stdin)
+		line, err := reader.ReadString('\n')
+		if err != nil && err != io.EOF {
+			return err
+		}
+		value = strings.TrimRight(line, "\n")
+	} else {
+		data, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return err
+		}
+		value = strings.TrimRight(string(data), "\n")
+	}
+
+	envPath := filepath.Join(secretsRoot(), cliName, "secrets.env")
+	existing, _ := readEnvAll(envPath)
+	if existing == nil {
+		existing = map[string]string{}
+	}
+	existing[key] = value
+	if err := os.MkdirAll(filepath.Dir(envPath), 0o700); err != nil {
+		return err
+	}
+	if err := writeEnvAtomic(envPath, existing); err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "set %s/%s\n", cliName, key)
+	return nil
+}
+
+func runSecretRm(cmd *cobra.Command, args []string) error {
+	cliName := args[0]
+	if !validBusName(cliName) {
+		return fmt.Errorf("invalid cli-name %q", cliName)
+	}
+	cliDir := filepath.Join(secretsRoot(), cliName)
+
+	if len(args) == 1 {
+		// Whole-CLI removal.
+		if err := os.RemoveAll(cliDir); err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "removed %s/\n", cliName)
+		return nil
+	}
+	key := args[1]
+	envPath := filepath.Join(cliDir, "secrets.env")
+	existing, err := readEnvAll(envPath)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", envPath, err)
+	}
+	if _, ok := existing[key]; !ok {
+		return fmt.Errorf("key %q not found for %s", key, cliName)
+	}
+	delete(existing, key)
+	if len(existing) == 0 {
+		// Remove the file entirely rather than leave an empty stub.
+		_ = os.Remove(envPath)
+	} else if err := writeEnvAtomic(envPath, existing); err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "removed %s/%s\n", cliName, key)
+	return nil
+}
+
+func runSecretImportFrom(cmd *cobra.Command, args []string) error {
+	if secretImportAs == "" {
+		return fmt.Errorf("--as <cli-name> is required")
+	}
+	if !validBusName(secretImportAs) {
+		return fmt.Errorf("invalid --as cli-name %q", secretImportAs)
+	}
+	src := args[0]
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", src, err)
+	}
+
+	// Detect format by extension and parse into a flat map. JSON is the
+	// most common shape in the U1 audit (tesla auth.json, superhuman
+	// tokens.json). TOML appears in many configs but the existing fields
+	// are usually under [auth] or top-level. Env files are already in
+	// shape.
+	flat, mappingNotes, err := importParse(src, data)
+	if err != nil {
+		return fmt.Errorf("parse %s: %w", src, err)
+	}
+	if len(flat) == 0 {
+		return fmt.Errorf("no recognizable keys in %s", src)
+	}
+
+	envPath := filepath.Join(secretsRoot(), secretImportAs, "secrets.env")
+	existing, _ := readEnvAll(envPath)
+	if existing == nil {
+		existing = map[string]string{}
+	}
+	for k, v := range flat {
+		existing[k] = v
+	}
+	if err := os.MkdirAll(filepath.Dir(envPath), 0o700); err != nil {
+		return err
+	}
+	if err := writeEnvAtomic(envPath, existing); err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "imported %d keys from %s into %s/secrets.env\n", len(flat), src, secretImportAs)
+	for _, note := range mappingNotes {
+		fmt.Fprintf(cmd.ErrOrStderr(), "  note: %s\n", note)
+	}
+	return nil
+}
+
+// importParse handles JSON, TOML, and env-shaped input via heuristic field
+// mapping. Unknown fields become _unknown_<original_name> per the spec's
+// reserved-key rule so the friend can review and rename.
+func importParse(path string, data []byte) (map[string]string, []string, error) {
+	ext := strings.ToLower(filepath.Ext(path))
+	var notes []string
+
+	// Common field-name heuristics observed in the U1 audit. Lowercase
+	// match; we render in canonical UPPER_SNAKE_CASE on the way out.
+	canonical := map[string]string{
+		"access_token":           "OAUTH_BEARER",
+		"accesstoken":            "OAUTH_BEARER",
+		"refresh_token":          "OAUTH_REFRESH",
+		"refreshtoken":           "OAUTH_REFRESH",
+		"api_key":                "API_KEY",
+		"apikey":                 "API_KEY",
+		"client_id":              "OAUTH_CLIENT_ID",
+		"clientid":               "OAUTH_CLIENT_ID",
+		"client_secret":          "OAUTH_CLIENT_SECRET",
+		"clientsecret":           "OAUTH_CLIENT_SECRET",
+		"token":                  "TOKEN",
+		"bearer":                 "OAUTH_BEARER",
+		"auth_header":            "AUTH_HEADER",
+		"token_expiry":           "OAUTH_EXPIRES_AT",
+		"expires_at":             "OAUTH_EXPIRES_AT",
+		"base_url":               "BASE_URL",
+	}
+
+	flat := map[string]string{}
+	mapKey := func(orig string) (string, bool) {
+		lower := strings.ToLower(orig)
+		if canon, ok := canonical[lower]; ok {
+			return canon, true
+		}
+		// Underscore-and-uppercase fallback for unknown but env-shaped keys.
+		if validBusKey(orig) {
+			return strings.ToUpper(orig), false
+		}
+		// Reserved prefix for fields we can't validate as env names.
+		safe := "_unknown_" + sanitizeForReserved(orig)
+		return safe, false
+	}
+
+	switch ext {
+	case ".env", "":
+		// Treat as env-shaped already.
+		kv, err := parseEnvBytesShim(data)
+		if err != nil {
+			return nil, nil, err
+		}
+		for k, v := range kv {
+			canon, mapped := mapKey(k)
+			flat[canon] = v
+			if !mapped && canon != k {
+				notes = append(notes, fmt.Sprintf("renamed %q -> %q (reserved-prefix; review)", k, canon))
+			}
+		}
+	case ".json":
+		var raw map[string]any
+		if err := json.Unmarshal(data, &raw); err != nil {
+			return nil, nil, fmt.Errorf("json: %w", err)
+		}
+		flattenJSON("", raw, flat, &notes, mapKey)
+	case ".toml":
+		// Best-effort: many config.toml files in the audit have flat
+		// top-level keys OR a single [auth] table. We parse via the
+		// existing TOML dep and walk it.
+		var raw map[string]any
+		// Re-use the same TOML lib via secretsbus indirectly.
+		if err := decodeTOML(data, &raw); err != nil {
+			return nil, nil, fmt.Errorf("toml: %w", err)
+		}
+		flattenJSON("", raw, flat, &notes, mapKey)
+	default:
+		return nil, nil, fmt.Errorf("unsupported extension %q (supported: .env .json .toml)", ext)
+	}
+	return flat, notes, nil
+}
+
+func flattenJSON(prefix string, raw map[string]any, out map[string]string, notes *[]string, mapKey func(string) (string, bool)) {
+	for k, v := range raw {
+		fullKey := k
+		if prefix != "" {
+			fullKey = prefix + "_" + k
+		}
+		switch val := v.(type) {
+		case string:
+			canon, mapped := mapKey(fullKey)
+			out[canon] = val
+			if !mapped && canon != fullKey && strings.HasPrefix(canon, "_unknown_") {
+				*notes = append(*notes, fmt.Sprintf("renamed %q -> %q (review)", fullKey, canon))
+			}
+		case float64:
+			canon, _ := mapKey(fullKey)
+			out[canon] = fmt.Sprintf("%v", val)
+		case bool:
+			canon, _ := mapKey(fullKey)
+			out[canon] = fmt.Sprintf("%v", val)
+		case map[string]any:
+			flattenJSON(fullKey, val, out, notes, mapKey)
+		default:
+			// Drop arrays + other non-string scalars; not env-shaped.
+		}
+	}
+}
+
+func sanitizeForReserved(orig string) string {
+	var b strings.Builder
+	for _, r := range orig {
+		isLetter := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')
+		isDigit := r >= '0' && r <= '9'
+		if isLetter || isDigit {
+			b.WriteRune(r)
+		} else {
+			b.WriteRune('_')
+		}
+	}
+	if b.Len() == 0 {
+		return "X"
+	}
+	return b.String()
+}
+
+// validBusName mirrors secretsbus.validCLIName (kept local to avoid an
+// unnecessary import + dependency cycle).
+func validBusName(name string) bool {
+	if name == "" || len(name) > 64 {
+		return false
+	}
+	if name[0] == '-' || name[len(name)-1] == '-' {
+		return false
+	}
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= '0' && r <= '9':
+		case r == '-':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// validBusKey mirrors secretsbus.validKeyName.
+func validBusKey(k string) bool {
+	if k == "" {
+		return false
+	}
+	for i, r := range k {
+		isLetter := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')
+		isDigit := r >= '0' && r <= '9'
+		isUnder := r == '_'
+		if i == 0 {
+			if !(isLetter || isUnder) {
+				return false
+			}
+			continue
+		}
+		if !(isLetter || isDigit || isUnder) {
+			return false
+		}
+	}
+	return true
+}
+
+// readEnvKeysOnly returns the KEY names from a secrets.env file (no values).
+// Used by `secret list` to print without leaking value content.
+func readEnvKeysOnly(path string) ([]string, error) {
+	all, err := readEnvAll(path)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(all))
+	for k := range all {
+		out = append(out, k)
+	}
+	return out, nil
+}
+
+// readEnvAll parses a secrets.env file. Wraps the strict parser used
+// inside the secretsbus package by going through a small in-line scanner.
+// Kept local to this file to avoid expanding the secretsbus public surface.
+func readEnvAll(path string) (map[string]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return parseEnvBytesShim(data)
+}
+
+// writeEnvAtomic mirrors secretsbus.atomicWrite via a tiny helper. The
+// secret subcommand needs a write path; we keep it next to the read path
+// for symmetry.
+func writeEnvAtomic(path string, kv map[string]string) error {
+	body := renderEnvForCmd(kv)
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, body, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+func renderEnvForCmd(kv map[string]string) []byte {
+	keys := make([]string, 0, len(kv))
+	for k := range kv {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	b.WriteString("# Written by agentcookie secret. See docs/spec-agentcookie-secrets-bus-v1.md.\n")
+	for _, k := range keys {
+		b.WriteString(k)
+		b.WriteString("=")
+		b.WriteString(kv[k])
+		b.WriteString("\n")
+	}
+	return []byte(b.String())
+}
+
+// parseEnvBytesShim and decodeTOML are tiny local helpers that re-use the
+// stdlib + the existing TOML dep without adding a new public surface.
+
+func parseEnvBytesShim(data []byte) (map[string]string, error) {
+	// Delegate to secretsbus via a copy of the strict scanner. Kept here
+	// rather than exporting from secretsbus to keep that package's public
+	// surface minimal.
+	out := map[string]string{}
+	for lineNum, line := range strings.Split(string(data), "\n") {
+		ln := lineNum + 1
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		eq := strings.IndexByte(line, '=')
+		if eq < 0 {
+			return nil, fmt.Errorf("line %d: missing '='", ln)
+		}
+		key := line[:eq]
+		if key != strings.TrimSpace(key) {
+			return nil, fmt.Errorf("line %d: whitespace around '='", ln)
+		}
+		val := line[eq+1:]
+		if len(val) >= 2 {
+			first, last := val[0], val[len(val)-1]
+			if (first == '"' && last == '"') || (first == '\'' && last == '\'') {
+				val = val[1 : len(val)-1]
+			}
+		}
+		out[key] = val
+	}
+	return out, nil
+}
+
+// decodeTOML wraps the existing BurntSushi/toml dep for the import-from
+// command's TOML branch.
+func decodeTOML(data []byte, out *map[string]any) error {
+	return toml.Unmarshal(data, out)
+}
+
+// isTerminal reports whether stdin is a TTY. Crude check; used to decide
+// between interactive prompt and pipe input in `secret set`.
+func isTerminal(f *os.File) bool {
+	info, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return (info.Mode() & os.ModeCharDevice) != 0
+}

--- a/internal/cli/secret_test.go
+++ b/internal/cli/secret_test.go
@@ -1,0 +1,201 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSecretList_EmptyBus(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	buf := &bytes.Buffer{}
+	cmd := secretListCmd
+	cmd.SetOut(buf)
+	if err := runSecretList(cmd, nil); err != nil {
+		t.Fatalf("runSecretList: %v", err)
+	}
+	if !strings.Contains(buf.String(), "empty") {
+		t.Errorf("expected 'empty' message, got: %q", buf.String())
+	}
+}
+
+func TestSecretList_PopulatedBus(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cliDir := filepath.Join(home, ".agentcookie", "secrets", "demo-cli")
+	if err := os.MkdirAll(cliDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cliDir, "secrets.env"), []byte("K1=v1\nK2=v2\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	buf := &bytes.Buffer{}
+	cmd := secretListCmd
+	cmd.SetOut(buf)
+	if err := runSecretList(cmd, nil); err != nil {
+		t.Fatalf("runSecretList: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "demo-cli") || !strings.Contains(out, "K1") || !strings.Contains(out, "K2") {
+		t.Errorf("list output incomplete: %q", out)
+	}
+	// Values must NOT leak in list output.
+	if strings.Contains(out, "v1") || strings.Contains(out, "v2") {
+		t.Errorf("list should not print values: %q", out)
+	}
+}
+
+func TestSecretGet_HappyPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cliDir := filepath.Join(home, ".agentcookie", "secrets", "demo-cli")
+	os.MkdirAll(cliDir, 0o700)
+	os.WriteFile(filepath.Join(cliDir, "secrets.env"), []byte("TOKEN=abc-123\n"), 0o600)
+
+	buf := &bytes.Buffer{}
+	cmd := secretGetCmd
+	cmd.SetOut(buf)
+	if err := runSecretGet(cmd, []string{"demo-cli", "TOKEN"}); err != nil {
+		t.Fatalf("runSecretGet: %v", err)
+	}
+	if buf.String() != "abc-123" {
+		t.Errorf("get output: %q", buf.String())
+	}
+}
+
+func TestSecretGet_KeyMissing(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cliDir := filepath.Join(home, ".agentcookie", "secrets", "demo-cli")
+	os.MkdirAll(cliDir, 0o700)
+	os.WriteFile(filepath.Join(cliDir, "secrets.env"), []byte("A=1\n"), 0o600)
+
+	cmd := secretGetCmd
+	cmd.SetOut(&bytes.Buffer{})
+	err := runSecretGet(cmd, []string{"demo-cli", "MISSING"})
+	if err == nil {
+		t.Errorf("missing key should error")
+	}
+}
+
+func TestSecretSet_StdinPipe(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// Pipe stdin via a temp file because runSecretSet reads os.Stdin
+	// directly. We replace os.Stdin for the duration.
+	r, w, _ := os.Pipe()
+	w.Write([]byte("piped-value\n"))
+	w.Close()
+	orig := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = orig }()
+
+	buf := &bytes.Buffer{}
+	cmd := secretSetCmd
+	cmd.SetOut(buf)
+	cmd.SetErr(&bytes.Buffer{})
+	if err := runSecretSet(cmd, []string{"demo-cli", "MYKEY"}); err != nil {
+		t.Fatalf("runSecretSet: %v", err)
+	}
+	stored, err := os.ReadFile(filepath.Join(home, ".agentcookie", "secrets", "demo-cli", "secrets.env"))
+	if err != nil {
+		t.Fatalf("read written file: %v", err)
+	}
+	if !strings.Contains(string(stored), "MYKEY=piped-value") {
+		t.Errorf("file content: %q", string(stored))
+	}
+}
+
+func TestSecretRm_SingleKey(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cliDir := filepath.Join(home, ".agentcookie", "secrets", "demo-cli")
+	os.MkdirAll(cliDir, 0o700)
+	os.WriteFile(filepath.Join(cliDir, "secrets.env"), []byte("A=1\nB=2\n"), 0o600)
+
+	cmd := secretRmCmd
+	cmd.SetOut(&bytes.Buffer{})
+	if err := runSecretRm(cmd, []string{"demo-cli", "A"}); err != nil {
+		t.Fatalf("runSecretRm: %v", err)
+	}
+	remaining, _ := os.ReadFile(filepath.Join(cliDir, "secrets.env"))
+	if strings.Contains(string(remaining), "A=") {
+		t.Errorf("A should be removed: %q", string(remaining))
+	}
+	if !strings.Contains(string(remaining), "B=2") {
+		t.Errorf("B should remain: %q", string(remaining))
+	}
+}
+
+func TestSecretRm_WholeCLI(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cliDir := filepath.Join(home, ".agentcookie", "secrets", "demo-cli")
+	os.MkdirAll(cliDir, 0o700)
+	os.WriteFile(filepath.Join(cliDir, "secrets.env"), []byte("X=Y\n"), 0o600)
+
+	cmd := secretRmCmd
+	cmd.SetOut(&bytes.Buffer{})
+	if err := runSecretRm(cmd, []string{"demo-cli"}); err != nil {
+		t.Fatalf("runSecretRm: %v", err)
+	}
+	if _, err := os.Stat(cliDir); err == nil {
+		t.Errorf("cliDir should be removed")
+	}
+}
+
+func TestSecretImportFrom_JSON(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	src := filepath.Join(home, "tesla-auth.json")
+	os.WriteFile(src, []byte(`{"access_token":"AT","refresh_token":"RT","expires_at":"2026-01-01T00:00:00Z"}`), 0o600)
+
+	cmd := secretImportFromCmd
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	secretImportAs = "tesla-pp-cli"
+	defer func() { secretImportAs = "" }()
+	if err := runSecretImportFrom(cmd, []string{src}); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	written, _ := os.ReadFile(filepath.Join(home, ".agentcookie", "secrets", "tesla-pp-cli", "secrets.env"))
+	s := string(written)
+	if !strings.Contains(s, "OAUTH_BEARER=AT") {
+		t.Errorf("access_token should canonicalize to OAUTH_BEARER: %q", s)
+	}
+	if !strings.Contains(s, "OAUTH_REFRESH=RT") {
+		t.Errorf("refresh_token should canonicalize to OAUTH_REFRESH: %q", s)
+	}
+}
+
+func TestSecretImportFrom_UnknownFieldGetsReservedPrefix(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	src := filepath.Join(home, "config.json")
+	os.WriteFile(src, []byte(`{"some-weird-field":"value"}`), 0o600)
+
+	cmd := secretImportFromCmd
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	secretImportAs = "demo-cli"
+	defer func() { secretImportAs = "" }()
+	if err := runSecretImportFrom(cmd, []string{src}); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	written, _ := os.ReadFile(filepath.Join(home, ".agentcookie", "secrets", "demo-cli", "secrets.env"))
+	if !strings.Contains(string(written), "_unknown_some_weird_field=value") {
+		t.Errorf("unknown field should land under _unknown_ prefix: %q", string(written))
+	}
+}
+
+func TestValidBusName_RejectsTraversal(t *testing.T) {
+	if validBusName("../etc") {
+		t.Errorf("traversal should be rejected")
+	}
+	if validBusName("Foo") {
+		t.Errorf("uppercase should be rejected")
+	}
+}

--- a/internal/cli/sink.go
+++ b/internal/cli/sink.go
@@ -19,6 +19,7 @@ import (
 	"github.com/mvanhorn/agentcookie/internal/cli/httpserver"
 	"github.com/mvanhorn/agentcookie/internal/config"
 	"github.com/mvanhorn/agentcookie/internal/keystore"
+	"github.com/mvanhorn/agentcookie/internal/secretsbus"
 	"github.com/mvanhorn/agentcookie/internal/protocol"
 	"github.com/mvanhorn/agentcookie/internal/sinkpush"
 	"github.com/mvanhorn/agentcookie/internal/state"
@@ -257,6 +258,23 @@ func runSink(cmd *cobra.Command, args []string) error {
 			adapterResults := sinkpush.RunAll(cookies)
 			sinkState.LastAdapterResults = toStateAdapterResults(adapterResults)
 			logAdapterResults(adapterResults)
+		}
+
+		// v0.13: secrets-bus payload. When present, persist per-CLI
+		// secrets.env files at the standard path under
+		// ~/.agentcookie/secrets/. Sealing is enabled when the master
+		// key is present AND v0.12's sealing posture is on; the sealed
+		// twin appears alongside the plaintext. R12 regression guard:
+		// when envelope.Secrets is empty/nil this branch is a no-op.
+		if len(envelope.Secrets) > 0 {
+			home, _ := os.UserHomeDir()
+			sealingEnabled := keystore.MasterKeyExists()
+			secResult, secErrs := secretsbus.WritePayload(home, envelope.Secrets, sealingEnabled)
+			for _, e := range secErrs {
+				fmt.Fprintf(os.Stderr, "agentcookie sink: secrets-bus: %v\n", e)
+			}
+			fmt.Fprintf(os.Stderr, "agentcookie sink: secrets-bus wrote %d cli(s), %d key(s), %d sealed\n",
+				secResult.CLIsWritten, secResult.KeysWritten, secResult.SealedWritten)
 		}
 
 		_ = stateWriter.Save(sinkState)

--- a/internal/cli/source.go
+++ b/internal/cli/source.go
@@ -20,6 +20,7 @@ import (
 	"github.com/mvanhorn/agentcookie/internal/config"
 	"github.com/mvanhorn/agentcookie/internal/pairing"
 	"github.com/mvanhorn/agentcookie/internal/protocol"
+	"github.com/mvanhorn/agentcookie/internal/secretsbus"
 	"github.com/mvanhorn/agentcookie/internal/state"
 	"github.com/mvanhorn/agentcookie/internal/transport"
 	"github.com/mvanhorn/agentcookie/internal/watcher"
@@ -137,6 +138,22 @@ func runSource(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("init watcher: %w", err)
 	}
 	fmt.Fprintf(os.Stderr, "agentcookie source --watch: watching %s, sink=%s\n", cfg.Chrome.DBPath, cfg.Sink.URL)
+
+	// v0.13: also watch ~/.agentcookie/secrets/ so a write to a per-CLI
+	// secrets.env triggers the same push pipeline as a Chrome cookie
+	// change. The secrets watcher tolerates a missing root (waits for the
+	// friend to create it) and fires the same push callback as the
+	// cookies watcher so the payload includes whichever surface changed.
+	watchHome, _ := os.UserHomeDir()
+	secretsWatcher := secretsbus.NewWatcher(watchHome, 0, func(ctx context.Context) {
+		_, _ = push(ctx)
+	})
+	go func() {
+		if err := secretsWatcher.Run(cmd.Context()); err != nil {
+			fmt.Fprintf(os.Stderr, "agentcookie source --watch: secrets-bus watcher exited: %v\n", err)
+		}
+	}()
+
 	return w.Run(cmd.Context())
 }
 
@@ -172,17 +189,34 @@ func pushOnce(
 			totalRead, totalDropped, len(droppedHosts), len(all))
 	}
 
+	// v0.13 secrets bus: load per-CLI secrets from ~/.agentcookie/secrets/
+	// and apply each manifest's sync policy. Non-fatal errors are logged
+	// (e.g. an oversized secrets.env) but do not stop the push.
+	home, _ := os.UserHomeDir()
+	secretsPayload, secretsErrs := secretsbus.LoadPayload(home)
+	for _, e := range secretsErrs {
+		fmt.Fprintf(os.Stderr, "agentcookie source: secrets-bus: %v\n", e)
+	}
+	secretsCLICount := 0
+	if secretsPayload != nil {
+		secretsCLICount = len(secretsPayload.CLIs)
+	}
+	if verbose && secretsCLICount > 0 {
+		fmt.Fprintf(os.Stderr, "agentcookie source: secrets-bus: shipping %d cli(s)\n", secretsCLICount)
+	}
+
 	result := map[string]any{
 		"cookies_read":    totalRead,
 		"cookies_blocked": totalDropped,
 		"cookies_passing": len(all),
+		"secrets_clis":    secretsCLICount,
 		"dry_run":         dryRun,
 		"sink_url":        cfg.Sink.URL,
 		"posted":          false,
 	}
 
-	if dryRun || len(all) == 0 {
-		_ = emit(result, fmt.Sprintf("agentcookie source: %d cookies after blocklist (dry-run=%v)\n", len(all), dryRun))
+	if dryRun || (len(all) == 0 && secretsCLICount == 0) {
+		_ = emit(result, fmt.Sprintf("agentcookie source: %d cookies after blocklist, %d secrets clis (dry-run=%v)\n", len(all), secretsCLICount, dryRun))
 		return 0, nil
 	}
 
@@ -221,6 +255,9 @@ func pushOnce(
 		LocalStorageTarball: lsTarball,
 		IndexedDBTarball:    idbTarball,
 		IndexedDBSkipped:    idbSkipped,
+	}
+	if secretsPayload != nil && len(secretsPayload.CLIs) > 0 {
+		envelope.Secrets = secretsPayload.CLIs
 	}
 	payload, err := json.Marshal(envelope)
 	if err != nil {

--- a/internal/protocol/envelope.go
+++ b/internal/protocol/envelope.go
@@ -39,4 +39,11 @@ type SyncEnvelope struct {
 	LocalStorageTarball []byte          `json:"local_storage_tarball,omitempty"`
 	IndexedDBTarball    []byte          `json:"indexed_db_tarball,omitempty"`
 	IndexedDBSkipped    []string        `json:"indexed_db_skipped,omitempty"`
+
+	// Secrets carries the v0.13 secrets-bus payload alongside cookies.
+	// Optional: omitempty so v0.12 sinks deserialize unchanged. The
+	// payload value is one map per registered CLI under
+	// ~/.agentcookie/secrets/, post-filter against the manifest's
+	// sync policy. Format defined in docs/spec-agentcookie-secrets-bus-v1.md.
+	Secrets map[string]map[string]string `json:"secrets,omitempty"`
 }

--- a/internal/secretsbus/secretsbus.go
+++ b/internal/secretsbus/secretsbus.go
@@ -1,0 +1,333 @@
+// Package secretsbus reads the per-CLI files under ~/.agentcookie/secrets/
+// into a wire-friendly payload, applies the manifest's sync policy, and
+// exposes a watcher that fires on changes. The on-disk format is the public
+// contract documented at docs/spec-agentcookie-secrets-bus-v1.md (v1).
+//
+// Source-side responsibilities live here. Sink-side write semantics live in
+// the (forthcoming) writer in the same package.
+package secretsbus
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+)
+
+// maxEnvFileBytes caps a single secrets.env at 256 KB per the v1 spec. Files
+// larger than this are dropped on the source with a clear error rather than
+// shipped, so a runaway log file accidentally renamed into the bus does not
+// silently swamp the sink.
+const maxEnvFileBytes = 256 * 1024
+
+// Payload is the on-wire shape carried inside protocol.SyncEnvelope. One
+// entry per registered CLI, only including CLIs whose effective sync policy
+// resolves to "ship something." The map values are post-filter (per-key
+// sync=false entries already removed).
+type Payload struct {
+	// CLIs maps cli-name -> env map. Empty map means "no CLIs registered yet."
+	CLIs map[string]map[string]string `json:"clis"`
+}
+
+// IsEmpty reports whether the payload carries any CLI data.
+func (p *Payload) IsEmpty() bool {
+	return p == nil || len(p.CLIs) == 0
+}
+
+// Manifest mirrors the v1 manifest.toml shape. Per the spec, [sync.keys]
+// stays source-side and does NOT travel to the sink. Filtering happens here.
+type Manifest struct {
+	SchemaVersion int    `toml:"schema_version"`
+	DisplayName   string `toml:"display_name"`
+	Sync          struct {
+		Default bool            `toml:"default"`
+		Keys    map[string]bool `toml:"keys"`
+	} `toml:"sync"`
+}
+
+// defaultSync returns the effective default. v1 spec: default is true when
+// the manifest omits [sync] entirely or omits sync.default.
+func (m *Manifest) defaultSync() bool {
+	// Burntsushi/toml zero-values Default to false; we need to distinguish
+	// "omitted" from "explicit false." We can't from the parsed struct
+	// alone, so callers parse via parseManifest which sets a sentinel.
+	return m.Sync.Default
+}
+
+// SecretsRoot returns the absolute path of the secrets root directory.
+// Caller passes a homeDir to keep the function testable without HOME magic.
+func SecretsRoot(homeDir string) string {
+	return filepath.Join(homeDir, ".agentcookie", "secrets")
+}
+
+// LoadPayload walks the secrets root, reads each per-CLI dir's env file and
+// manifest, applies per-key sync filtering, and returns the payload. The
+// caller (source push code) packs this into the wire envelope.
+//
+// Behavior on edge cases:
+//   - Missing root: returns empty payload, no error.
+//   - Per-CLI dir with no secrets.env (manifest-only): skipped, logged.
+//   - secrets.env exceeding maxEnvFileBytes: skipped, returns the error
+//     for the caller to log, BUT still returns whatever was loaded for
+//     other CLIs.
+//   - Manifest parse error: skipped (the per-CLI dir is excluded) and
+//     returned as a non-fatal error.
+//   - Unexpected file at root level (not a directory): skipped silently.
+func LoadPayload(homeDir string) (*Payload, []error) {
+	root := SecretsRoot(homeDir)
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &Payload{CLIs: map[string]map[string]string{}}, nil
+		}
+		return nil, []error{fmt.Errorf("read secrets root %s: %w", root, err)}
+	}
+
+	out := &Payload{CLIs: map[string]map[string]string{}}
+	var nonFatal []error
+
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		cliName := e.Name()
+		if !validCLIName(cliName) {
+			nonFatal = append(nonFatal, fmt.Errorf("skipping invalid cli-name directory %q (must match v1 spec naming)", cliName))
+			continue
+		}
+		cliDir := filepath.Join(root, cliName)
+		envPath := filepath.Join(cliDir, "secrets.env")
+		manifestPath := filepath.Join(cliDir, "manifest.toml")
+
+		envInfo, err := os.Stat(envPath)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				nonFatal = append(nonFatal, fmt.Errorf("%s: stat secrets.env: %w", cliName, err))
+			}
+			continue
+		}
+		if envInfo.Size() > maxEnvFileBytes {
+			nonFatal = append(nonFatal, fmt.Errorf("%s: secrets.env is %d bytes, over the %d byte limit; not shipping this CLI", cliName, envInfo.Size(), maxEnvFileBytes))
+			continue
+		}
+
+		envMap, err := parseEnvFile(envPath)
+		if err != nil {
+			nonFatal = append(nonFatal, fmt.Errorf("%s: parse secrets.env: %w", cliName, err))
+			continue
+		}
+
+		manifest, manifestExplicitDefault, mErr := loadManifest(manifestPath)
+		if mErr != nil {
+			nonFatal = append(nonFatal, fmt.Errorf("%s: parse manifest.toml: %w", cliName, mErr))
+			continue
+		}
+
+		filtered := applySyncPolicy(envMap, manifest, manifestExplicitDefault)
+		if len(filtered) > 0 {
+			out.CLIs[cliName] = filtered
+		}
+	}
+
+	return out, nonFatal
+}
+
+// validCLIName mirrors the v1 spec: lowercase, alphanumeric + hyphens, no
+// dots, no slashes, no ".." traversal. Hyphens may not lead or trail.
+func validCLIName(name string) bool {
+	if name == "" || len(name) > 64 {
+		return false
+	}
+	if name[0] == '-' || name[len(name)-1] == '-' {
+		return false
+	}
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= '0' && r <= '9':
+		case r == '-':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// parseEnvFile reads a v1-conformant secrets.env file. Implements the strict
+// grammar subset documented in the spec: KEY=VALUE one per line, # comments,
+// double or single quotes, no variable interpolation. Backslash continuation
+// at end-of-line joins the next line. Reserved keys (underscore-prefixed)
+// pass through unchanged.
+func parseEnvFile(path string) (map[string]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	out := map[string]string{}
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), maxEnvFileBytes)
+	lineNum := 0
+	var pending strings.Builder
+	var pendingKey string
+	inContinuation := false
+
+	for scanner.Scan() {
+		lineNum++
+		line := scanner.Text()
+
+		if inContinuation {
+			// Continue the previous value. Backslash continuation handled below.
+			if strings.HasSuffix(line, "\\") {
+				pending.WriteString(line[:len(line)-1])
+				continue
+			}
+			pending.WriteString(line)
+			out[pendingKey] = stripQuotes(pending.String())
+			pending.Reset()
+			pendingKey = ""
+			inContinuation = false
+			continue
+		}
+
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		eq := strings.IndexByte(line, '=')
+		if eq < 0 {
+			return nil, fmt.Errorf("line %d: missing '=' (expected KEY=VALUE)", lineNum)
+		}
+		key := line[:eq]
+		if key != strings.TrimRight(key, " \t") || key != strings.TrimLeft(key, " \t") {
+			return nil, fmt.Errorf("line %d: whitespace around '=' is not allowed", lineNum)
+		}
+		if !validKeyName(key) {
+			return nil, fmt.Errorf("line %d: invalid key name %q", lineNum, key)
+		}
+		value := line[eq+1:]
+
+		if strings.HasSuffix(value, "\\") {
+			pending.WriteString(value[:len(value)-1])
+			pendingKey = key
+			inContinuation = true
+			continue
+		}
+		out[key] = stripQuotes(value)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan: %w", err)
+	}
+	if inContinuation {
+		return nil, fmt.Errorf("unterminated backslash continuation for key %q", pendingKey)
+	}
+	return out, nil
+}
+
+// stripQuotes removes a single surrounding pair of double or single quotes.
+// Mirrors the dotenv-common convention.
+func stripQuotes(v string) string {
+	if len(v) >= 2 {
+		first, last := v[0], v[len(v)-1]
+		if (first == '"' && last == '"') || (first == '\'' && last == '\'') {
+			return v[1 : len(v)-1]
+		}
+	}
+	return v
+}
+
+// validKeyName mirrors the v1 spec: must start with a letter or underscore,
+// rest may include letters, digits, underscores. Hyphens and dots are NOT
+// permitted in keys (most dotenv parsers reject them in env-var export).
+func validKeyName(k string) bool {
+	if k == "" {
+		return false
+	}
+	for i, r := range k {
+		isLetter := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')
+		isDigit := r >= '0' && r <= '9'
+		isUnder := r == '_'
+		if i == 0 {
+			if !(isLetter || isUnder) {
+				return false
+			}
+			continue
+		}
+		if !(isLetter || isDigit || isUnder) {
+			return false
+		}
+	}
+	return true
+}
+
+// loadManifest reads manifest.toml if present. Returns the parsed manifest,
+// a boolean indicating whether sync.default was explicitly set in the file
+// (vs absent and zero-valued), and any parse error.
+//
+// When the file is missing the function returns a manifest with default
+// sync=true (v1 spec default), explicitDefault=false, no error.
+func loadManifest(path string) (*Manifest, bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			m := &Manifest{}
+			m.Sync.Default = true
+			return m, false, nil
+		}
+		return nil, false, err
+	}
+	// Two-pass: first decode into a generic map to detect whether
+	// sync.default was set explicitly; second pass into the typed struct.
+	var raw map[string]interface{}
+	if err := toml.Unmarshal(data, &raw); err != nil {
+		return nil, false, fmt.Errorf("unmarshal: %w", err)
+	}
+	explicit := false
+	if syncRaw, ok := raw["sync"].(map[string]interface{}); ok {
+		if _, ok := syncRaw["default"]; ok {
+			explicit = true
+		}
+	}
+
+	m := &Manifest{}
+	if err := toml.Unmarshal(data, m); err != nil {
+		return nil, false, fmt.Errorf("typed unmarshal: %w", err)
+	}
+	if !explicit {
+		// Apply v1 default of true.
+		m.Sync.Default = true
+	}
+	return m, explicit, nil
+}
+
+// applySyncPolicy returns the subset of envMap that should ship to the sink
+// based on the manifest's [sync] default + [sync.keys] per-key overrides.
+// Per the v1 spec, the [sync.keys] table itself does NOT travel to the
+// sink; only filtered data does.
+func applySyncPolicy(envMap map[string]string, m *Manifest, explicitDefault bool) map[string]string {
+	out := map[string]string{}
+	defaultSync := true
+	if explicitDefault {
+		defaultSync = m.Sync.Default
+	}
+	keys := make([]string, 0, len(envMap))
+	for k := range envMap {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys) // deterministic ordering for tests + wire stability
+	for _, k := range keys {
+		shouldSync := defaultSync
+		if override, ok := m.Sync.Keys[k]; ok {
+			shouldSync = override
+		}
+		if shouldSync {
+			out[k] = envMap[k]
+		}
+	}
+	return out
+}

--- a/internal/secretsbus/secretsbus_test.go
+++ b/internal/secretsbus/secretsbus_test.go
@@ -1,0 +1,300 @@
+package secretsbus
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func TestLoadPayload_MissingRoot(t *testing.T) {
+	home := t.TempDir()
+	p, errs := LoadPayload(home)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !p.IsEmpty() {
+		t.Fatalf("missing root should produce empty payload, got %d clis", len(p.CLIs))
+	}
+}
+
+func TestLoadPayload_SimpleEnvFile(t *testing.T) {
+	home := t.TempDir()
+	writeFile(t, filepath.Join(SecretsRoot(home), "tesla-pp-cli", "secrets.env"),
+		"TESLA_OAUTH_BEARER=ey-test\nTESLA_OAUTH_REFRESH=ey-refresh\n")
+
+	p, errs := LoadPayload(home)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	got := p.CLIs["tesla-pp-cli"]
+	if got["TESLA_OAUTH_BEARER"] != "ey-test" {
+		t.Errorf("BEARER mismatch: %v", got)
+	}
+	if got["TESLA_OAUTH_REFRESH"] != "ey-refresh" {
+		t.Errorf("REFRESH mismatch: %v", got)
+	}
+}
+
+func TestLoadPayload_ManifestSyncFalseSkipsKey(t *testing.T) {
+	home := t.TempDir()
+	cliDir := filepath.Join(SecretsRoot(home), "demo-cli")
+	writeFile(t, filepath.Join(cliDir, "secrets.env"),
+		"PUBLIC_API_KEY=abc\nPRIVATE_KEY=xyz\n")
+	writeFile(t, filepath.Join(cliDir, "manifest.toml"),
+		`schema_version = 1
+display_name = "demo"
+[sync]
+default = true
+[sync.keys]
+PRIVATE_KEY = false
+`)
+
+	p, errs := LoadPayload(home)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	cli := p.CLIs["demo-cli"]
+	if _, leaked := cli["PRIVATE_KEY"]; leaked {
+		t.Errorf("PRIVATE_KEY should be filtered out: %v", cli)
+	}
+	if cli["PUBLIC_API_KEY"] != "abc" {
+		t.Errorf("PUBLIC_API_KEY should pass through: %v", cli)
+	}
+}
+
+func TestLoadPayload_ManifestDefaultFalseSkipsAll(t *testing.T) {
+	home := t.TempDir()
+	cliDir := filepath.Join(SecretsRoot(home), "demo-cli")
+	writeFile(t, filepath.Join(cliDir, "secrets.env"), "A=1\nB=2\n")
+	writeFile(t, filepath.Join(cliDir, "manifest.toml"),
+		`schema_version = 1
+[sync]
+default = false
+`)
+
+	p, errs := LoadPayload(home)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if _, present := p.CLIs["demo-cli"]; present {
+		t.Errorf("default=false should drop the entire CLI from the payload")
+	}
+}
+
+func TestLoadPayload_ManifestKeysOverrideFalseDefault(t *testing.T) {
+	home := t.TempDir()
+	cliDir := filepath.Join(SecretsRoot(home), "demo-cli")
+	writeFile(t, filepath.Join(cliDir, "secrets.env"), "A=1\nB=2\n")
+	writeFile(t, filepath.Join(cliDir, "manifest.toml"),
+		`schema_version = 1
+[sync]
+default = false
+[sync.keys]
+A = true
+`)
+
+	p, errs := LoadPayload(home)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	cli := p.CLIs["demo-cli"]
+	if cli["A"] != "1" {
+		t.Errorf("A should be allowed by per-key override: %v", cli)
+	}
+	if _, present := cli["B"]; present {
+		t.Errorf("B should still be filtered (no override, default=false): %v", cli)
+	}
+}
+
+func TestLoadPayload_OversizeFileSkipped(t *testing.T) {
+	home := t.TempDir()
+	cliDir := filepath.Join(SecretsRoot(home), "huge-cli")
+	huge := strings.Repeat("BIG_KEY=" + strings.Repeat("x", 100) + "\n", 3000)
+	writeFile(t, filepath.Join(cliDir, "secrets.env"), huge)
+
+	p, errs := LoadPayload(home)
+	if len(errs) == 0 {
+		t.Fatalf("expected an error about oversize file")
+	}
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e.Error(), "over the") || strings.Contains(e.Error(), "limit") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected size-limit error, got: %v", errs)
+	}
+	if _, present := p.CLIs["huge-cli"]; present {
+		t.Errorf("huge cli should not be in payload")
+	}
+}
+
+func TestLoadPayload_InvalidCLINameSkipped(t *testing.T) {
+	home := t.TempDir()
+	// "Foo" violates lowercase rule
+	writeFile(t, filepath.Join(SecretsRoot(home), "Foo", "secrets.env"), "A=1\n")
+	p, errs := LoadPayload(home)
+	if _, present := p.CLIs["Foo"]; present {
+		t.Errorf("invalid cli-name dir should be skipped")
+	}
+	if len(errs) == 0 {
+		t.Errorf("expected a non-fatal error about invalid name")
+	}
+}
+
+func TestLoadPayload_ManifestOnlySkippedSilently(t *testing.T) {
+	home := t.TempDir()
+	cliDir := filepath.Join(SecretsRoot(home), "demo-cli")
+	writeFile(t, filepath.Join(cliDir, "manifest.toml"),
+		`schema_version = 1
+[sync]
+default = true
+`)
+
+	p, errs := LoadPayload(home)
+	if len(errs) > 0 {
+		t.Errorf("manifest-only should be silent, got errors: %v", errs)
+	}
+	if _, present := p.CLIs["demo-cli"]; present {
+		t.Errorf("manifest-only (no env file) should not produce a CLI entry")
+	}
+}
+
+func TestLoadPayload_MalformedManifest(t *testing.T) {
+	home := t.TempDir()
+	cliDir := filepath.Join(SecretsRoot(home), "broken-cli")
+	writeFile(t, filepath.Join(cliDir, "secrets.env"), "A=1\n")
+	writeFile(t, filepath.Join(cliDir, "manifest.toml"), "not = toml = invalid\n")
+
+	p, errs := LoadPayload(home)
+	if len(errs) == 0 {
+		t.Errorf("malformed manifest should produce an error")
+	}
+	if _, present := p.CLIs["broken-cli"]; present {
+		t.Errorf("malformed manifest should drop the CLI from payload")
+	}
+}
+
+func TestParseEnvFile_Comments(t *testing.T) {
+	tmp := t.TempDir()
+	p := filepath.Join(tmp, "secrets.env")
+	writeFile(t, p, "# header comment\nKEY1=value1\n\n# another\nKEY2=value2\n")
+	got, err := parseEnvFile(p)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got["KEY1"] != "value1" || got["KEY2"] != "value2" {
+		t.Errorf("comments should be ignored, got: %v", got)
+	}
+}
+
+func TestParseEnvFile_QuotesStripped(t *testing.T) {
+	tmp := t.TempDir()
+	p := filepath.Join(tmp, "secrets.env")
+	writeFile(t, p, `DQ="quoted value"
+SQ='single quoted'
+BARE=plain
+`)
+	got, err := parseEnvFile(p)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got["DQ"] != "quoted value" {
+		t.Errorf("DQ: %q", got["DQ"])
+	}
+	if got["SQ"] != "single quoted" {
+		t.Errorf("SQ: %q", got["SQ"])
+	}
+	if got["BARE"] != "plain" {
+		t.Errorf("BARE: %q", got["BARE"])
+	}
+}
+
+func TestParseEnvFile_WhitespaceAroundEqualsRejected(t *testing.T) {
+	tmp := t.TempDir()
+	p := filepath.Join(tmp, "secrets.env")
+	writeFile(t, p, "KEY = value\n")
+	_, err := parseEnvFile(p)
+	if err == nil {
+		t.Fatalf("whitespace around = should be rejected")
+	}
+}
+
+func TestParseEnvFile_MissingEqualsRejected(t *testing.T) {
+	tmp := t.TempDir()
+	p := filepath.Join(tmp, "secrets.env")
+	writeFile(t, p, "KEY value without equals\n")
+	_, err := parseEnvFile(p)
+	if err == nil {
+		t.Fatalf("missing = should be rejected")
+	}
+}
+
+func TestParseEnvFile_BackslashContinuation(t *testing.T) {
+	tmp := t.TempDir()
+	p := filepath.Join(tmp, "secrets.env")
+	writeFile(t, p, "LONG=part1\\\npart2\n")
+	got, err := parseEnvFile(p)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got["LONG"] != "part1part2" {
+		t.Errorf("backslash continuation: %q", got["LONG"])
+	}
+}
+
+func TestParseEnvFile_ReservedKeysPassThrough(t *testing.T) {
+	tmp := t.TempDir()
+	p := filepath.Join(tmp, "secrets.env")
+	writeFile(t, p, "_unknown_legacy_field=somevalue\n_BIN_BLOB=YmFzZTY0\n")
+	got, err := parseEnvFile(p)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got["_unknown_legacy_field"] != "somevalue" {
+		t.Errorf("reserved key should pass through: %v", got)
+	}
+	if got["_BIN_BLOB"] != "YmFzZTY0" {
+		t.Errorf("_BIN_ key should pass through: %v", got)
+	}
+}
+
+func TestValidCLIName(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"foo", true},
+		{"foo-bar", true},
+		{"foo-pp-cli", true},
+		{"foo123", true},
+		{"123foo", true},
+		{"", false},
+		{"Foo", false},      // uppercase
+		{"-foo", false},     // leading hyphen
+		{"foo-", false},     // trailing hyphen
+		{"foo.bar", false},  // dot
+		{"foo/bar", false},  // slash
+		{"foo_bar", false},  // underscore (per spec, only hyphen)
+		{"..", false},       // traversal
+	}
+	for _, tc := range cases {
+		got := validCLIName(tc.in)
+		if got != tc.want {
+			t.Errorf("validCLIName(%q): got %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/secretsbus/watcher.go
+++ b/internal/secretsbus/watcher.go
@@ -1,0 +1,161 @@
+package secretsbus
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// Watcher fires a callback whenever a file under ~/.agentcookie/secrets/
+// changes. Mirrors the cookies watcher pattern in internal/watcher: debounce
+// rapid writes, watch parent directory (fsnotify on macOS misses sub-dir
+// creation if you watch sub-dirs directly), tolerate the secrets root not
+// existing yet (the friend may create it after install).
+type Watcher struct {
+	root     string
+	debounce time.Duration
+	onChange func(ctx context.Context)
+
+	mu        sync.Mutex
+	fireCount int
+}
+
+// NewWatcher constructs a watcher rooted at homeDir/.agentcookie/secrets/.
+// debounce defaults to 500ms when zero.
+func NewWatcher(homeDir string, debounce time.Duration, onChange func(ctx context.Context)) *Watcher {
+	if debounce <= 0 {
+		debounce = 500 * time.Millisecond
+	}
+	return &Watcher{
+		root:     SecretsRoot(homeDir),
+		debounce: debounce,
+		onChange: onChange,
+	}
+}
+
+// Run blocks until ctx is canceled. Returns when ctx is canceled or fsnotify
+// can no longer be created. Missing-root is NOT an error: the watcher polls
+// for the root's appearance and starts watching it as soon as it exists.
+func (w *Watcher) Run(ctx context.Context) error {
+	fsw, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("new fsnotify watcher: %w", err)
+	}
+	defer fsw.Close()
+
+	// Wait for root to exist before subscribing. fsnotify on macOS cannot
+	// watch a path that doesn't exist; if the friend hasn't created the
+	// secrets root yet we poll lightly until it appears.
+	if !w.waitForRoot(ctx, fsw) {
+		return nil
+	}
+
+	// Walk one level deep on startup so already-existing per-CLI dirs are
+	// also watched. New per-CLI dirs created later trigger an event on the
+	// root, at which point we add them dynamically below.
+	if err := w.watchExistingChildren(fsw); err != nil {
+		fmt.Fprintf(os.Stderr, "agentcookie source: secrets-bus watcher startup: %v\n", err)
+	}
+
+	debounceTimer := time.NewTimer(time.Hour)
+	debounceTimer.Stop()
+	defer debounceTimer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+
+		case ev, ok := <-fsw.Events:
+			if !ok {
+				return nil
+			}
+			// If a new per-CLI dir appeared at root, start watching it
+			// too so we pick up writes inside it on the same watcher.
+			if ev.Op&fsnotify.Create != 0 {
+				if info, statErr := os.Stat(ev.Name); statErr == nil && info.IsDir() && filepath.Dir(ev.Name) == w.root {
+					_ = fsw.Add(ev.Name)
+				}
+			}
+			// Reset the debounce timer on any event under the root.
+			if !debounceTimer.Stop() {
+				select {
+				case <-debounceTimer.C:
+				default:
+				}
+			}
+			debounceTimer.Reset(w.debounce)
+
+		case err, ok := <-fsw.Errors:
+			if !ok {
+				return nil
+			}
+			fmt.Fprintf(os.Stderr, "agentcookie source: secrets-bus watcher: fsnotify error: %v\n", err)
+
+		case <-debounceTimer.C:
+			w.mu.Lock()
+			w.fireCount++
+			w.mu.Unlock()
+			if w.onChange != nil {
+				w.onChange(ctx)
+			}
+		}
+	}
+}
+
+// FireCount returns the number of debounced callback invocations so far.
+// Test helper.
+func (w *Watcher) FireCount() int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.fireCount
+}
+
+// waitForRoot blocks until the secrets root exists or ctx is canceled.
+// Returns true if the root exists (and was added to the watcher), false if
+// ctx canceled first.
+func (w *Watcher) waitForRoot(ctx context.Context, fsw *fsnotify.Watcher) bool {
+	for {
+		if _, err := os.Stat(w.root); err == nil {
+			if err := fsw.Add(w.root); err == nil {
+				return true
+			}
+		}
+		// Watch the parent if it exists so a Create at the parent fires
+		// our re-attempt. The parent is ~/.agentcookie which is created
+		// at install time, but in fresh-machine tests it may also not
+		// exist yet, so fall back to a slow poll.
+		parent := filepath.Dir(w.root)
+		if _, perr := os.Stat(parent); perr == nil {
+			_ = fsw.Add(parent)
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(5 * time.Second):
+			// retry
+		}
+	}
+}
+
+// watchExistingChildren adds sub-dirs of the secrets root to the fsnotify
+// subscription so writes inside per-CLI dirs fire events. New per-CLI dirs
+// created later are added dynamically in Run's event loop.
+func (w *Watcher) watchExistingChildren(fsw *fsnotify.Watcher) error {
+	entries, err := os.ReadDir(w.root)
+	if err != nil {
+		return err
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		_ = fsw.Add(filepath.Join(w.root, e.Name()))
+	}
+	return nil
+}

--- a/internal/secretsbus/writer.go
+++ b/internal/secretsbus/writer.go
@@ -1,0 +1,176 @@
+package secretsbus
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/mvanhorn/agentcookie/internal/keystore"
+)
+
+// WriteResult is the per-write outcome the sink uses for logging and
+// sink-state reporting.
+type WriteResult struct {
+	// CLIsWritten is the number of per-CLI directories that received
+	// at least one file write (env or sealed twin).
+	CLIsWritten int
+	// KeysWritten is the total count of KEY=VALUE pairs persisted
+	// across all CLIs.
+	KeysWritten int
+	// SealedWritten is the number of `secrets.env.sealed` files written
+	// (zero when sealing is disabled or the master key is absent).
+	SealedWritten int
+	// PlaintextWritten is the number of `secrets.env` files written.
+	PlaintextWritten int
+}
+
+// WritePayload persists the source-shipped secrets to disk under
+// ~/.agentcookie/secrets/. Atomic write semantics: write to a sibling
+// `.tmp` file, fsync, rename over the target. Every file is mode 0600.
+//
+// When sealing is requested AND the v0.12 master key is available in the
+// Keychain, each per-CLI dataset is also written as `secrets.env.sealed`
+// (the existing v0.12 sealed-envelope shape from internal/keystore).
+//
+// payload is the map carried in the wire envelope (envelope.Secrets).
+// A nil or empty payload is a no-op and returns a zero WriteResult.
+//
+// Sealing policy decisions:
+//   - `sealingEnabled = false` (the v0.12 default): writes only plaintext
+//     `secrets.env`. No sealed twin.
+//   - `sealingEnabled = true` AND master key present: writes sealed twin
+//     alongside the plaintext (mirrors v0.12 cookies-sidecar behavior).
+//   - `sealingEnabled = true` AND master key MISSING: writes plaintext only
+//     and returns a non-fatal error so the sink can log without failing
+//     the whole /sync.
+func WritePayload(homeDir string, payload map[string]map[string]string, sealingEnabled bool) (WriteResult, []error) {
+	var result WriteResult
+	var errs []error
+	if len(payload) == 0 {
+		return result, nil
+	}
+
+	root := SecretsRoot(homeDir)
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		return result, []error{fmt.Errorf("mkdir secrets root %s: %w", root, err)}
+	}
+
+	var masterKey []byte
+	if sealingEnabled {
+		mk, err := keystore.ReadMasterKey()
+		if err != nil {
+			errs = append(errs, fmt.Errorf("sealing requested but master key unavailable: %w; writing plaintext only", err))
+		} else {
+			masterKey = mk
+		}
+	}
+
+	for cliName, kv := range payload {
+		if !validCLIName(cliName) {
+			errs = append(errs, fmt.Errorf("refusing to write cli with invalid name %q (path traversal protection)", cliName))
+			continue
+		}
+		// Filter out malformed keys defensively. The source should have
+		// done this, but the sink does NOT trust the wire payload.
+		safe := map[string]string{}
+		for k, v := range kv {
+			if !validKeyName(k) {
+				errs = append(errs, fmt.Errorf("%s: dropping invalid key name %q", cliName, k))
+				continue
+			}
+			safe[k] = v
+		}
+		if len(safe) == 0 {
+			continue
+		}
+
+		cliDir := filepath.Join(root, cliName)
+		if err := os.MkdirAll(cliDir, 0o700); err != nil {
+			errs = append(errs, fmt.Errorf("%s: mkdir: %w", cliName, err))
+			continue
+		}
+
+		// Plaintext env file.
+		envBytes := renderEnvFile(safe)
+		envPath := filepath.Join(cliDir, "secrets.env")
+		if err := atomicWrite(envPath, envBytes, 0o600); err != nil {
+			errs = append(errs, fmt.Errorf("%s: write secrets.env: %w", cliName, err))
+			continue
+		}
+		result.PlaintextWritten++
+
+		// Sealed twin, when configured.
+		if masterKey != nil {
+			sealed, err := keystore.Seal(masterKey, envBytes)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("%s: seal: %w", cliName, err))
+			} else {
+				sealedPath := filepath.Join(cliDir, "secrets.env.sealed")
+				if werr := atomicWrite(sealedPath, sealed, 0o600); werr != nil {
+					errs = append(errs, fmt.Errorf("%s: write secrets.env.sealed: %w", cliName, werr))
+				} else {
+					result.SealedWritten++
+				}
+			}
+		}
+
+		result.CLIsWritten++
+		result.KeysWritten += len(safe)
+	}
+	return result, errs
+}
+
+// renderEnvFile produces the canonical secrets.env content for a map.
+// Keys are sorted for deterministic output (helps tests and avoids
+// noisy diffs on inspection). Values are written as-is, no quoting:
+// the v1 spec accepts unquoted values for any string that doesn't need
+// escape semantics, which is the common case for OAuth tokens, hex
+// API keys, and base64-encoded payloads.
+func renderEnvFile(kv map[string]string) []byte {
+	keys := make([]string, 0, len(kv))
+	for k := range kv {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	b.WriteString("# Written by agentcookie sink. See docs/spec-agentcookie-secrets-bus-v1.md for format.\n")
+	b.WriteString("# Do not hand-edit while a sync is in progress: the next sync overwrites this file.\n")
+	for _, k := range keys {
+		b.WriteString(k)
+		b.WriteString("=")
+		b.WriteString(kv[k])
+		b.WriteString("\n")
+	}
+	return []byte(b.String())
+}
+
+// atomicWrite writes data to path via a sibling .tmp + fsync + rename
+// so a crashed write never leaves a partial file at the canonical path.
+func atomicWrite(path string, data []byte, mode os.FileMode) error {
+	tmp := path + ".tmp"
+	f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	return nil
+}

--- a/internal/secretsbus/writer_test.go
+++ b/internal/secretsbus/writer_test.go
@@ -1,0 +1,173 @@
+package secretsbus
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWritePayload_HappyPath(t *testing.T) {
+	home := t.TempDir()
+	payload := map[string]map[string]string{
+		"demo-cli": {"KEY1": "value1", "KEY2": "value2"},
+	}
+	result, errs := WritePayload(home, payload, false)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if result.CLIsWritten != 1 || result.KeysWritten != 2 || result.PlaintextWritten != 1 || result.SealedWritten != 0 {
+		t.Errorf("result mismatch: %+v", result)
+	}
+	envPath := filepath.Join(SecretsRoot(home), "demo-cli", "secrets.env")
+	info, err := os.Stat(envPath)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("expected mode 0600, got %v", info.Mode().Perm())
+	}
+	content, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(content), "KEY1=value1") || !strings.Contains(string(content), "KEY2=value2") {
+		t.Errorf("content mismatch: %s", string(content))
+	}
+}
+
+func TestWritePayload_EmptyPayloadIsNoOp(t *testing.T) {
+	home := t.TempDir()
+	result, errs := WritePayload(home, nil, false)
+	if len(errs) > 0 || result.CLIsWritten != 0 {
+		t.Errorf("nil payload should be no-op, got %+v %v", result, errs)
+	}
+	result, errs = WritePayload(home, map[string]map[string]string{}, false)
+	if len(errs) > 0 || result.CLIsWritten != 0 {
+		t.Errorf("empty payload should be no-op, got %+v %v", result, errs)
+	}
+	// Root should not exist on no-op
+	if _, err := os.Stat(SecretsRoot(home)); err == nil {
+		t.Errorf("no-op should not create the secrets root")
+	}
+}
+
+func TestWritePayload_RejectsInvalidCLIName(t *testing.T) {
+	home := t.TempDir()
+	payload := map[string]map[string]string{
+		"../etc/passwd": {"X": "Y"},
+		"good-cli":      {"GOOD": "VAL"},
+	}
+	result, errs := WritePayload(home, payload, false)
+	if result.CLIsWritten != 1 {
+		t.Errorf("expected 1 good cli to land, got %d (errs=%v)", result.CLIsWritten, errs)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".agentcookie", "secrets", "good-cli", "secrets.env")); err != nil {
+		t.Errorf("good cli should be written: %v", err)
+	}
+	// Confirm the traversal path was not created.
+	if _, err := os.Stat("/etc/passwd.agentcookie-test"); err == nil {
+		t.Errorf("path traversal should have been blocked")
+	}
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e.Error(), "invalid name") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected invalid-name error, got: %v", errs)
+	}
+}
+
+func TestWritePayload_RejectsInvalidKeyNames(t *testing.T) {
+	home := t.TempDir()
+	payload := map[string]map[string]string{
+		"demo-cli": {
+			"GOOD_KEY":   "value",
+			"123starts":  "rejected",
+			"has spaces": "rejected",
+			"has-hyphen": "rejected",
+		},
+	}
+	result, errs := WritePayload(home, payload, false)
+	if result.KeysWritten != 1 {
+		t.Errorf("only GOOD_KEY should write; got %d (errs=%v)", result.KeysWritten, errs)
+	}
+	content, _ := os.ReadFile(filepath.Join(SecretsRoot(home), "demo-cli", "secrets.env"))
+	if strings.Contains(string(content), "123starts") || strings.Contains(string(content), "has-hyphen") || strings.Contains(string(content), "has spaces") {
+		t.Errorf("invalid keys leaked into output: %s", string(content))
+	}
+}
+
+func TestWritePayload_AtomicTmpCleanup(t *testing.T) {
+	home := t.TempDir()
+	payload := map[string]map[string]string{
+		"demo-cli": {"K": "V"},
+	}
+	_, errs := WritePayload(home, payload, false)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	// .tmp file should not survive the rename.
+	tmpGlob, _ := filepath.Glob(filepath.Join(SecretsRoot(home), "demo-cli", "*.tmp"))
+	if len(tmpGlob) > 0 {
+		t.Errorf(".tmp files left behind: %v", tmpGlob)
+	}
+}
+
+func TestWritePayload_SealingRequested_MasterKeyMissing(t *testing.T) {
+	home := t.TempDir()
+	payload := map[string]map[string]string{
+		"demo-cli": {"K": "V"},
+	}
+	// Sealing requested but no master key in the keychain: should still
+	// write plaintext and produce a non-fatal error.
+	result, errs := WritePayload(home, payload, true)
+	if result.PlaintextWritten != 1 {
+		t.Errorf("plaintext should still write when master key missing, got %+v", result)
+	}
+	if result.SealedWritten != 0 {
+		t.Errorf("sealed should be 0 when master key missing, got %d", result.SealedWritten)
+	}
+	if len(errs) == 0 {
+		t.Errorf("expected a non-fatal error about missing master key")
+	}
+}
+
+func TestRenderEnvFile_SortedDeterministic(t *testing.T) {
+	out := string(renderEnvFile(map[string]string{
+		"Z": "1",
+		"A": "2",
+		"M": "3",
+	}))
+	// Strip the header comments to check just the key order.
+	lines := strings.Split(out, "\n")
+	var keyLines []string
+	for _, l := range lines {
+		if l == "" || strings.HasPrefix(l, "#") {
+			continue
+		}
+		keyLines = append(keyLines, l)
+	}
+	if len(keyLines) != 3 || keyLines[0] != "A=2" || keyLines[1] != "M=3" || keyLines[2] != "Z=1" {
+		t.Errorf("expected sorted A,M,Z, got: %v", keyLines)
+	}
+}
+
+func TestAtomicWrite_BasicRoundTrip(t *testing.T) {
+	tmpdir := t.TempDir()
+	p := filepath.Join(tmpdir, "out.txt")
+	if err := atomicWrite(p, []byte("hello"), 0o600); err != nil {
+		t.Fatalf("atomicWrite: %v", err)
+	}
+	got, _ := os.ReadFile(p)
+	if string(got) != "hello" {
+		t.Errorf("content: %q", got)
+	}
+	info, _ := os.Stat(p)
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("mode: %v", info.Mode().Perm())
+	}
+}

--- a/pkg/agentcookiesecret/doc.go
+++ b/pkg/agentcookiesecret/doc.go
@@ -1,0 +1,28 @@
+// Package agentcookiesecret is the canonical Go reader for the
+// agentcookie secrets bus.
+//
+// A CLI that wants to pick up secrets from agentcookie does this at startup:
+//
+//	env, err := agentcookiesecret.Load("my-pp-cli")
+//	if err != nil {
+//	    // fall back to your existing config-file loading
+//	}
+//	token := env["MY_OAUTH_BEARER"]
+//
+// The library resolves values from the v1 secrets-bus format described in
+// docs/spec-agentcookie-secrets-bus-v1.md. The resolution priority chain is:
+//
+//  1. ~/.agentcookie/secrets/<cli>/secrets.env.sealed
+//     (when the agentcookie master key is available)
+//  2. ~/.agentcookie/secrets/<cli>/secrets.env
+//  3. Any caller-registered fallback file (via LoadWithFallback)
+//  4. Process environment variables
+//
+// Bus values take precedence over caller fallback and process env. This is
+// deliberate: if a key exists in the bus, the bus owns its value, and an
+// older env-var leak does not silently override.
+//
+// The library never writes. The bus is source-of-truth; the CLI is read-only
+// against it. Rotation, format changes, and sealing transitions are
+// agentcookie's responsibility.
+package agentcookiesecret

--- a/pkg/agentcookiesecret/load.go
+++ b/pkg/agentcookiesecret/load.go
@@ -1,0 +1,287 @@
+package agentcookiesecret
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/mvanhorn/agentcookie/internal/keystore"
+)
+
+// Source is where a particular key/value pair came from. Useful for
+// debug / verbose loggers; consumers usually ignore it.
+type Source int
+
+const (
+	SourceBusSealed Source = iota
+	SourceBusPlain
+	SourceFallback
+	SourceEnv
+)
+
+// LoadResult is the structured form of Load's return value. Most callers
+// just want the Env map, but library authors writing debug commands like
+// "agentcookie secret list" find the per-key source useful.
+type LoadResult struct {
+	// Env is the merged map. Callers typically destructure this.
+	Env map[string]string
+	// Sources records where each key was resolved from. Same keys as Env.
+	Sources map[string]Source
+}
+
+// ErrInvalidCLIName is returned when the cli-name argument does not
+// satisfy the v1 spec naming rules. Surfaced explicitly so callers can
+// distinguish "you passed a bad name" from "the bus has no entry for
+// this cli."
+var ErrInvalidCLIName = errors.New("agentcookiesecret: cli name violates v1 naming rules")
+
+// Load resolves secrets for the given CLI from the agentcookie bus and
+// returns them as a flat map. Equivalent to LoadWithFallback(cliName, "").
+//
+// Errors are returned for invalid cli-name and for unreadable sealed
+// files when the master key is required. Missing bus files are NOT
+// errors: Load falls through to process env and returns whatever env
+// variables match. Callers can distinguish "no bus entry, env-only" by
+// inspecting the result's Sources field.
+func Load(cliName string) (map[string]string, error) {
+	res, err := LoadDetailed(cliName, "")
+	if err != nil {
+		return nil, err
+	}
+	return res.Env, nil
+}
+
+// LoadWithFallback is like Load but consults a caller-supplied file path
+// before falling through to process env. Useful for CLIs migrating to the
+// bus while preserving compatibility with their existing config file
+// during the transition.
+//
+// The fallback file must be in the same KEY=VALUE format the bus uses.
+// Missing fallback files are silently ignored.
+func LoadWithFallback(cliName string, fallbackPath string) (map[string]string, error) {
+	res, err := LoadDetailed(cliName, fallbackPath)
+	if err != nil {
+		return nil, err
+	}
+	return res.Env, nil
+}
+
+// LoadDetailed returns the full LoadResult with per-key Sources, for
+// callers that need to know provenance.
+func LoadDetailed(cliName string, fallbackPath string) (*LoadResult, error) {
+	if !validCLIName(cliName) {
+		return nil, fmt.Errorf("%w: %q", ErrInvalidCLIName, cliName)
+	}
+
+	res := &LoadResult{
+		Env:     map[string]string{},
+		Sources: map[string]Source{},
+	}
+
+	// Lowest priority first; later layers overwrite. Process env -> fallback
+	// -> plaintext bus -> sealed bus. (Reading in that order, then the
+	// final value for each key is the highest-priority source seen.)
+
+	// 4. Process env (lowest priority).
+	for _, kv := range os.Environ() {
+		eq := strings.IndexByte(kv, '=')
+		if eq < 1 {
+			continue
+		}
+		k := kv[:eq]
+		v := kv[eq+1:]
+		// We don't have a list of "interesting" keys to pre-filter on.
+		// Callers usually want everything; if they didn't, they would
+		// not be using a env-shaped loader. Skip a few obviously-noisy
+		// shell-internal keys to avoid polluting the map.
+		switch k {
+		case "PWD", "OLDPWD", "SHLVL", "_":
+			continue
+		}
+		res.Env[k] = v
+		res.Sources[k] = SourceEnv
+	}
+
+	// 3. Fallback file, if requested.
+	if fallbackPath != "" {
+		if fb, err := readEnvFile(fallbackPath); err == nil {
+			for k, v := range fb {
+				res.Env[k] = v
+				res.Sources[k] = SourceFallback
+			}
+		}
+	}
+
+	// 2. Plaintext bus file.
+	home, _ := os.UserHomeDir()
+	plainPath := filepath.Join(home, ".agentcookie", "secrets", cliName, "secrets.env")
+	if plain, err := readEnvFile(plainPath); err == nil {
+		for k, v := range plain {
+			res.Env[k] = v
+			res.Sources[k] = SourceBusPlain
+		}
+	}
+
+	// 1. Sealed bus file (highest priority).
+	sealedPath := plainPath + ".sealed"
+	if _, err := os.Stat(sealedPath); err == nil {
+		masterKey, mkErr := keystore.ReadMasterKey()
+		if mkErr != nil {
+			// Sealed file present but no master key. Caller almost
+			// certainly wants to know about this; return the error.
+			return res, fmt.Errorf("read master key for sealed file at %s: %w", sealedPath, mkErr)
+		}
+		raw, err := os.ReadFile(sealedPath)
+		if err != nil {
+			return res, fmt.Errorf("read sealed file %s: %w", sealedPath, err)
+		}
+		plain, err := keystore.Unseal(masterKey, raw)
+		if err != nil {
+			return res, fmt.Errorf("unseal %s: %w", sealedPath, err)
+		}
+		parsed, err := parseEnvBytes(plain)
+		if err != nil {
+			return res, fmt.Errorf("parse unsealed %s: %w", sealedPath, err)
+		}
+		for k, v := range parsed {
+			res.Env[k] = v
+			res.Sources[k] = SourceBusSealed
+		}
+	}
+
+	return res, nil
+}
+
+// readEnvFile is a minimal v1-conformant .env parser. Mirrors the strict
+// subset documented in the spec so this package has zero non-stdlib
+// dependencies beyond keystore (which is needed only for sealed-file
+// unseal).
+func readEnvFile(path string) (map[string]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 256*1024)
+	return parseEnvScanner(scanner)
+}
+
+// parseEnvBytes parses a byte slice via the same scanner-based grammar
+// as readEnvFile. Used after sealed-file unseal returns plaintext bytes.
+func parseEnvBytes(data []byte) (map[string]string, error) {
+	scanner := bufio.NewScanner(strings.NewReader(string(data)))
+	scanner.Buffer(make([]byte, 0, 64*1024), 256*1024)
+	return parseEnvScanner(scanner)
+}
+
+func parseEnvScanner(scanner *bufio.Scanner) (map[string]string, error) {
+	out := map[string]string{}
+	lineNum := 0
+	var pending strings.Builder
+	var pendingKey string
+	inContinuation := false
+
+	for scanner.Scan() {
+		lineNum++
+		line := scanner.Text()
+
+		if inContinuation {
+			if strings.HasSuffix(line, "\\") {
+				pending.WriteString(line[:len(line)-1])
+				continue
+			}
+			pending.WriteString(line)
+			out[pendingKey] = stripQuotes(pending.String())
+			pending.Reset()
+			pendingKey = ""
+			inContinuation = false
+			continue
+		}
+
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		eq := strings.IndexByte(line, '=')
+		if eq < 0 {
+			return nil, fmt.Errorf("line %d: missing '=' (expected KEY=VALUE)", lineNum)
+		}
+		key := line[:eq]
+		if key != strings.TrimRight(key, " \t") || key != strings.TrimLeft(key, " \t") {
+			return nil, fmt.Errorf("line %d: whitespace around '=' is not allowed", lineNum)
+		}
+		if !validKeyName(key) {
+			return nil, fmt.Errorf("line %d: invalid key name %q", lineNum, key)
+		}
+		value := line[eq+1:]
+
+		if strings.HasSuffix(value, "\\") {
+			pending.WriteString(value[:len(value)-1])
+			pendingKey = key
+			inContinuation = true
+			continue
+		}
+		out[key] = stripQuotes(value)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan: %w", err)
+	}
+	if inContinuation {
+		return nil, fmt.Errorf("unterminated backslash continuation for key %q", pendingKey)
+	}
+	return out, nil
+}
+
+func stripQuotes(v string) string {
+	if len(v) >= 2 {
+		first, last := v[0], v[len(v)-1]
+		if (first == '"' && last == '"') || (first == '\'' && last == '\'') {
+			return v[1 : len(v)-1]
+		}
+	}
+	return v
+}
+
+func validCLIName(name string) bool {
+	if name == "" || len(name) > 64 {
+		return false
+	}
+	if name[0] == '-' || name[len(name)-1] == '-' {
+		return false
+	}
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= '0' && r <= '9':
+		case r == '-':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func validKeyName(k string) bool {
+	if k == "" {
+		return false
+	}
+	for i, r := range k {
+		isLetter := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')
+		isDigit := r >= '0' && r <= '9'
+		isUnder := r == '_'
+		if i == 0 {
+			if !(isLetter || isUnder) {
+				return false
+			}
+			continue
+		}
+		if !(isLetter || isDigit || isUnder) {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/agentcookiesecret/load_test.go
+++ b/pkg/agentcookiesecret/load_test.go
@@ -1,0 +1,175 @@
+package agentcookiesecret
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeFile is a t.Helper for tests; mkdir parents, write 0600.
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+func TestLoad_InvalidCLIName(t *testing.T) {
+	_, err := Load("Bad-Name")
+	if !errors.Is(err, ErrInvalidCLIName) {
+		t.Errorf("expected ErrInvalidCLIName, got: %v", err)
+	}
+	_, err = Load("../etc")
+	if !errors.Is(err, ErrInvalidCLIName) {
+		t.Errorf("expected ErrInvalidCLIName, got: %v", err)
+	}
+}
+
+func TestLoad_PlaintextBusOnly(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeFile(t, filepath.Join(home, ".agentcookie", "secrets", "demo-cli", "secrets.env"),
+		"FOO=from-bus\nBAR=also-bus\n")
+
+	env, err := Load("demo-cli")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if env["FOO"] != "from-bus" || env["BAR"] != "also-bus" {
+		t.Errorf("missing keys: %v", env)
+	}
+}
+
+func TestLoad_BusWinsOverEnv(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("OAUTH_BEARER", "from-env-stale")
+	writeFile(t, filepath.Join(home, ".agentcookie", "secrets", "demo-cli", "secrets.env"),
+		"OAUTH_BEARER=from-bus-fresh\n")
+
+	res, err := LoadDetailed("demo-cli", "")
+	if err != nil {
+		t.Fatalf("LoadDetailed: %v", err)
+	}
+	if res.Env["OAUTH_BEARER"] != "from-bus-fresh" {
+		t.Errorf("bus should win over env, got: %q", res.Env["OAUTH_BEARER"])
+	}
+	if res.Sources["OAUTH_BEARER"] != SourceBusPlain {
+		t.Errorf("source should be SourceBusPlain, got: %v", res.Sources["OAUTH_BEARER"])
+	}
+}
+
+func TestLoad_FallbackBetweenBusAndEnv(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("FROM_ENV_ONLY", "env-val")
+
+	fallbackPath := filepath.Join(home, "legacy-config.env")
+	writeFile(t, fallbackPath, "FROM_FALLBACK=fallback-val\nFROM_ENV_ONLY=fallback-overrides-env\n")
+
+	writeFile(t, filepath.Join(home, ".agentcookie", "secrets", "demo-cli", "secrets.env"),
+		"FROM_BUS=bus-val\nFROM_FALLBACK=bus-overrides-fallback\n")
+
+	res, err := LoadDetailed("demo-cli", fallbackPath)
+	if err != nil {
+		t.Fatalf("LoadDetailed: %v", err)
+	}
+	if res.Env["FROM_BUS"] != "bus-val" || res.Sources["FROM_BUS"] != SourceBusPlain {
+		t.Errorf("bus key wrong: %v / %v", res.Env["FROM_BUS"], res.Sources["FROM_BUS"])
+	}
+	if res.Env["FROM_FALLBACK"] != "bus-overrides-fallback" || res.Sources["FROM_FALLBACK"] != SourceBusPlain {
+		t.Errorf("bus should override fallback")
+	}
+	if res.Env["FROM_ENV_ONLY"] != "fallback-overrides-env" || res.Sources["FROM_ENV_ONLY"] != SourceFallback {
+		t.Errorf("fallback should override env when bus has no entry")
+	}
+}
+
+func TestLoad_NoBusEntryFallsThroughToEnv(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("STANDALONE_VAR", "shell-set")
+
+	res, err := LoadDetailed("nonexistent-cli", "")
+	if err != nil {
+		t.Fatalf("LoadDetailed: %v", err)
+	}
+	if res.Env["STANDALONE_VAR"] != "shell-set" {
+		t.Errorf("env should still come through when no bus entry")
+	}
+	if res.Sources["STANDALONE_VAR"] != SourceEnv {
+		t.Errorf("source should be SourceEnv")
+	}
+}
+
+func TestLoad_SealedFilePresentNoMasterKey(t *testing.T) {
+	// Place a sealed file (with arbitrary bytes; this test doesn't need
+	// real ciphertext, since ReadMasterKey will return ErrMasterKeyMissing
+	// first). We exercise the error path where sealed exists but master
+	// key is unavailable.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeFile(t, filepath.Join(home, ".agentcookie", "secrets", "demo-cli", "secrets.env.sealed"),
+		"opaque-sealed-bytes")
+
+	_, err := Load("demo-cli")
+	if err == nil {
+		t.Errorf("expected error when sealed file present but master key missing")
+	}
+	if !strings.Contains(err.Error(), "master key") {
+		t.Errorf("error should mention master key, got: %v", err)
+	}
+}
+
+func TestParseEnvScanner_QuotesStripped(t *testing.T) {
+	got, err := parseEnvBytes([]byte("A=\"hello world\"\nB='also quoted'\nC=plain\n"))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got["A"] != "hello world" || got["B"] != "also quoted" || got["C"] != "plain" {
+		t.Errorf("quote handling: %v", got)
+	}
+}
+
+func TestParseEnvScanner_BackslashContinuation(t *testing.T) {
+	got, err := parseEnvBytes([]byte("LONG=part1\\\npart2\n"))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got["LONG"] != "part1part2" {
+		t.Errorf("continuation: %q", got["LONG"])
+	}
+}
+
+func TestParseEnvScanner_RejectsWhitespaceAroundEquals(t *testing.T) {
+	_, err := parseEnvBytes([]byte("KEY = value\n"))
+	if err == nil {
+		t.Errorf("whitespace around = should reject")
+	}
+}
+
+func TestValidCLIName(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want bool
+	}{
+		{"foo", true},
+		{"foo-bar", true},
+		{"foo-pp-cli", true},
+		{"Foo", false},
+		{"foo_bar", false},
+		{"foo.bar", false},
+		{"-foo", false},
+		{"foo-", false},
+		{"", false},
+	} {
+		if got := validCLIName(tc.in); got != tc.want {
+			t.Errorf("validCLIName(%q): got %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds a standardized, runtime-agnostic format for per-CLI secrets/auth-tokens that ride alongside cookies in the existing source-to-sink push.

- Per-CLI directory at \`~/.agentcookie/secrets/<cli>/secrets.env\` (mode 0600)
- Optional sealed twin \`secrets.env.sealed\` under the v0.12 master key
- Optional \`manifest.toml\` for per-key sync overrides
- New \`agentcookie secret\` subcommand: list / get / set / rm / import-from / env
- New \`pkg/agentcookiesecret/\` Go reader library for in-process consumers
- Doctor check (now 11 categories) reports cli count, key count, sealed/plaintext/mixed mode

Includes worked example for \`gh\` via a 50-line bash shim proving the bus is consumable by non-PP CLIs.

## Implementation units

- U1: Audit of all 34 PP CLIs auth shapes -> \`docs/audits/2026-05-22-pp-cli-auth-inventory.md\`
- U2: Format specification v1 -> \`docs/spec-agentcookie-secrets-bus-v1.md\`
- U3: Source-side fsnotify watcher + push pipeline integration
- U4: Sink-side receive + write + sealed-optional twin
- U5: Public Go reader library at \`pkg/agentcookiesecret/\`
- U7: \`agentcookie secret\` CLI subcommand
- U8: Doctor coverage
- U9: \`examples/gh-shim/\` + \`docs/runbook-secrets-bus-gh-example.md\`
- U10: \`docs/runbook-secrets-bus-adoption.md\` - migration runbook for CLI authors
- U11: Changelog + this PR

Deferred to v0.13.1:
- U6: Python reader at \`clients/python/agentcookie_secret\`
- Three v1.1 spec gaps documented in U1 audit: multi-account namespacing, per-file local-only markers, device-bound-but-shippable third classification

## Test plan

- [x] \`go test -race ./...\` -> 379 passing in 25 packages
- [x] \`go vet ./...\` clean
- [x] \`make build\` succeeds
- [x] \`agentcookie secret env gh\` smoke test (bus -> stdout)
- [x] End-to-end shim test: bus value reached real \`gh\` binary via shim
- [x] \`agentcookie doctor\` reports new secrets-bus check
- [ ] Live source-to-sink dry-run with a bus payload (next step on Trevin's machine)