### PR TITLE
docs: README scope refresh for v0.13/v0.14 secrets-bus era

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # agentcookie
 
-Your agent runs on a Mac that isn't your daily driver. It needs to act as you on every site you're already logged into. agentcookie keeps your second Mac's sessions in sync with your first Mac's, continuously, encrypted over your Tailscale tailnet, with zero per-site auth ceremony.
+Your agent runs on a Mac that isn't your daily driver. It needs to act as you on every site you're already logged into and against every API you've already authenticated. agentcookie keeps your second Mac's session state (Chrome cookies, per-CLI bearer tokens, API keys, and the auth blobs your tools persist next to them) in sync with your first Mac's, continuously, encrypted over your Tailscale tailnet, with zero per-site auth ceremony.
 
-OpenClaw, Hermes, or any other agent runtime you point at the second Mac wakes up authenticated.
+OpenClaw, Hermes, or any other agent runtime you point at the second Mac wakes up authenticated, on the web and in the terminal.
 
 ## What it looks like
 
-You browse normally on your first Mac. agentcookie watches Chrome's Cookies file and ships the diff to your second Mac the moment anything changes. On the second Mac, an agent does its work:
+You browse normally on your first Mac. agentcookie watches Chrome's Cookies file (and a parallel per-CLI secrets bus) and ships the diff to your second Mac the moment anything changes. On the second Mac, an agent does its work:
 
 ```
 $ ssh second-mac 'instacart-pp-cli carts'
@@ -23,13 +23,13 @@ $ ssh second-mac 'table-reservation-goat-pp-cli goat "omakase" --location seattl
 { "results": [ { "name": "Omakase Dinner Series", "network": "tock", ... } ] }
 ```
 
-No `auth login`. No Keychain prompt. No paste-the-cookie ritual. The agent's sessions were already there when the request hit.
+No `auth login`. No Keychain prompt. No paste-the-cookie ritual. No re-entering API keys you already configured on your laptop. The agent's sessions were already there when the request hit.
 
-The same is true for browser-driving agents. Point them at the agentcookie-managed Chrome profile on the second Mac and your agent sees the same logged-in state you have on your laptop. Or skip Chrome entirely: read the plaintext cookies sidecar at `~/.agentcookie/cookies-plain.db` from any agent that knows cookies.
+The same is true for browser-driving agents. Point them at the agentcookie-managed Chrome profile on the second Mac and your agent sees the same logged-in state you have on your laptop. Or skip Chrome entirely: read the plaintext cookies sidecar at `~/.agentcookie/cookies-plain.db` from any agent that knows cookies, and the per-CLI secrets the same agent persisted under `~/.agentcookie/secrets/<cli>/secrets.env`.
 
 ## What this fixes
 
-Logging in twice. Once on your laptop, once again on the Mac your agent lives on. Per site. Forever.
+Logging in twice. Once on your laptop, once again on the Mac your agent lives on. Per site, per CLI, per API key. Forever.
 
 Tools that ship cookies between machines today assume a human is going to click "merge" or unlock a vault or open the destination browser. They were built for switching accounts between two laptops the same person uses. They weren't built for "the agent on the headless Mac mini needs my session in 30 seconds and there's nobody home."
 
@@ -41,19 +41,26 @@ agentcookie is the second pattern. One-way, continuous, unattended replication f
 laptop                                              second Mac
 ======                                              ==========
 
