### PR TITLE
docs: reframe PP CLI coverage as broad, not five-CLI-bound

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Working:
 
 - Continuous laptop to second-Mac sync via fsnotify on Chrome's Cookies file, debounced, allowlist + blocklist filtered, AES-256-GCM over Tailscale.
 - Three cookie delivery surfaces on the sink (Chrome SQLite, plaintext sidecar, per-CLI adapter session files).
-- Zero-config drop-in cookie adapters for five PP CLIs (instacart, airbnb, ebay, pagliacci, table-reservation-goat with OpenTable + Tock) on top of the universal surfaces; any other cookie-consuming agent reads the plaintext sidecar, any other secrets-consuming CLI reads the bus.
+- Works with Printing Press CLIs like Stripe, Linear, Notion, Granola, Slack, Kalshi, ElevenLabs, Mercury, and dozens more: anything with a bearer token or API key reads the secrets bus, anything that reads cookies reads the plaintext sidecar. Five PP CLIs (instacart, airbnb, ebay, pagliacci, table-reservation-goat with OpenTable + Tock) additionally get a bespoke zero-config cookie adapter.
 - Per-CLI secrets bus: bearer tokens, API keys, and `KEY=VALUE` auth blobs ride the same encrypted push and land at `~/.agentcookie/secrets/<cli>/secrets.env` (mode 0600) with an optional sealed twin.
 - `agentcookie secret list / get / set / rm / revoke / import-from / env` for managing the bus, and `pkg/agentcookiesecret` as an in-process Go reader library.
 - v2 adoption standard: drop an `agentcookie.toml` in your repo and `agentcookie discover` auto-detects it. Three integration tiers (explicit-manifest, pp-cli-derived auto-synthesized from `.printing-press.json`, and legacy v1 directories) coexist.

--- a/web/lib/features.ts
+++ b/web/lib/features.ts
@@ -18,8 +18,8 @@ export const FEATURES: Feature[] = [
     body: "Chrome's SQLite re-encrypted for the sink keychain, plaintext sidecar at ~/.agentcookie/cookies-plain.db, or per-CLI adapter session files.",
   },
   {
-    title: "zero-config drop-in for five PP CLIs",
-    body: "instacart, airbnb, ebay, pagliacci, table-reservation-goat. anything else reads the universal surfaces above.",
+    title: "works with Printing Press CLIs like",
+    body: "Stripe, Linear, Notion, Granola, Slack, Kalshi, ElevenLabs, Mercury, and dozens more - anything with a bearer token or API key reads the secrets bus. Five (instacart, airbnb, ebay, pagliacci, table-reservation-goat) additionally get a bespoke cookie adapter.",
   },
   {
     title: "per-CLI secrets bus",


### PR DESCRIPTION
The prior copy made it sound like agentcookie only works with five Printing Press CLIs. It actually works with ~97 PP CLIs today (every one that reads a bearer token or API key, via the secrets bus shipped in v0.13/v0.14) plus the five that get a bespoke cookie adapter on top.

Touches both surfaces in lockstep:

- `web/lib/features.ts`: card title is now "works with Printing Press CLIs like" + a representative list (Stripe, Linear, Notion, Granola, Slack, Kalshi, ElevenLabs, Mercury). The five-adapter line stays as a follow-on, not the headline.
- `README.md` Working bullet: same shape - broad coverage first, five bespoke adapters second.

`page.test.tsx` asserts every `features.ts` entry renders, so the title change is exercised. All 7 tests pass; `pnpm build` clean.