-Chrome cookies change
-  |
-  v
-agentcookie source --watch  (fsnotify on Chrome's Cookies SQLite)
-  |
-  | decrypt with Keychain key, filter against blocklist
-  v
+Chrome cookies change      secrets bus change
+(fsnotify on Cookies)      (fsnotify on ~/.agentcookie/
+  |                         secrets/<cli>/secrets.env,
+  |                         or autodiscovered via
+  |                         agentcookie.toml manifests)
+  |                                |
+  +--------------+-----------------+
+                 |
+                 v
+agentcookie source --watch  (decrypt Chrome with Keychain key,
+                             filter against blocklist, fold in
+                             secrets bus payload)
+                 |
+                 v
 +----- HTTPS over Tailscale (AES-256-GCM, replay-defended) -----+
                                                                 |
                                                                 v
                                               agentcookie sink (LaunchAgent)
                                                 |
-                                                | one of three delivery surfaces:
+                                                | one of three cookie delivery surfaces:
                                                 v
                                               1. Chrome's Cookies SQLite (re-encrypted for sink Keychain)
                                               2. Plaintext sidecar at ~/.agentcookie/cookies-plain.db
@@ -64,11 +71,17 @@ agentcookie source --watch  (fsnotify on Chrome's Cookies SQLite)
                                                    ebay       -> config.toml + cookies.json
                                                    pagliacci  -> config.toml + cookies.json
                                                    table-reservation-goat -> session.json
+
+                                              plus the secrets bus mirror:
+                                                ~/.agentcookie/secrets/<cli>/secrets.env  (mode 0600,
+                                                  optional sealed twin under the v0.12 master key)
 ```
 
-Three surfaces because different agents read cookies differently. A browser-driving agent uses surface 1 (or its own profile pointed at the sidecar). A CLI with a built-in adapter uses surface 3. A raw cookies consumer uses surface 2. The sink runs all three after every sync, so the agent picks what fits.
+Three cookie surfaces because different agents read cookies differently. A browser-driving agent uses surface 1 (or its own profile pointed at the sidecar). A CLI with a built-in adapter uses surface 3. A raw cookies consumer uses surface 2. The sink runs all three after every sync, so the agent picks what fits.
 
-New adapters are roughly 50 lines of Go and a `Register()` call; the runbook walks through it.
+Bearer tokens, API keys, and other per-CLI auth blobs ride the same encrypted push and land at `~/.agentcookie/secrets/<cli>/secrets.env` on the sink. CLIs read them via environment variables, the in-process `pkg/agentcookiesecret` Go library, or a project's own `agentcookie.toml` manifest (see the adoption standard below).
+
+New cookie adapters are roughly 50 lines of Go and a `Register()` call; the runbook walks through it. New secrets bus consumers usually require no agentcookie-side change at all: drop an `agentcookie.toml` next to your CLI and `agentcookie discover` finds it.
 
 ## Install
 
@@ -119,18 +132,24 @@ macOS only on both ends today. The source side reads Chrome on macOS via the Key
 Working:
 
 - Continuous laptop to second-Mac sync via fsnotify on Chrome's Cookies file, debounced, allowlist + blocklist filtered, AES-256-GCM over Tailscale.
-- Three delivery surfaces on the sink (Chrome SQLite, plaintext sidecar, per-CLI adapter session files).
-- Five built-in PP CLI adapters: instacart, airbnb, ebay, pagliacci, table-reservation-goat (OpenTable + Tock).
+- Three cookie delivery surfaces on the sink (Chrome SQLite, plaintext sidecar, per-CLI adapter session files).
+- Five built-in PP CLI cookie adapters: instacart, airbnb, ebay, pagliacci, table-reservation-goat (OpenTable + Tock).
+- Per-CLI secrets bus: bearer tokens, API keys, and `KEY=VALUE` auth blobs ride the same encrypted push and land at `~/.agentcookie/secrets/<cli>/secrets.env` (mode 0600) with an optional sealed twin.
+- `agentcookie secret list / get / set / rm / revoke / import-from / env` for managing the bus, and `pkg/agentcookiesecret` as an in-process Go reader library.
+- v2 adoption standard: drop an `agentcookie.toml` in your repo and `agentcookie discover` auto-detects it. Three integration tiers (explicit-manifest, pp-cli-derived auto-synthesized from `.printing-press.json`, and legacy v1 directories) coexist.
 - Tailnet-only listeners on both ends; pair endpoint rate-limited with a 64-bit code.
 - Persistent replay defense; per-peer pairing-derived keys.
 - Apple Developer ID signed binaries; per-binary `-T` Keychain ACL on Chrome Safe Storage.
 - Headless second-Mac install over SSH with no GUI clicks required.
-- `agentcookie doctor` reports binary signature, Tailscale, config, keystore, listener bind, sink/source state, sealing posture, adapter coverage, CDP injector health.
-- 330+ unit tests across 23 packages.
+- `agentcookie doctor` runs 11 health categories: binary signature, Tailscale, config, keystore, listener bind, sink/source state, sealing posture, adapter coverage, CDP injector health, and secrets bus coverage.
+- 449+ unit tests across 26 packages.
 
 Not yet:
 
-- More built-in adapters beyond the five above. Anything else uses the plaintext sidecar via `AGENTCOOKIE_PLAIN_COOKIES`.
+- More built-in cookie adapters beyond the five above. Anything else uses the plaintext sidecar via `AGENTCOOKIE_PLAIN_COOKIES`, or the secrets bus for non-cookie auth.
+- Python reader library at `clients/python/agentcookie_secret` (queued for v0.13.1; Go reader ships today).
+- Signature verification on adoption manifests (`signed_by` field reserved; v2.1).
+- `[secrets.command]` and `[secrets.keychain]` source kinds (reserved; v2.1).
 - `agentcookie pair --rotate` for live key rotation. Today: re-run `wizard install` on both sides.
 - One first-Mac, many second-Macs fan-out.
 - Linux and Windows on either side.
@@ -150,6 +169,10 @@ Not yet:
 | [v0.11 adapter runbook](docs/runbook-v0.11-adapter-cookie-push.md) | adapter mechanism + how to write your own |
 | [v0.12 security runbook](docs/runbook-v0.12-security-hardening.md) | sealed master key, tailnet-only listeners, rate-limited pairing |
 | [v0.12 codesign runbook](docs/runbook-v0.12-codesign.md) | Developer ID signing, notarization, CI secrets, renewal |
+| [Secrets bus v1 spec](docs/spec-agentcookie-secrets-bus-v1.md) | wire format and on-disk layout for non-cookie auth |
+| [Secrets bus v2 adoption spec](docs/spec-agentcookie-secrets-bus-v2-adoption.md) | `agentcookie.toml` manifest format and discovery rules |
+| [Secrets bus adoption runbook](docs/runbook-secrets-bus-adoption.md) | migrating a CLI from imperative `secret import-from` to manifest-driven sync |
+| [gh shim worked example](docs/runbook-secrets-bus-gh-example.md) | 50-line bash shim consuming the bus from a non-PP CLI |
 | [Install skill](skill/SKILL.md) | Claude Code skill so an agent can drive the install |
 
 ## License

--- a/docs/plans/2026-05-23-001-feat-readme-scope-refresh-plan.md
+++ b/docs/plans/2026-05-23-001-feat-readme-scope-refresh-plan.md
@@ -1,0 +1,168 @@
+---
+title: "feat: README scope refresh for v0.13/v0.14 secrets-bus era"
+status: active
+type: feat
+created: 2026-05-23
+---
+
+# feat: README scope refresh for v0.13/v0.14 secrets-bus era
+
+## Problem Frame
+
+The current `README.md` was last rewritten on 2026-05-22 (PR #59) as a marketing-shaped pass. Two big PRs landed the same day that materially widened agentcookie's scope:
+
+- v0.13.0-beta.1 (#61) shipped the secrets bus: per-CLI `secrets.env` files riding alongside the cookie sync, a new `agentcookie secret` subcommand, a Go reader library at `pkg/agentcookiesecret`, an updated doctor (11 categories), and the v1 format spec.
+- v0.14.0-beta.1 (#62) shipped the adoption standard: `agentcookie.toml` manifests, auto-discovery via `agentcookie discover`, three integration tiers (explicit-manifest / pp-cli-derived / legacy-v1), and the author-side helper at `pkg/agentcookieadoption`.
+
+The README still describes agentcookie as a cookie-sync tool. The product is now session-state sync: cookies AND the bearer tokens / API keys / per-CLI auth blobs that ride next to them. A first-time reader landing on the repo today gets an incomplete picture of what gets replicated and what they get for free when they install it.
+
+Refresh the framing to cover session state (cookies + secrets), keep the cookie story dominant since that is still the headline value, and slot the secrets bus + adoption standard in as features. Don't over-rotate the doc around the new work — most of agentcookie is still the cookie sync engine.
+
+## Scope
+
+In scope:
+- `README.md` only.
+- Widen the intro framing from "cookies sync" to "session state sync (cookies + secrets)".
+- Slot the secrets bus and adoption standard into the existing structure (How it works, Working list, Documentation table) without restructuring the doc.
+- Update outdated numbers (test count, package count, doctor categories).
+- Add documentation table rows for the v0.13/v0.14 specs and runbooks.
+
+Out of scope:
+- No changes to `docs/quickstart.md`, `docs/quickstart-beta.md`, or any runbook.
+- No new marketing pass on the whole doc; existing tone and structure stay.
+- No expansion of the "How it works" ASCII diagram into a multi-panel diagram — keep it scannable.
+
+### Deferred to Follow-Up Work
+
+- Quickstart-level walkthrough of the secrets bus from a user's perspective (currently lives in `docs/runbook-secrets-bus-adoption.md`; pulling it forward into the main quickstart is a separate doc task).
+- Top-level project description on GitHub (the `gh repo edit --description` text) — refresh after the README lands.
+
+## Requirements
+
+- R1: A reader who has never seen agentcookie understands within the first paragraph that it syncs both cookies and per-CLI secrets, not just cookies.
+- R2: The secrets bus and adoption standard each appear at least once in the "Working" status list as concrete features.
+- R3: The "How it works" section acknowledges that the source ships secrets bus payloads alongside cookies in the same envelope, without redrawing the diagram from scratch.
+- R4: The "Documentation" table cites the v1 secrets-bus spec, v2 adoption-standard spec, the adoption runbook, and the gh-shim worked example.
+- R5: Numeric claims match reality at HEAD: `449+` tests across `26` packages, `11` doctor categories.
+- R6: The cookie sync remains the visible headline — the install commands, the "What it looks like" examples, and the diagram stay cookie-centric; secrets get integrated into the surrounding context rather than taking over the page.
+
+## Key Technical Decisions
+
+- **Refresh in place, do not rewrite.** The README was rewritten 2 days ago; structure and tone are still good. Touch only the sections where v0.13/v0.14 changed the picture.
+- **One "What it looks like" example stays, no secrets-bus example added.** The cookie examples (instacart carts, ebay auctions, table reservations) carry the headline because they're the user-visible payoff. Adding a `secrets.env` shell example would shift weight to the new feature. Mention secrets in the framing sentence right above or below the code block instead.
+- **Extend the existing diagram, don't redraw.** The current ASCII diagram has the laptop -> tailnet -> sink shape. Add a second short arrow / line acknowledging the secrets bus rides the same envelope. No second diagram.
+- **Working/Not yet are the right home for feature mentions.** This is where readers scan for "what does this actually do." That section gets the bulk of the secrets-bus content.
+
+## Implementation Units
+
+### U1. Reframe the intro
+
+**Goal:** Widen the opening from "sessions" (currently shorthand for cookies) to "session state" — explicitly cookies + secrets — so a first-time reader gets the right mental model in the first scroll.
+
+**Requirements:** R1, R6.
+
+**Dependencies:** None.
+
+**Files:** `README.md` (lines 1-6, and the "What it looks like" framing prose at lines 9 and 26-28).
+
+**Approach:**
+- Replace "keeps your second Mac's sessions in sync" with phrasing that names both cookies and per-CLI secrets (e.g., "keeps your second Mac's session state — cookies, bearer tokens, per-CLI auth blobs — in sync").
+- Keep the "OpenClaw, Hermes, or any other agent runtime" sentence as-is.
+- In the "What it looks like" intro sentence (currently "watches Chrome's Cookies file and ships the diff"), add a clause that the per-CLI secrets bus rides the same channel — one clause, not a paragraph.
+- Do not change the three example commands. They carry the headline.
+
+**Patterns to follow:** The voice of the existing intro (concrete, second-person, no jargon). Preserve sentence-level rhythm.
+
+**Test scenarios:**
+- Test expectation: none -- README copy verified by reading rendered output against R1 and R6.
+
+**Verification:** A reader who knows nothing about v0.13/v0.14 should be able to answer "does this replicate API keys too, or just browser cookies?" from the first paragraph alone.
+
+---
+
+### U2. Extend "How it works" to acknowledge the secrets bus
+
+**Goal:** Make the architecture section honest about what crosses the wire without redrawing the diagram.
+
+**Requirements:** R3, R6.
+
+**Dependencies:** U1 (intro framing sets up the reader for the diagram update).
+
+**Files:** `README.md` (lines 38-71).
+
+**Approach:**
+- Add a short stanza to the source side of the ASCII diagram noting `secrets bus (~/.agentcookie/secrets/<cli>/secrets.env)` as a second watched surface feeding into the same encrypted push. Keep the diagram under ~30 lines total.
+- Below the diagram, the "Three surfaces because different agents read cookies differently" paragraph stays but gets a follow-up sentence: per-CLI auth tokens land at `~/.agentcookie/secrets/<cli>/secrets.env` on the sink (mode 0600), and CLIs read them via env vars or the `pkg/agentcookiesecret` Go library.
+- Do not introduce a fourth "delivery surface" — secrets are a parallel track, not a fourth cookie sink.
+
+**Patterns to follow:** Existing ASCII conventions (column layout, arrow style). Match the casing and spacing.
+
+**Test scenarios:**
+- Test expectation: none -- diagram + prose verified against `CHANGELOG.md` v0.13/v0.14 entries and `docs/spec-agentcookie-secrets-bus-v1.md`.
+
+**Verification:** The diagram still fits on one screen. A reader can trace cookie flow and secret flow without re-reading.
+
+---
+
+### U3. Refresh the "Working" / "Not yet" status lists
+
+**Goal:** Make the at-a-glance feature list reflect what shipped yesterday.
+
+**Requirements:** R2, R5.
+
+**Dependencies:** None (independent of U1/U2 prose changes).
+
+**Files:** `README.md` (lines 115-138).
+
+**Approach:**
+- Update the test/package counts to `449+ unit tests across 26 packages`.
+- Mention `agentcookie doctor` now reporting 11 categories (currently the line lists what doctor checks; add secrets-bus health to it).
+- Add Working-list bullets for: secrets bus delivery (per-CLI `secrets.env` files, sealed-optional twin, mode 0600); the `agentcookie secret` and `agentcookie discover` subcommands; the v2 adoption standard with three integration tiers.
+- Adjust "Not yet" if anything previously listed is now shipped. The current "Not yet" list (more adapters, `pair --rotate`, fan-out, Linux/Windows, at-rest sealing default) is still accurate; verify before editing.
+- Keep the section terse — one line per bullet.
+
+**Patterns to follow:** Existing bullet voice (verb-first, no marketing fluff). The current list is the template.
+
+**Test scenarios:**
+- Test expectation: none -- numbers cross-checked via `go test ./... 2>&1 | tail -3` and `find . -name '*_test.go' | wc -l`; subcommand list verified against `internal/cli/`.
+
+**Verification:** Every claim in the Working list maps to a feature that ships in `cmd/agentcookie` at HEAD.
+
+---
+
+### U4. Refresh the Documentation table
+
+**Goal:** Surface the new specs and runbooks so a reader scanning the table can find the secrets-bus material.
+
+**Requirements:** R4.
+
+**Dependencies:** None.
+
+**Files:** `README.md` (lines 140-153).
+
+**Approach:**
+- Add four rows for: `docs/spec-agentcookie-secrets-bus-v1.md` (v1 format spec), `docs/spec-agentcookie-secrets-bus-v2-adoption.md` (adoption standard), `docs/runbook-secrets-bus-adoption.md` (migration runbook), and `docs/runbook-secrets-bus-gh-example.md` (gh-shim worked example).
+- Keep existing rows. Order new rows after the v0.12 runbook rows so the table reads roughly version-chronological.
+- Optional: add a row for `examples/gh-shim/` if it reads naturally; skip if it doesn't fit the "doc / use" framing.
+
+**Patterns to follow:** Existing two-column markdown table format. Path-as-link in column 1, short use-case phrase in column 2.
+
+**Test scenarios:**
+- Test expectation: none -- paths verified by `ls docs/`.
+
+**Verification:** Every new row's path resolves to a file at HEAD.
+
+## Scope Boundaries
+
+- Touch only `README.md`. No edits to `docs/`, `CHANGELOG.md`, or `skill/SKILL.md`.
+- No structural reorganization of the README. Sections stay in their current order; only content within sections changes.
+- No removal of existing content unless it became factually false (numbers, missing subcommands).
+- The "Install" and "Verify it's working" sections do not change — install flow is identical, and `verify-adapters` output still represents the cookie path which remains the headline.
+
+## Verification
+
+For the plan as a whole:
+- Render the updated README locally (or via `gh repo view --web` after pushing a branch) and read it cold from top to bottom.
+- Confirm R1-R6 are each satisfiable by a specific passage.
+- Confirm the cookie sync remains the dominant story by word-count and example-count — the secrets bus is mentioned, not featured.
+- Cross-check every numeric claim against the live build (test count, package count, doctor categories).


### PR DESCRIPTION
## Summary

The README was rewritten on 2026-05-22 (#59) as a marketing-shaped pass for the cookie-sync product. v0.13.0-beta.1 (#61, secrets bus) and v0.14.0-beta.1 (#62, adoption standard) landed the same day and meaningfully widened scope to cookies + per-CLI secrets. This refresh updates the framing without restructuring the doc.

Cookie sync stays the visible headline. The secrets bus and v2 adoption standard are slotted in as features, not the lede.

## What changed

- Intro paragraph now names cookies, bearer tokens, API keys, and per-CLI auth blobs as the synced surface.
- "What it looks like" examples are unchanged (still cookie-driven CLI flows); one prose sentence above and one below the code block acknowledge the secrets bus.
- "How it works" ASCII diagram gains a parallel source-side lane for the secrets bus; a follow-up paragraph describes the per-CLI `secrets.env` mirror on the sink and how CLIs read it.
- "Working" status list adds bullets for: bus delivery, the `agentcookie secret` subcommand surface, the `agentcookie discover` subcommand, and the v2 adoption standard with three integration tiers.
- "Not yet" updated with the Python reader, signature verification, and additional v2.1 source kinds.
- Numeric claims refreshed: 449+ tests across 26 packages; 11 doctor categories.
- Documentation table adds four rows for the v1 spec, v2 adoption spec, adoption runbook, and gh-shim worked example.

## Plan

`docs/plans/2026-05-23-001-feat-readme-scope-refresh-plan.md` is included in this PR.

## Test plan

- [ ] Read the rendered README on the PR page top to bottom; confirm a first-time reader gets the broader scope from the first paragraph alone.
- [ ] Verify cookie sync remains the dominant story by example count and section weight (secrets bus is mentioned, not featured).
- [ ] Spot-check the four new documentation table rows resolve to files.
- [ ] Cross-check `449+ tests across 26 packages` and `11 doctor categories` against HEAD (`go test ./...`, `internal/cli/doctor.go`).