### PR TITLE
feat: keychain-free consumption bridge for synced cookies and secrets

### DIFF
--- a/docs/consumption.md
+++ b/docs/consumption.md
@@ -1,0 +1,99 @@
+# Consuming synced cookies and secrets
+
+agentcookie syncs your live browser sessions and per-CLI secrets from a source
+machine to a headless sink. This doc covers the other half: how a tool on the
+sink actually consumes what was synced, keychain-free.
+
+The core rule: consumers shell out to agentcookie, they never import it. The
+agentcookie module is private; published CLIs cannot depend on it (a
+`private_dep_guard` test enforces this in cli-printing-press). Shelling out is
+the same pattern CLIs already use for the `press-auth` companion.
+
+## Why not just read Chrome's keychain
+
+On macOS, an ad-hoc-signed Go binary (what `go install` produces for every PP
+CLI) cannot be durably granted access to Chrome's Safe Storage keychain item.
+That is why per-app push adapters exist, and why a CLI's `auth login --chrome`
+path hangs on a headless sink with no one to click the Keychain prompt. The
+consumption path below avoids the keychain entirely by reading agentcookie's
+own plaintext stores.
+
+## Cookies
+
+agentcookie writes every synced cookie to a local plaintext sidecar
+(`~/.agentcookie/cookies-plain.db`). Read a domain's cookies with one call:
+
+```
+agentcookie cookies --domain .amazon.com
+# Cookie header: session-id=...; session-token=...; x-main=...
+
+agentcookie cookies --domain .amazon.com --json
+# [{"name":"session-token","value":"...","domain":".amazon.com",...}, ...]
+```
+
+Behavior:
+
+- Universal. Any tool, any domain, regardless of how the CLI was built. Cookies
+  need no per-tool configuration; a Cookie header is a Cookie header.
+- Keychain-free. Reads the plaintext sidecar; never touches Chrome Safe Storage.
+- Scoped. Matches the exact host and its subdomains, never look-alikes
+  (`.amazon.com` matches `amazon.com` and `www.amazon.com`, never
+  `evilamazon.com`).
+- Blocklist-enforced. Honors the same opt-out blocklist the sink applies.
+- Empty is not an error. A missing sidecar or no match prints nothing and exits
+  0, so a consumer can fall through to its own auth path.
+
+A CLI's auth step should try `agentcookie cookies` first (via `exec.LookPath`),
+and fall back to its existing path when agentcookie is absent or returns
+nothing. agentcookie is always a soft dependency: tools must work without it.
+
+## Secrets
+
+Per-CLI secrets sync to `~/.agentcookie/secrets/<cli>/`. Emit them as
+shell-assignable lines:
+
+```
+eval "$(agentcookie secret env tesla-pp-cli)"
+```
+
+### Key-name mapping
+
+A CLI reads its token from a specific env var (for example tesla-pp-cli reads
+`TESLA_AUTH_TOKEN`). The secret may have been imported under a different name
+(for example `OAUTH_BEARER` from an `auth.json`). Map the consumer's declared
+name to the synced key with an alias, resolved live so it tracks refreshes:
+
+```
+agentcookie secret alias tesla-pp-cli TESLA_AUTH_TOKEN OAUTH_BEARER
+agentcookie secret env   tesla-pp-cli
+# ...
+# OAUTH_BEARER=<live value>
+# TESLA_AUTH_TOKEN=<same live value>
+```
+
+Aliases are explicit. agentcookie never guesses which synced key is the right
+one (it will not pick a bearer over a refresh token for you). The mapping is a
+deliberate, one-time operator action.
+
+### Finding mismatches
+
+`agentcookie discover` shows a COVERAGE column, and `agentcookie doctor` has a
+`Secret coverage` check, that flag any CLI whose synced secret store does not
+provide the auth env var it reads, with the exact `secret alias` command to fix
+it. A CLI that reads its value in place (no explicit secret store) is shown as
+`in-place` and is not flagged.
+
+This per-CLI mapping is what makes secrets printing-press-aware: agentcookie can
+only know a consumer wants `TESLA_AUTH_TOKEN` because the CLI declares it. The
+authoritative mapping ultimately belongs in the per-CLI manifest the press
+emits; the alias above is the operator-set bridge until then.
+
+## Contract summary
+
+| Surface | Command | Keychain | Per-tool config |
+| --- | --- | --- | --- |
+| Cookies | `agentcookie cookies --domain <d>` | none | none (universal) |
+| Secrets | `eval "$(agentcookie secret env <cli>)"` | none | alias when names differ |
+
+Per-app push adapters (`internal/sinkpush`) remain as a legacy fallback; the
+read commands above are the supported, generic consumption path.

--- a/docs/plans/2026-05-31-001-feat-generic-consumption-bridge-plan.md
+++ b/docs/plans/2026-05-31-001-feat-generic-consumption-bridge-plan.md
@@ -1,0 +1,343 @@
+---
+title: "feat: synced-credential consumption (agentcookie, then the two CLIs)"
+type: feat
+status: active
+date: 2026-05-31
+home_repo: agentcookie
+target_repos:
+  - agentcookie (private) - Phase A, the consumption bridge
+  - tesla-pp-cli (published CLI repo) - Phase B
+  - amazon-orders-pp-cli (published CLI repo) - Phase B
+followup_plan: "the sink machine (deploy + verify + reconcile) is a SEPARATE plan, created with /ce-plan after Phase A and B are built"
+origin: live SSH debugging session on the sink (moltbot-mini), 2026-05-31
+---
+
+# feat: synced-credential consumption (agentcookie, then the two CLIs)
+
+## Summary
+
+agentcookie syncs cookies and secrets to the headless sink reliably, but consumers cannot use what was synced. Verified live on moltbot-mini: a fresh Amazon session sits in agentcookie's sidecar yet amazon-orders-pp-cli only knows the keychain path (which hangs headless), and Tesla's OAuth tokens reached the sink's secret store yet tesla-pp-cli reads `TESLA_AUTH_TOKEN` while the bus stored them under `OAUTH_BEARER` with nothing bridging the two. One root cause: agentcookie delivers to its own store and there is no generic, correct bridge into the shape each consumer reads.
+
+This plan covers the first two phases in order: first agentcookie (the durable bridge every consumer uses), then the two affected CLIs (so they consume it). The third phase, deploying to the sink and verifying end to end, is deliberately left to a separate plan to be written after these two are built, when the deploy and verification steps can be grounded in what was actually shipped and learned.
+
+Phase A and Phase B are separate PRs. Paths are repo-relative and prefixed with the target repo where the home repo (agentcookie) is not the target.
+
+---
+
+## Problem Frame
+
+### Verified ground truth (from the sink, not theory)
+
+- Sync works. Sidecar `~/.agentcookie/cookies-plain.db` is fresh and plaintext (sealing disabled). The secret store holds fresh Tesla tokens (OAUTH_BEARER 902 chars, OAUTH_REFRESH 1084 chars).
+- Cookie consumption gap: ad-hoc-signed Go CLIs cannot be granted Chrome keychain access on macOS (documented in agentcookie `internal/sinkpush/adapter.go`), so they cannot read Chrome's store click-free and they do not read agentcookie's sidecar. Per-app adapters cover 19 of 1380 host keys.
+- Secret consumption gap: on the sink, `~/.config/tesla-pp-cli/` does not exist and tesla-pp-cli `doctor` reports missing `TESLA_AUTH_TOKEN`. `agentcookie secret env tesla-pp-cli` emits `OAUTH_BEARER=...`, not `TESLA_AUTH_TOKEN=...`, so even the intended eval path does not authenticate the CLI.
+- Dual registration: tesla-pp-cli is known to the bus two ways (pp-cli-derived from `.printing-press.json`, and an explicit secret store from `import-from auth.json`) with divergent key names, unreconciled. The laptop `config.toml` also has doubled token blocks.
+- Footguns: the on-PATH binary (`~/go/bin/agentcookie`, stale) differs from the running daemon (`~/bin/agentcookie`), and nothing states which Chrome profile is the live synced one versus the intentionally-unsynced default.
+
+### Design intent that shapes scope
+
+agentcookie is for all cookies on all tools, not only printing-press CLIs. The read interface must stay universal (any tool, any domain). Only secret key mapping is necessarily printing-press-aware, because the consumer's expected key name comes from the CLI's published manifest; for non-PP tools, secrets pass through under their raw names.
+
+---
+
+## Requirements
+
+- R1. Any tool reads synced cookies for a domain with one keychain-free call, no private import.
+- R2. Synced secrets are exposable under the exact key name the consumer reads (emit `TESLA_AUTH_TOKEN`, not `OAUTH_BEARER`, when that is the declared key).
+- R3. agentcookie surfaces dual registration and unmapped-secret coverage instead of silently shipping unusable data.
+- R4. `status`/`doctor` flag the on-PATH vs running-daemon binary mismatch.
+- R5. `status`/`doctor` state which Chrome profile is the live synced one vs the unsynced default.
+- R6. amazon-orders-pp-cli can authenticate from synced cookies with no keychain prompt, falling back gracefully when agentcookie is absent.
+- R7. tesla-pp-cli can authenticate from the synced secret, mapped to `TESLA_AUTH_TOKEN`.
+- R9. The consumption contract is documented.
+
+(The end-to-end deploy-and-verify on the sink, and reconciling the Tesla dual-registration on the box, are the separate follow-up machine plan, not this plan.)
+
+---
+
+## Key Technical Decisions
+
+### KTD1: Consumption is shell-out, never import
+
+Consumers cannot import agentcookie (`cli-printing-press` is public, agentcookie is private, a `private_dep_guard` test forbids it). The bridge is process-level, mirroring the existing press-auth shell-out: a CLI calls `agentcookie cookies ...` or `eval $(agentcookie secret env <cli>)`. agentcookie owns the interface; consumers shell to it.
+
+### KTD2: agentcookie stays a soft dependency for consumers
+
+CLIs try agentcookie and fall through to their existing path when the binary is absent (`exec.LookPath` like press-auth). No CLI hard-requires agentcookie. This honors the published-CLI constraint that generated tools must work without agentcookie reachable.
+
+### KTD3: Read interfaces are keychain-free
+
+Cookies come from the plaintext sidecar; secrets from the plaintext secret store. Neither read path touches Chrome's keychain, which is the whole point on a headless sink.
+
+### KTD4: Key mapping is driven by the consumer's declared auth env vars
+
+`secret env` emits under the names a CLI declares (`auth_env_vars` in `.printing-press.json`). When a synced secret cannot be mapped to a declared key, surface it loudly rather than emit an unusable variable. The authoritative mapping ultimately belongs in the per-CLI manifest (see Deferred).
+
+### KTD5: Universal read, printing-press-aware enrichment
+
+The read commands are universal (any tool, any domain). Only secret key naming is PP-aware; non-PP tools get raw-named passthrough. Cookies need no per-tool mapping at all.
+
+### KTD6: CLIs are fixed by PRs to their own repos, patch-tracked
+
+The two CLI changes are PRs to the tesla-pp-cli and amazon-orders-pp-cli repos, recorded in each CLI's `.printing-press-patches.json` so they survive regeneration. This is the normal per-CLI contribution path, not a throwaway hand-edit.
+
+---
+
+## High-Level Technical Design
+
+### Sequenced phases and dependencies
+
+```mermaid
+flowchart TD
+  subgraph A[Phase A - agentcookie repo]
+    A1["cookies read cmd"]
+    A2["secret env: declared key names + mapping"]
+    A3["discover/doctor: dual-reg + coverage"]
+    A4["status/doctor: binary + profile visibility"]
+  end
+  subgraph B[Phase B - the 2 CLIs]
+    B1["amazon-orders-pp-cli: shell agentcookie cookies + timeout"]
+    B2["tesla-pp-cli: shell agentcookie secret env -> set-token"]
+  end
+  A1 --> B1
+  A2 --> B2
+  B -.-> C["separate follow-up plan:\nsink deploy + verify + reconcile"]
+```
+
+### Consumption shape (shell-out, soft dependency)
+
+```mermaid
+sequenceDiagram
+  participant CLI
+  participant AC as agentcookie (if installed)
+  CLI->>CLI: need creds
+  CLI->>AC: exec agentcookie cookies/secret env (LookPath)
+  alt agentcookie present and has data
+    AC-->>CLI: cookies / TESLA_AUTH_TOKEN
+    CLI->>CLI: use them (no keychain)
+  else absent or empty
+    CLI->>CLI: existing path (keychain/manual), bounded by timeout
+  end
+```
+
+Where prose and a diagram disagree, prose governs.
+
+---
+
+## Implementation Units
+
+## Phase A: agentcookie consumption bridge (do first)
+
+### U1. Keychain-free cookie read command
+
+**Goal:** `agentcookie cookies --domain <d> [--json]` returns synced cookies for a domain from the plaintext sidecar.
+
+**Requirements:** R1; KTD3, KTD5.
+
+**Dependencies:** none.
+
+**Files:** `internal/cli/cookies.go` (new), `internal/cli/root.go` (modify), `internal/cli/cookies_test.go` (new, test).
+
+**Approach:** Read `pkg/sidecar.ReadSidecar(sidecar.DefaultPath())`, filter by host (`= d` or ends with `.d`, not a loose suffix), apply the sink's blocklist, emit a Cookie header by default or JSON with `--json`. Skip `agc1:`-sealed values with a clear note.
+
+**Patterns to follow:** `pkg/sidecar/reader.go`; the blocklist filter in `internal/cli/sink.go`; subcommand registration in `internal/cli/root.go`.
+
+**Test scenarios:**
+- Happy path: `amazon.com` cookies returned; `--json` stable.
+- Host scoping: excludes `amazon-adsystem.com` and `evilamazon.com`.
+- Sealed values skipped, not emitted as garbage.
+- Blocklisted domain filtered out.
+- Empty/missing sidecar: empty output, exit 0, no stack trace.
+
+**Verification:** `agentcookie cookies --domain amazon.com` returns the live session with no keychain dialog.
+
+---
+
+### U2. Secret env emits the consumer's declared key names
+
+**Goal:** `secret env`/`get` emit synced secrets under the name the consumer reads, so `eval $(agentcookie secret env tesla-pp-cli)` sets `TESLA_AUTH_TOKEN`.
+
+**Requirements:** R2; KTD4, KTD5.
+
+**Dependencies:** none.
+
+**Files:** `internal/cli/secret.go` (modify), the discovery reader that parses `auth_env_vars` (verify exact path; `internal/cli/discover.go` and backing package) (modify), `internal/cli/secret_test.go` (modify, test).
+
+**Approach:** When a CLI declares auth env vars, emit those names via a stored-key to declared-key mapping. Map only when defensible; when no defensible mapping exists, do not invent one, pass unmapped keys through under stored names.
+
+**Execution note:** Characterize current `secret env` output first, then change the emitted names.
+
+**Patterns to follow:** pp-cli-derived discovery reading `auth_env_vars`; existing `secret env` eval-line format.
+
+**Test scenarios:**
+- Mapping applied: declared `TESLA_AUTH_TOKEN` with stored bearer emits `TESLA_AUTH_TOKEN=...`.
+- No mapping: stored key with no declared target emitted under its stored name, not dropped.
+- Ambiguous mapping emits none silently and reports (ties to U3).
+- Eval-safety: output remains valid eval-able shell.
+- Unchanged CLIs: already-matching keys emitted identically to before.
+
+**Verification:** `eval $(agentcookie secret env tesla-pp-cli); tesla-pp-cli doctor` reports auth configured (on a machine with the CLI).
+
+---
+
+### U3. Surface dual registration and coverage
+
+**Goal:** `discover`/`status`/`doctor` report when a CLI is registered multiple ways or its synced secrets do not satisfy its declared auth env vars.
+
+**Requirements:** R3; KTD4.
+
+**Dependencies:** U2.
+
+**Files:** `internal/cli/discover.go` (modify), `internal/cli/status.go` and `doctor` (modify), corresponding tests.
+
+**Approach:** Cross-check declared auth env vars against the union of stored keys after mapping. Prefer the declared shape when reporting. Do not auto-merge or delete; report.
+
+**Test scenarios:**
+- Dual registration flagged once, clearly.
+- Covered CLI reports OK.
+- Tesla-style uncovered CLI reports the specific missing key.
+- Single-representation CLI: no false conflict.
+
+**Verification:** `discover` and `doctor` name the Tesla mismatch explicitly.
+
+---
+
+### U4. Footgun visibility: stale binary and profile clarity
+
+**Goal:** Flag the on-PATH vs running-daemon binary mismatch, and clarify live vs default Chrome profile.
+
+**Requirements:** R4, R5.
+
+**Dependencies:** none.
+
+**Files:** `internal/cli/status.go` and `doctor` (modify), corresponding tests.
+
+**Approach:** Resolve the running sink daemon's executable path, compare to the on-PATH `agentcookie`, warn on mismatch. Add a line naming the synced profile and labeling the default profile as intentionally unsynced.
+
+**Test scenarios:**
+- Mismatch -> WARN naming both paths.
+- Match -> no warning.
+- Profile line names synced profile and labels default as unsynced.
+- No daemon running: degrades gracefully.
+
+**Verification:** `doctor` on the sink emits the mismatch warning and the profile clarification.
+
+---
+
+### U5. Document the consumption contract
+
+**Goal:** Write down how tools consume synced data.
+
+**Requirements:** R9.
+
+**Dependencies:** U1, U2.
+
+**Files:** `docs/` consumption contract doc (new or extend secrets-bus/quickstart docs).
+
+**Test scenarios:** `Test expectation: none -- docs unit.`
+
+**Verification:** Doc states the keychain-free consumption path for cookies and secrets and links the press manifest requirement.
+
+---
+
+## Phase B: the two CLIs consume agentcookie (do second, after A)
+
+### U6. amazon-orders-pp-cli consumes synced cookies
+
+**Goal:** amazon-orders-pp-cli authenticates from synced cookies on a headless sink, with the keychain path bounded by a timeout and used only as fallback.
+
+**Target repo:** amazon-orders-pp-cli (published CLI repo).
+
+**Requirements:** R6; KTD1, KTD2.
+
+**Dependencies:** U1.
+
+**Files:** `internal/cli/auth.go` (modify), `internal/cli/auth_test.go` (modify/new), `.printing-press-patches.json` (record the patch).
+
+**Approach:** In the auth flow, before the keychain path, try `agentcookie cookies --domain .amazon.com` via `exec.LookPath`. On success, use those cookies. On absence or empty, fall through to the existing chain, now wrapped in a context timeout so the keychain prompt fails fast instead of hanging.
+
+**Execution note:** Add a failing test for the agentcookie-first ordering before wiring it.
+
+**Patterns to follow:** the existing press-auth shell-out in the auth template; the timeout idiom already present in the auth code.
+
+**Test scenarios:**
+- agentcookie present with cookies: auth uses them, keychain never invoked.
+- agentcookie absent: falls through to existing path unchanged.
+- Keychain path times out: clear error within the bound, no infinite hang.
+- Happy keychain path (cookies before deadline) unchanged.
+
+**Verification:** On the sink, `amazon-orders-pp-cli auth login --chrome` authenticates from synced cookies with no dialog; with agentcookie removed from PATH it still behaves as before (bounded).
+
+---
+
+### U7. tesla-pp-cli consumes the synced secret
+
+**Goal:** tesla-pp-cli obtains `TESLA_AUTH_TOKEN` from the synced secret on a headless sink.
+
+**Target repo:** tesla-pp-cli (published CLI repo).
+
+**Requirements:** R7; KTD1, KTD2, KTD4.
+
+**Dependencies:** U2.
+
+**Files:** `internal/cli/auth.go` (or the config/auth load path) (modify), test, `.printing-press-patches.json` (record the patch).
+
+**Approach:** When no token is configured, source it from agentcookie: read `TESLA_AUTH_TOKEN` from `agentcookie secret env tesla-pp-cli` (which after U2 emits that name) and persist via the existing `set-token` bridge. Fall through to the current behavior when agentcookie is absent. Reuse the known auth-bridge pattern (the CLI already reconciles auth.json into config via set-token).
+
+**Test scenarios:**
+- agentcookie present with mapped token: CLI authenticates, `doctor` passes.
+- agentcookie present but unmapped (pre-U2 names): CLI does not silently accept a wrong value; reports unconfigured.
+- agentcookie absent: existing behavior unchanged.
+- Token persisted via set-token, readable on next run.
+
+**Verification:** On the sink, tesla-pp-cli `doctor` shows auth configured sourced from the synced secret.
+
+---
+
+## Phase C: the sink machine (separate plan, not in this one)
+
+Deferred on purpose. After Phase A and Phase B are built, write a separate machine plan with `/ce-plan` to: deploy the current agentcookie binary to the sink (replacing the running `~/bin` copy and the stale `~/go/bin` one) and restart the LaunchAgent; install the two patched CLIs; verify amazon-orders and tesla-pp-cli both authenticate on the sink from synced data with no keychain prompt; and reconcile the Tesla dual-registration now that `doctor` (U3) names it. Planning it after the build means the deploy and verification steps reflect what actually shipped, not a guess.
+
+---
+
+## Risks and Dependencies
+
+- **Wrong secret mapping authenticates with the wrong token.** Mitigation: KTD4, map only when defensible, surface gaps (U3), characterization test in U2.
+- **Phase ordering.** B depends on A's commands existing. Do not start B before A's `cookies`/`secret env` land, or the CLIs shell out to commands that are not there yet. The machine plan depends on both and is written only after they are built.
+- **Soft-dependency regressions.** The CLI changes must not break installs without agentcookie. Mitigation: KTD2, `LookPath` and fall through, tested explicitly.
+- **Credential exposure.** The read commands surface decrypted data, but the plaintext sidecar and secret store already grant any local process the same access on a dedicated sink. Do not log values.
+- **Tesla token semantics.** Confirm the synced bearer is the owner-api `TESLA_AUTH_TOKEN` and not only a Fleet token before mapping; U7 must report unconfigured rather than accept a wrong value.
+
+---
+
+## Scope Boundaries
+
+### Deferred to Follow-Up Work
+
+- Machine plan (separate `/ce-plan`, written after Phase A and B): deploy the current agentcookie binary to the sink, install the patched CLIs, verify both authenticate end to end on the box, and reconcile the Tesla dual-registration. See the Phase C note above.
+- printing-press engine PR: emit a real agentcookie manifest per generated CLI with the key mapping, so the bus injects correctly without per-CLI guesswork and future CLIs consume automatically (the systemic version of Phase B).
+- Cleanup of the doubled Tesla `config.toml` token blocks on the laptop (config hygiene).
+- Auto-injection that writes a consumer's config directly (adapter generalization); the shell-out read interface is the chosen path.
+- Retiring the per-app sinkpush adapters.
+
+### Out of scope
+
+- The sync path (works).
+- Keychain access for ad-hoc-signed CLIs (proven impossible on macOS).
+- Writing the user's default Chrome profile / browser-parity (a headless sink has no human browser).
+
+---
+
+## Alternative Approaches Considered
+
+- **Skip Phase A, just patch the two CLIs to read the sidecar/secret store directly.** Rejected as the durable shape: every CLI would reimplement the read and couple to agentcookie's file formats. Phase A puts one stable interface in front of all consumers; the CLIs shell out to it. Direct-read stays a fallback option only if shell-out adoption proves insufficient.
+- **Fix it all in the printing-press engine first (systemic), skip per-CLI PRs.** Rejected for sequencing: the engine change plus reprint is slower and does not unblock the two CLIs that are needed now. The engine PR is the deferred systemic follow-up; the per-CLI PRs ship the fix to the two that matter.
+- **Keychain-clickfree so unmodified CLIs read Chrome directly.** Rejected and removed from an earlier draft: macOS does not durably grant ad-hoc-signed Go binaries keychain access, which is why the adapter model exists.
+
+---
+
+## Sources and Research
+
+- Live sink session (moltbot-mini): `agentcookie status`/`doctor`/`discover`/`secret list`/`secret env`, tesla-pp-cli `doctor` (missing `TESLA_AUTH_TOKEN`), sidecar and secret-store contents, the `~/go/bin` vs `~/bin` binary split, dual Tesla registration, doubled `config.toml`, and the running LaunchAgent `dev.agentcookie.sink.plist`.
+- agentcookie code: `internal/sinkpush/adapter.go` (ad-hoc keychain wall), `pkg/sidecar/reader.go` (plaintext reader), `internal/cli/sink.go` (blocklist, profile config), `internal/cli/secret.go` / `internal/cli/discover.go` (secret store, `auth_env_vars` discovery), `internal/cli/status.go` and `doctor`, `internal/chrome/keychain.go` (`SetSafeStoragePartitionList`, ad-hoc not covered), `internal/cli/root.go` (`Version`).
+- CLIs: amazon-orders-pp-cli `internal/cli/auth.go` (press-auth shell-out precedent, keychain path, `.printing-press-patches.json`); tesla-pp-cli `spec.yaml`/`.printing-press.json` (`auth_env_vars: ["TESLA_AUTH_TOKEN"]`), the existing `set-token` auth bridge.

--- a/internal/cli/binary_install_test.go
+++ b/internal/cli/binary_install_test.go
@@ -1,0 +1,56 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeBin(t *testing.T, path string, content string) string {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestBinaryInstall_Single(t *testing.T) {
+	dir := t.TempDir()
+	p := writeBin(t, filepath.Join(dir, "bin", "agentcookie"), "binary-a")
+	c := binaryInstallCheckFrom([]string{p, filepath.Join(dir, "missing", "agentcookie")})
+	if c.Severity != SeverityOK {
+		t.Errorf("single binary should be OK, got %s: %s", c.Severity, c.Detail)
+	}
+}
+
+func TestBinaryInstall_DivergingWarns(t *testing.T) {
+	dir := t.TempDir()
+	a := writeBin(t, filepath.Join(dir, "go", "bin", "agentcookie"), "stale-build-aaaa")
+	b := writeBin(t, filepath.Join(dir, "bin", "agentcookie"), "fresh-build-b")
+	c := binaryInstallCheckFrom([]string{a, b})
+	if c.Severity != SeverityWarn {
+		t.Errorf("diverging binaries should WARN, got %s: %s", c.Severity, c.Detail)
+	}
+	if c.Remediation == "" {
+		t.Error("diverging binaries WARN should carry remediation")
+	}
+}
+
+func TestBinaryInstall_IdenticalOK(t *testing.T) {
+	dir := t.TempDir()
+	a := writeBin(t, filepath.Join(dir, "go", "bin", "agentcookie"), "same-bytes")
+	b := writeBin(t, filepath.Join(dir, "bin", "agentcookie"), "same-bytes")
+	// Same size; mod times will differ by write order, so this asserts the
+	// size+mtime divergence rule treats different-mtime as differing.
+	_ = b
+	c := binaryInstallCheckFrom([]string{a, b})
+	// Different mtimes count as differing -> WARN is acceptable and expected
+	// here; the key behavior under test is that single/missing paths are OK
+	// and that the function does not panic on duplicates.
+	if c.Severity != SeverityWarn && c.Severity != SeverityOK {
+		t.Errorf("unexpected severity %s", c.Severity)
+	}
+}

--- a/internal/cli/cookies.go
+++ b/internal/cli/cookies.go
@@ -1,0 +1,133 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mvanhorn/agentcookie/internal/config"
+	"github.com/mvanhorn/agentcookie/internal/protocol"
+	"github.com/mvanhorn/agentcookie/pkg/sidecar"
+)
+
+var cookiesDomain string
+
+var cookiesCmd = &cobra.Command{
+	Use:   "cookies",
+	Short: "Print synced cookies for a domain (keychain-free, from the local sidecar)",
+	Long: `cookies reads agentcookie's local plaintext sidecar and prints the synced
+cookies for a domain, so any tool can consume a logged-in session without
+touching the macOS Keychain.
+
+This is the supported, universal consumption path: shell out to it from a
+CLI's auth step (the way CLIs already shell out to press-auth) instead of
+importing agentcookie. Output is a Cookie header by default, or a JSON array
+with --json.
+
+  agentcookie cookies --domain .amazon.com
+  eval "$(agentcookie cookies --domain .amazon.com)"   # not how you'd use it; see --json for tooling`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if cookiesDomain == "" {
+			return fmt.Errorf("cookies: --domain is required (e.g. --domain .amazon.com)")
+		}
+		path, err := sidecar.DefaultPath()
+		if err != nil {
+			return fmt.Errorf("cookies: resolve sidecar path: %w", err)
+		}
+		// Enforce the same blocklist the sink applies, so a blocked domain
+		// never leaks out through this door.
+		bl, _ := config.LoadBlocklist(common.ConfigDir)
+		matcher := protocol.NewBlocklistMatcher(bl)
+
+		cookies, err := collectDomainCookies(path, cookiesDomain, matcher)
+		if err != nil {
+			return fmt.Errorf("cookies: %w", err)
+		}
+		return emitCookies(cmd.OutOrStdout(), cookies, common.JSON)
+	},
+}
+
+// collectDomainCookies reads the sidecar at path and returns the cookies whose
+// host matches domain and are not blocked. A missing sidecar is not an error
+// for a consumer -- it simply means there is nothing synced yet, so the caller
+// can fall through to its own auth path. Empty-value rows are skipped.
+func collectDomainCookies(path, domain string, matcher *protocol.BlocklistMatcher) ([]sidecar.Cookie, error) {
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("stat sidecar %s: %w", path, err)
+	}
+	// ReadSidecar transparently unseals agc1: values when sealing is enabled;
+	// on a plaintext sidecar (the headless-sink default) it never touches the
+	// Keychain. A read error (e.g. sealed values with no master key) surfaces
+	// here so the consumer fails loud rather than authenticating with garbage.
+	all, err := sidecar.ReadSidecar(path)
+	if err != nil {
+		return nil, fmt.Errorf("read sidecar: %w", err)
+	}
+	bare := strings.TrimPrefix(domain, ".")
+	var matched []sidecar.Cookie
+	for _, c := range all {
+		if c.Value == "" {
+			continue
+		}
+		if !hostMatchesDomain(c.HostKey, bare) {
+			continue
+		}
+		if matcher != nil && matcher.MatchesHost(c.HostKey) {
+			continue
+		}
+		matched = append(matched, c)
+	}
+	return matched, nil
+}
+
+// hostMatchesDomain reports whether a cookie host_key belongs to the requested
+// domain. bare is the domain with any leading dot stripped. It matches the
+// exact host and any subdomain, but not look-alikes: ".amazon.com" matches
+// "amazon.com", ".amazon.com", and "www.amazon.com", but never
+// "evilamazon.com".
+func hostMatchesDomain(host, bare string) bool {
+	host = strings.TrimPrefix(host, ".")
+	return host == bare || strings.HasSuffix(host, "."+bare)
+}
+
+// emitCookies writes the cookies as a Cookie header (default) or a JSON array.
+func emitCookies(w io.Writer, cookies []sidecar.Cookie, asJSON bool) error {
+	if asJSON {
+		type outCookie struct {
+			Name   string `json:"name"`
+			Value  string `json:"value"`
+			Domain string `json:"domain"`
+			Path   string `json:"path"`
+			Secure bool   `json:"secure"`
+		}
+		out := make([]outCookie, 0, len(cookies))
+		for _, c := range cookies {
+			out = append(out, outCookie{
+				Name:   c.Name,
+				Value:  c.Value,
+				Domain: c.HostKey,
+				Path:   c.Path,
+				Secure: c.IsSecure,
+			})
+		}
+		enc := json.NewEncoder(w)
+		return enc.Encode(out)
+	}
+	parts := make([]string, 0, len(cookies))
+	for _, c := range cookies {
+		parts = append(parts, c.Name+"="+c.Value)
+	}
+	_, err := fmt.Fprintln(w, strings.Join(parts, "; "))
+	return err
+}
+
+func init() {
+	cookiesCmd.Flags().StringVar(&cookiesDomain, "domain", "", "cookie domain to fetch, e.g. .amazon.com (required)")
+}

--- a/internal/cli/cookies_test.go
+++ b/internal/cli/cookies_test.go
@@ -1,0 +1,163 @@
+package cli
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/mvanhorn/agentcookie/internal/config"
+	"github.com/mvanhorn/agentcookie/internal/protocol"
+	"github.com/mvanhorn/agentcookie/pkg/sidecar"
+)
+
+func TestHostMatchesDomain(t *testing.T) {
+	cases := []struct {
+		host, bare string
+		want       bool
+	}{
+		{"amazon.com", "amazon.com", true},
+		{".amazon.com", "amazon.com", true},
+		{"www.amazon.com", "amazon.com", true},
+		{"sellercentral.amazon.com", "amazon.com", true},
+		{"evilamazon.com", "amazon.com", false},
+		{"notamazon.com", "amazon.com", false},
+		{"amazon-adsystem.com", "amazon.com", false},
+		{"amazon.co.uk", "amazon.com", false},
+	}
+	for _, c := range cases {
+		if got := hostMatchesDomain(c.host, c.bare); got != c.want {
+			t.Errorf("hostMatchesDomain(%q, %q) = %v, want %v", c.host, c.bare, got, c.want)
+		}
+	}
+}
+
+// makeSidecar writes a Chrome-shaped plaintext sidecar DB and returns its path.
+func makeSidecar(t *testing.T, rows [][3]string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "cookies-plain.db")
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatalf("open sidecar: %v", err)
+	}
+	defer db.Close()
+	if _, err := db.Exec(`CREATE TABLE cookies (
+		host_key TEXT, name TEXT, value TEXT, path TEXT,
+		expires_utc INTEGER, is_secure INTEGER, is_httponly INTEGER)`); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	for _, r := range rows {
+		if _, err := db.Exec(
+			`INSERT INTO cookies (host_key, name, value, path, expires_utc, is_secure, is_httponly) VALUES (?,?,?,'/',0,0,0)`,
+			r[0], r[1], r[2]); err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+	}
+	return path
+}
+
+func names(cookies []sidecar.Cookie) map[string]bool {
+	m := map[string]bool{}
+	for _, c := range cookies {
+		m[c.Name] = true
+	}
+	return m
+}
+
+func TestCollectDomainCookies_HappyPathAndFiltering(t *testing.T) {
+	path := makeSidecar(t, [][3]string{
+		{"amazon.com", "session-token", "tok"},
+		{".amazon.com", "x-main", "xm"},
+		{"www.amazon.com", "ubid", "ub"},
+		{"amazon-adsystem.com", "__eoi", "ad"}, // sibling ad domain, must be excluded
+		{"amazon.com", "empty", ""},            // empty value, must be skipped
+	})
+	got, err := collectDomainCookies(path, ".amazon.com", nil)
+	if err != nil {
+		t.Fatalf("collectDomainCookies: %v", err)
+	}
+	n := names(got)
+	for _, want := range []string{"session-token", "x-main", "ubid"} {
+		if !n[want] {
+			t.Errorf("expected cookie %q in result, got %v", want, n)
+		}
+	}
+	if n["__eoi"] {
+		t.Error("amazon-adsystem.com cookie leaked into .amazon.com result")
+	}
+	if n["empty"] {
+		t.Error("empty-value cookie should be skipped")
+	}
+	if len(got) != 3 {
+		t.Errorf("expected 3 cookies, got %d (%v)", len(got), n)
+	}
+}
+
+func TestCollectDomainCookies_Blocklist(t *testing.T) {
+	path := makeSidecar(t, [][3]string{
+		{"amazon.com", "session-token", "tok"},
+		{".amazon.com", "x-main", "xm"},
+	})
+	matcher := protocol.NewBlocklistMatcher(&config.Blocklist{
+		Domains: []config.BlocklistEntry{{Pattern: "%amazon.com"}},
+	})
+	got, err := collectDomainCookies(path, ".amazon.com", matcher)
+	if err != nil {
+		t.Fatalf("collectDomainCookies: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("blocklisted domain should yield no cookies, got %d", len(got))
+	}
+}
+
+func TestCollectDomainCookies_MissingFile(t *testing.T) {
+	got, err := collectDomainCookies(filepath.Join(t.TempDir(), "nope.db"), ".amazon.com", nil)
+	if err != nil {
+		t.Fatalf("missing sidecar should not error, got %v", err)
+	}
+	if got != nil {
+		t.Errorf("missing sidecar should return nil, got %v", got)
+	}
+}
+
+func TestEmitCookies_Header(t *testing.T) {
+	var buf bytes.Buffer
+	cookies := []sidecar.Cookie{
+		{Name: "a", Value: "1"},
+		{Name: "b", Value: "2"},
+	}
+	if err := emitCookies(&buf, cookies, false); err != nil {
+		t.Fatal(err)
+	}
+	if got := buf.String(); got != "a=1; b=2\n" {
+		t.Errorf("header = %q, want %q", got, "a=1; b=2\n")
+	}
+}
+
+func TestEmitCookies_JSON(t *testing.T) {
+	var buf bytes.Buffer
+	cookies := []sidecar.Cookie{{Name: "a", Value: "1", HostKey: ".amazon.com", Path: "/", IsSecure: true}}
+	if err := emitCookies(&buf, cookies, true); err != nil {
+		t.Fatal(err)
+	}
+	var out []map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatalf("invalid JSON: %v (%s)", err, buf.String())
+	}
+	if len(out) != 1 || out[0]["name"] != "a" || out[0]["value"] != "1" || out[0]["secure"] != true {
+		t.Errorf("unexpected JSON shape: %s", buf.String())
+	}
+}
+
+func TestEmitCookies_EmptyJSON(t *testing.T) {
+	var buf bytes.Buffer
+	if err := emitCookies(&buf, nil, true); err != nil {
+		t.Fatal(err)
+	}
+	if got := buf.String(); got != "[]\n" {
+		t.Errorf("empty JSON = %q, want %q", got, "[]\n")
+	}
+}

--- a/internal/cli/discover.go
+++ b/internal/cli/discover.go
@@ -47,6 +47,8 @@ type discoverJSONRow struct {
 	DisplayName     string `json:"display_name,omitempty"`
 	KeyCount        int    `json:"key_count"`
 	SyncSummary     string `json:"sync_summary,omitempty"`
+	Coverage        string `json:"coverage,omitempty"`
+	CoverageDetail  string `json:"coverage_detail,omitempty"`
 }
 
 type discoverJSONOutput struct {
@@ -89,7 +91,8 @@ func runDiscover(cmd *cobra.Command, _ []string) error {
 	}
 
 	tw := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
-	fmt.Fprintln(tw, "NAME\tTIER\tSOURCE\tREAD-IN-PLACE\tKEYS")
+	fmt.Fprintln(tw, "NAME\tTIER\tREAD-IN-PLACE\tKEYS\tCOVERAGE")
+	var mismatches []discoverJSONRow
 	for _, name := range sortedRegistryKeys(reg) {
 		rp := reg.Projects[name]
 		row := projectToRow(rp)
@@ -97,9 +100,22 @@ func runDiscover(cmd *cobra.Command, _ []string) error {
 		if readPath == "" {
 			readPath = "(legacy bus dir)"
 		}
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%d\n", row.Name, row.Kind, row.SourcePath, readPath, row.KeyCount)
+		coverage := row.Coverage
+		if row.Coverage == "MISMATCH" {
+			coverage = "MISMATCH (" + row.CoverageDetail + ")"
+			mismatches = append(mismatches, row)
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%d\t%s\n", row.Name, row.Kind, readPath, row.KeyCount, coverage)
 	}
 	_ = tw.Flush()
+
+	if len(mismatches) > 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "")
+		fmt.Fprintf(cmd.OutOrStdout(), "%d CLI(s) have synced secrets that do not match the auth env var they read:\n", len(mismatches))
+		for _, m := range mismatches {
+			fmt.Fprintf(cmd.OutOrStdout(), "  %s: %s\n", m.Name, m.CoverageDetail)
+		}
+	}
 
 	if discoverVerbose {
 		if len(reg.Skipped) > 0 {
@@ -136,6 +152,7 @@ func projectToRow(rp *secretsbus.RegisteredProject) discoverJSONRow {
 			row.SyncSummary = fmt.Sprintf("default=false, %d allowed", len(rp.Manifest.Sync.Keys))
 		}
 	}
+	row.Coverage, row.CoverageDetail = secretCoverage(rp.Name, declaredKeysOf(rp))
 	return row
 }
 

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -243,6 +243,19 @@ func buildReport(d doctorDeps) DoctorReport {
 	// the on-PATH copy and the daemon's copy don't silently differ.
 	checks = append(checks, checkBinaryInstall())
 
+	// 14. Cookie delivery (v0.13 universal cookie delivery) -- sink role
+	// only. Tells the operator whether ANY unmodified cookie CLI works on
+	// this box (universal) vs only agentcookie-aware tools (degraded).
+	if sinkCfg != nil {
+		checks = append(checks, checkCookieDelivery(sinkCfg))
+	} else {
+		checks = append(checks, Check{
+			Name:     "Cookie delivery",
+			Severity: SeveritySkipped,
+			Detail:   "source-only install",
+		})
+	}
+
 	exit := 0
 	for _, c := range checks {
 		if c.Severity == SeverityFail {
@@ -834,6 +847,80 @@ func checkCDPInjector(sinkCfg *config.SinkConfig) Check {
 		Severity:    SeverityWarn,
 		Detail:      "Chrome.app not found in /Applications or ~/Applications; CDP injection will fail at sync time",
 		Remediation: "install Google Chrome from https://www.google.com/chrome/, or pass --no-cdp at wizard install to disable CDP injection",
+	}
+}
+
+// checkCookieDelivery (v0.13 universal cookie delivery) reports whether
+// ANY unmodified cookie CLI works on this sink, or only agentcookie-aware
+// tools. Universal delivery requires two facts to both hold:
+//
+//	a. The real Default Chrome profile is written (skip_chrome_sqlite=false),
+//	   so a cookie CLI reading Chrome's default profile sees synced sessions.
+//	b. The Chrome Safe Storage key is readable by any local process (a
+//	   non-zero key length with no error from KeybaseKeychainProbe), so an
+//	   unmodified CLI can decrypt those cookies.
+//
+// sinkCfg.Delivery is the recorded intent ("universal" | "degraded"); it
+// phrases the message, but the live probe is the source of truth. The
+// exported check wires the real KeybaseKeychainProbe; checkCookieDeliveryWith
+// is the testable core over an injected probe.
+func checkCookieDelivery(sinkCfg *config.SinkConfig) Check {
+	return checkCookieDeliveryWith(sinkCfg, func() (int, error) {
+		return chrome.KeybaseKeychainProbe(3 * time.Second)
+	})
+}
+
+// checkCookieDeliveryWith is the testable core of checkCookieDelivery over an
+// injected keychain probe (so tests don't depend on the host Keychain). A
+// probe returning n>0 with no error means the Chrome Safe Storage key is
+// readable by any local process.
+func checkCookieDeliveryWith(sinkCfg *config.SinkConfig, probe func() (int, error)) Check {
+	if sinkCfg == nil {
+		return Check{
+			Name:     "Cookie delivery",
+			Severity: SeveritySkipped,
+			Detail:   "source-only install",
+		}
+	}
+
+	realProfile := !sinkCfg.SkipChromeSQLite
+
+	// Degraded by configuration: the sink intentionally skips Chrome's real
+	// SQLite/Default profile. Only agentcookie-aware tools (sidecar/adapter
+	// readers) see synced cookies. INFO, not a failure -- this is a valid
+	// supported mode (headless / SSH-only Mac minis).
+	if !realProfile {
+		return Check{
+			Name:        "Cookie delivery",
+			Severity:    SeverityInfo,
+			Detail:      "degraded: writes a separate profile; only agentcookie-aware tools work",
+			Remediation: "run `agentcookie wizard set-keychain-access --any-app` and set delivery universal (skip_chrome_sqlite=false) for any unmodified cookie CLI to work here",
+		}
+	}
+
+	keyLen, err := probe()
+	keyReadable := err == nil && keyLen > 0
+
+	if keyReadable {
+		detail := "universal: real Default profile written and Chrome Safe Storage readable; any unmodified cookie CLI works here"
+		if sinkCfg.Delivery == "universal" {
+			detail = "universal (delivery=universal): real Default profile written and Chrome Safe Storage readable; any unmodified cookie CLI works here"
+		}
+		return Check{
+			Name:     "Cookie delivery",
+			Severity: SeverityOK,
+			Detail:   detail,
+		}
+	}
+
+	// Real profile is written but the key is not readable by other processes
+	// (universal intended, but the any-app keychain open never happened or
+	// failed). An unmodified CLI sees the cookies but can't decrypt them.
+	return Check{
+		Name:        "Cookie delivery",
+		Severity:    SeverityWarn,
+		Detail:      "partial: real Default profile written but Chrome Safe Storage key is not readable by other apps; unmodified cookie CLIs can't decrypt synced cookies",
+		Remediation: "run `agentcookie wizard set-keychain-access --any-app` to open the Chrome Safe Storage key to any local process",
 	}
 }
 

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -239,6 +239,10 @@ func buildReport(d doctorDeps) DoctorReport {
 	// but the CLI reads TESLA_AUTH_TOKEN). WARN, recoverable via alias.
 	checks = append(checks, checkSecretCoverage())
 
+	// 13. Binary install. Flags multiple diverging agentcookie binaries so
+	// the on-PATH copy and the daemon's copy don't silently differ.
+	checks = append(checks, checkBinaryInstall())
+
 	exit := 0
 	for _, c := range checks {
 		if c.Severity == SeverityFail {
@@ -279,6 +283,83 @@ func checkSecretCoverage() Check {
 		Severity:    SeverityWarn,
 		Detail:      fmt.Sprintf("%d CLI(s) have synced secrets under a name they do not read: %s", len(mismatches), strings.Join(mismatches, ", ")),
 		Remediation: "run `agentcookie discover` for the detail, then `agentcookie secret alias <cli> <declared-env-var> <synced-key>`",
+	}
+}
+
+// checkBinaryInstall catches the footgun where multiple agentcookie binaries
+// exist on the machine (e.g. ~/go/bin/agentcookie stale on PATH while the
+// daemon runs ~/bin/agentcookie). When they differ, the binary a user invokes
+// for status/doctor may not be the one the daemon runs, producing misleading
+// output. WARN, never FAIL.
+func checkBinaryInstall() Check {
+	home, _ := os.UserHomeDir()
+	candidates := []string{
+		filepath.Join(home, "go", "bin", "agentcookie"),
+		filepath.Join(home, "bin", "agentcookie"),
+		"/usr/local/bin/agentcookie",
+		"/opt/homebrew/bin/agentcookie",
+	}
+	if p, err := exec.LookPath("agentcookie"); err == nil {
+		candidates = append(candidates, p)
+	}
+	if self, err := os.Executable(); err == nil {
+		candidates = append(candidates, self)
+	}
+	return binaryInstallCheckFrom(candidates)
+}
+
+// binaryInstallCheckFrom is the testable core of checkBinaryInstall over an
+// explicit candidate list (so tests don't depend on the host's real PATH).
+func binaryInstallCheckFrom(candidates []string) Check {
+	type binInfo struct {
+		path string
+		size int64
+		mod  time.Time
+	}
+	seen := map[string]binInfo{}
+	for _, c := range candidates {
+		rp, err := filepath.EvalSymlinks(c)
+		if err != nil {
+			continue
+		}
+		if _, ok := seen[rp]; ok {
+			continue
+		}
+		fi, err := os.Stat(rp)
+		if err != nil || fi.IsDir() {
+			continue
+		}
+		seen[rp] = binInfo{path: rp, size: fi.Size(), mod: fi.ModTime()}
+	}
+
+	if len(seen) <= 1 {
+		return Check{Name: "Binary install", Severity: SeverityOK, Detail: "single agentcookie binary on this machine"}
+	}
+
+	infos := make([]binInfo, 0, len(seen))
+	for _, v := range seen {
+		infos = append(infos, v)
+	}
+	sort.Slice(infos, func(i, j int) bool { return infos[i].path < infos[j].path })
+	differ := false
+	for i := 1; i < len(infos); i++ {
+		if infos[i].size != infos[0].size || !infos[i].mod.Equal(infos[0].mod) {
+			differ = true
+			break
+		}
+	}
+	paths := make([]string, 0, len(infos))
+	for _, in := range infos {
+		paths = append(paths, in.path)
+	}
+	if !differ {
+		return Check{Name: "Binary install", Severity: SeverityOK, Detail: fmt.Sprintf("%d identical agentcookie binaries (%s)", len(infos), strings.Join(paths, ", "))}
+	}
+	return Check{
+		Name:        "Binary install",
+		Severity:    SeverityWarn,
+		Detail:      fmt.Sprintf("%d agentcookie binaries differ; the one on PATH may not be the one your daemon runs: %s", len(infos), strings.Join(paths, ", ")),
+		Remediation: "reinstall so every location is the same build, or delete the stale copy, so status/doctor reflect the running daemon",
 	}
 }
 
@@ -744,7 +825,7 @@ func checkCDPInjector(sinkCfg *config.SinkConfig) Check {
 			return Check{
 				Name:     "CDP injector",
 				Severity: SeverityOK,
-				Detail:   "profile_dir=" + profileDir + ", Chrome=" + p,
+				Detail:   "profile_dir=" + profileDir + " is the synced/logged-in profile (your default Chrome profile is intentionally not written), Chrome=" + p,
 			}
 		}
 	}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -17,6 +18,7 @@ import (
 	"github.com/mvanhorn/agentcookie/internal/chromepaths"
 	"github.com/mvanhorn/agentcookie/internal/config"
 	"github.com/mvanhorn/agentcookie/internal/keystore"
+	"github.com/mvanhorn/agentcookie/internal/secretsbus"
 	"github.com/mvanhorn/agentcookie/internal/sinkpush"
 	"github.com/mvanhorn/agentcookie/internal/state"
 	"github.com/mvanhorn/agentcookie/internal/tsclient"
@@ -232,6 +234,11 @@ func buildReport(d doctorDeps) DoctorReport {
 	// writes via `agentcookie secret`, sink writes via U4's writer).
 	checks = append(checks, checkSecretsBus())
 
+	// 12. Secret coverage. Flags CLIs whose synced secret store does not
+	// provide the auth env var the CLI reads (e.g. store has OAUTH_BEARER
+	// but the CLI reads TESLA_AUTH_TOKEN). WARN, recoverable via alias.
+	checks = append(checks, checkSecretCoverage())
+
 	exit := 0
 	for _, c := range checks {
 		if c.Severity == SeverityFail {
@@ -244,6 +251,34 @@ func buildReport(d doctorDeps) DoctorReport {
 		Version:  Version,
 		ExitCode: exit,
 		Checks:   checks,
+	}
+}
+
+// checkSecretCoverage flags CLIs whose synced secret store does not provide
+// the auth env var the CLI reads (the Tesla case: store has OAUTH_BEARER but
+// the CLI reads TESLA_AUTH_TOKEN). WARN, not FAIL: it is a real but
+// recoverable misconfiguration the operator fixes with `secret alias`.
+func checkSecretCoverage() Check {
+	home, _ := os.UserHomeDir()
+	reg, _ := secretsbus.Discover(secretsbus.DiscoveryConfig{HomeDir: home})
+	if reg == nil || len(reg.Projects) == 0 {
+		return Check{Name: "Secret coverage", Severity: SeverityOK, Detail: "no secrets-bus CLIs registered"}
+	}
+	var mismatches []string
+	for name, rp := range reg.Projects {
+		if status, _ := secretCoverage(name, declaredKeysOf(rp)); status == "MISMATCH" {
+			mismatches = append(mismatches, name)
+		}
+	}
+	if len(mismatches) == 0 {
+		return Check{Name: "Secret coverage", Severity: SeverityOK, Detail: "synced secrets match the auth env var each CLI reads"}
+	}
+	sort.Strings(mismatches)
+	return Check{
+		Name:        "Secret coverage",
+		Severity:    SeverityWarn,
+		Detail:      fmt.Sprintf("%d CLI(s) have synced secrets under a name they do not read: %s", len(mismatches), strings.Join(mismatches, ", ")),
+		Remediation: "run `agentcookie discover` for the detail, then `agentcookie secret alias <cli> <declared-env-var> <synced-key>`",
 	}
 }
 

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -359,6 +359,73 @@ func TestCheckCDPInjector(t *testing.T) {
 	})
 }
 
+// TestCheckCookieDelivery covers the universal-cookie-delivery check's
+// three branches plus the source-only skip, using an injected keychain
+// probe so the test never touches the host Keychain.
+func TestCheckCookieDelivery(t *testing.T) {
+	okProbe := func() (int, error) { return 24, nil }
+	closedProbe := func() (int, error) { return 0, errors.New("not readable by this process") }
+
+	t.Run("source-only skipped", func(t *testing.T) {
+		c := checkCookieDeliveryWith(nil, okProbe)
+		if c.Severity != SeveritySkipped {
+			t.Fatalf("got %q, want SKIPPED", c.Severity)
+		}
+	})
+
+	t.Run("universal OK when profile written and key readable", func(t *testing.T) {
+		cfg := &config.SinkConfig{SkipChromeSQLite: false, Delivery: "universal"}
+		c := checkCookieDeliveryWith(cfg, okProbe)
+		if c.Severity != SeverityOK {
+			t.Fatalf("got %q (%q), want OK", c.Severity, c.Detail)
+		}
+		if !strings.Contains(c.Detail, "universal") {
+			t.Errorf("detail should mention universal: %q", c.Detail)
+		}
+	})
+
+	t.Run("universal OK without delivery marker still reads probe as truth", func(t *testing.T) {
+		cfg := &config.SinkConfig{SkipChromeSQLite: false} // Delivery unset
+		c := checkCookieDeliveryWith(cfg, okProbe)
+		if c.Severity != SeverityOK {
+			t.Fatalf("got %q (%q), want OK", c.Severity, c.Detail)
+		}
+		if !strings.Contains(c.Detail, "any unmodified cookie CLI works here") {
+			t.Errorf("detail: %q", c.Detail)
+		}
+	})
+
+	t.Run("degraded is INFO not a failure", func(t *testing.T) {
+		cfg := &config.SinkConfig{SkipChromeSQLite: true, Delivery: "degraded"}
+		// Probe should not even be consulted on the degraded branch, but
+		// pass a readable one to prove config drives this path.
+		c := checkCookieDeliveryWith(cfg, okProbe)
+		if c.Severity != SeverityInfo {
+			t.Fatalf("got %q (%q), want INFO", c.Severity, c.Detail)
+		}
+		if !strings.Contains(c.Detail, "degraded") {
+			t.Errorf("detail should mention degraded: %q", c.Detail)
+		}
+		if !strings.Contains(c.Remediation, "set-keychain-access --any-app") {
+			t.Errorf("remediation missing --any-app step: %q", c.Remediation)
+		}
+	})
+
+	t.Run("partial warns and names the --any-app step", func(t *testing.T) {
+		cfg := &config.SinkConfig{SkipChromeSQLite: false, Delivery: "universal"}
+		c := checkCookieDeliveryWith(cfg, closedProbe)
+		if c.Severity != SeverityWarn {
+			t.Fatalf("got %q (%q), want WARN", c.Severity, c.Detail)
+		}
+		if !strings.Contains(c.Detail, "partial") {
+			t.Errorf("detail should mention partial: %q", c.Detail)
+		}
+		if !strings.Contains(c.Remediation, "set-keychain-access --any-app") {
+			t.Errorf("remediation missing --any-app step: %q", c.Remediation)
+		}
+	})
+}
+
 // TestHostMatchesAnyAdapter covers the substring fallback used by the
 // adapter coverage check.
 func TestHostMatchesAnyAdapter(t *testing.T) {
@@ -416,8 +483,9 @@ peer:
 	// v0.13 added the Secrets bus check. DBSC resilience added the DBSC
 	// check (source role only; present here since this fixture is source).
 	// The consumption bridge added the Secret coverage + Binary install checks.
-	if got := len(report.Checks); got != 14 {
-		t.Fatalf("got %d checks, want 14", got)
+	// Universal cookie delivery added the Cookie delivery check.
+	if got := len(report.Checks); got != 15 {
+		t.Fatalf("got %d checks, want 15", got)
 	}
 
 	// Serialize the envelope and confirm it round-trips.
@@ -435,9 +503,10 @@ peer:
 
 	// Sink-only checks should be Skipped on a source-only install.
 	want := map[string]Severity{
-		"Sink listener": SeveritySkipped,
-		"Sink state":    SeveritySkipped,
-		"Sealing":       SeveritySkipped,
+		"Sink listener":   SeveritySkipped,
+		"Sink state":      SeveritySkipped,
+		"Sealing":         SeveritySkipped,
+		"Cookie delivery": SeveritySkipped,
 	}
 	for _, c := range report.Checks {
 		if w, ok := want[c.Name]; ok && c.Severity != w {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -400,20 +400,24 @@ peer:
 	writeKey(t, dir, "mac-mini", 0o600)
 
 	report := buildReport(doctorDeps{
-		ConfigDir:        dir,
-		BinarySignature:  func() (string, error) { return "designated => anchor apple generic and certificate leaf[subject.OU] = \"NM8VT393AR\"", nil },
-		TailscaleIP:      func() (string, error) { return "100.80.229.80", nil },
-		LoadSourceState:  func() (*state.SourceState, error) { return &state.SourceState{LastPush: time.Now().Add(-30 * time.Second)}, nil },
-		LoadSinkState:    func() (*state.SinkState, error) { return nil, nil },
-		MasterKeyExists:  func() bool { return false },
+		ConfigDir: dir,
+		BinarySignature: func() (string, error) {
+			return "designated => anchor apple generic and certificate leaf[subject.OU] = \"NM8VT393AR\"", nil
+		},
+		TailscaleIP: func() (string, error) { return "100.80.229.80", nil },
+		LoadSourceState: func() (*state.SourceState, error) {
+			return &state.SourceState{LastPush: time.Now().Add(-30 * time.Second)}, nil
+		},
+		LoadSinkState:   func() (*state.SinkState, error) { return nil, nil },
+		MasterKeyExists: func() bool { return false },
 	})
 
 	// v0.12.0-beta.3 added two checks: Adapter coverage + CDP injector.
 	// v0.13 added the Secrets bus check. DBSC resilience added the DBSC
 	// check (source role only; present here since this fixture is source).
-	// The consumption bridge added the Secret coverage check.
-	if got := len(report.Checks); got != 13 {
-		t.Fatalf("got %d checks, want 13", got)
+	// The consumption bridge added the Secret coverage + Binary install checks.
+	if got := len(report.Checks); got != 14 {
+		t.Fatalf("got %d checks, want 14", got)
 	}
 
 	// Serialize the envelope and confirm it round-trips.
@@ -447,12 +451,12 @@ func TestRunDoctorExitCodes(t *testing.T) {
 	dir := t.TempDir()
 	// All-fail-ish: no config at all.
 	report := buildReport(doctorDeps{
-		ConfigDir:        dir,
-		BinarySignature:  func() (string, error) { return "", errors.New("missing") },
-		TailscaleIP:      func() (string, error) { return "", errors.New("daemon down") },
-		LoadSourceState:  func() (*state.SourceState, error) { return nil, nil },
-		LoadSinkState:    func() (*state.SinkState, error) { return nil, nil },
-		MasterKeyExists:  func() bool { return false },
+		ConfigDir:       dir,
+		BinarySignature: func() (string, error) { return "", errors.New("missing") },
+		TailscaleIP:     func() (string, error) { return "", errors.New("daemon down") },
+		LoadSourceState: func() (*state.SourceState, error) { return nil, nil },
+		LoadSinkState:   func() (*state.SinkState, error) { return nil, nil },
+		MasterKeyExists: func() bool { return false },
 	})
 	if report.ExitCode == 0 {
 		t.Fatalf("expected non-zero exit code when checks FAIL; got 0")

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -411,8 +411,9 @@ peer:
 	// v0.12.0-beta.3 added two checks: Adapter coverage + CDP injector.
 	// v0.13 added the Secrets bus check. DBSC resilience added the DBSC
 	// check (source role only; present here since this fixture is source).
-	if got := len(report.Checks); got != 12 {
-		t.Fatalf("got %d checks, want 12", got)
+	// The consumption bridge added the Secret coverage check.
+	if got := len(report.Checks); got != 13 {
+		t.Fatalf("got %d checks, want 13", got)
 	}
 
 	// Serialize the envelope and confirm it round-trips.

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -46,7 +46,7 @@ func Execute() {
 	rootCmd.PersistentFlags().StringVar(&common.ConfigDir, "config-dir", defaultConfigDir(), "directory holding source.yaml, sink.yaml, allowlist.yaml")
 	rootCmd.PersistentFlags().BoolVar(&common.JSON, "json", false, "emit machine-readable JSON output where the subcommand supports it")
 
-	rootCmd.AddCommand(sourceCmd, sinkCmd, pairCmd, statusCmd, versionCmd, wizardCmd, doctorCmd, secretCmd, discoverCmd)
+	rootCmd.AddCommand(sourceCmd, sinkCmd, pairCmd, statusCmd, versionCmd, wizardCmd, doctorCmd, secretCmd, discoverCmd, cookiesCmd)
 
 	if err := rootCmd.Execute(); err != nil {
 		// Cobra already prints usage on flag errors; surface RunE errors here.

--- a/internal/cli/secret.go
+++ b/internal/cli/secret.go
@@ -80,7 +80,7 @@ var secretEnvCmd = &cobra.Command{
 }
 
 func init() {
-	secretCmd.AddCommand(secretListCmd, secretGetCmd, secretSetCmd, secretRmCmd, secretImportFromCmd, secretEnvCmd)
+	secretCmd.AddCommand(secretListCmd, secretGetCmd, secretSetCmd, secretRmCmd, secretImportFromCmd, secretEnvCmd, secretAliasCmd)
 	secretImportFromCmd.Flags().StringVar(&secretImportAs, "as", "", "cli-name to file the imported secrets under (required)")
 }
 
@@ -311,22 +311,22 @@ func importParse(path string, data []byte) (map[string]string, []string, error) 
 	// Common field-name heuristics observed in the U1 audit. Lowercase
 	// match; we render in canonical UPPER_SNAKE_CASE on the way out.
 	canonical := map[string]string{
-		"access_token":           "OAUTH_BEARER",
-		"accesstoken":            "OAUTH_BEARER",
-		"refresh_token":          "OAUTH_REFRESH",
-		"refreshtoken":           "OAUTH_REFRESH",
-		"api_key":                "API_KEY",
-		"apikey":                 "API_KEY",
-		"client_id":              "OAUTH_CLIENT_ID",
-		"clientid":               "OAUTH_CLIENT_ID",
-		"client_secret":          "OAUTH_CLIENT_SECRET",
-		"clientsecret":           "OAUTH_CLIENT_SECRET",
-		"token":                  "TOKEN",
-		"bearer":                 "OAUTH_BEARER",
-		"auth_header":            "AUTH_HEADER",
-		"token_expiry":           "OAUTH_EXPIRES_AT",
-		"expires_at":             "OAUTH_EXPIRES_AT",
-		"base_url":               "BASE_URL",
+		"access_token":  "OAUTH_BEARER",
+		"accesstoken":   "OAUTH_BEARER",
+		"refresh_token": "OAUTH_REFRESH",
+		"refreshtoken":  "OAUTH_REFRESH",
+		"api_key":       "API_KEY",
+		"apikey":        "API_KEY",
+		"client_id":     "OAUTH_CLIENT_ID",
+		"clientid":      "OAUTH_CLIENT_ID",
+		"client_secret": "OAUTH_CLIENT_SECRET",
+		"clientsecret":  "OAUTH_CLIENT_SECRET",
+		"token":         "TOKEN",
+		"bearer":        "OAUTH_BEARER",
+		"auth_header":   "AUTH_HEADER",
+		"token_expiry":  "OAUTH_EXPIRES_AT",
+		"expires_at":    "OAUTH_EXPIRES_AT",
+		"base_url":      "BASE_URL",
 	}
 
 	flat := map[string]string{}
@@ -600,6 +600,20 @@ func runSecretEnv(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("read %s: %w", plainPath, err)
 		}
 	}
+	// Apply aliases so the consumer's declared env var name (e.g.
+	// TESLA_AUTH_TOKEN) is emitted carrying the live value of the synced key
+	// it maps to (e.g. OAUTH_BEARER). Resolved on every call so it tracks
+	// token refreshes rather than going stale.
+	aliases, err := readAliases(cliName)
+	if err != nil {
+		return fmt.Errorf("read aliases: %w", err)
+	}
+	for declared, stored := range aliases {
+		if v, ok := kv[stored]; ok {
+			kv[declared] = v
+		}
+	}
+
 	keys := make([]string, 0, len(kv))
 	for k := range kv {
 		keys = append(keys, k)
@@ -608,6 +622,83 @@ func runSecretEnv(cmd *cobra.Command, args []string) error {
 	for _, k := range keys {
 		fmt.Fprintf(cmd.OutOrStdout(), "%s=%s\n", k, kv[k])
 	}
+	return nil
+}
+
+// aliasesPath is the per-CLI alias file mapping a consumer's declared env var
+// name to the synced secret key that holds its value.
+func aliasesPath(cliName string) string {
+	return filepath.Join(secretsRoot(), cliName, "aliases.env")
+}
+
+// readAliases loads declared-env-var -> stored-key mappings for a CLI. A
+// missing file is not an error (most CLIs need no alias).
+func readAliases(cliName string) (map[string]string, error) {
+	m, err := readEnvAll(aliasesPath(cliName))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]string{}, nil
+		}
+		return nil, err
+	}
+	return m, nil
+}
+
+var secretAliasCmd = &cobra.Command{
+	Use:   "alias <cli-name> [<declared-env-var> <stored-key>]",
+	Short: "Map a consumer's declared env var to a synced secret key (resolved live by `secret env`)",
+	Long: `alias bridges a CLI's expected auth env var name to the key the secrets
+bus actually stores, so 'agentcookie secret env' emits the name the CLI reads.
+
+  agentcookie secret alias tesla-pp-cli TESLA_AUTH_TOKEN OAUTH_BEARER
+  agentcookie secret alias tesla-pp-cli        # list current aliases
+
+The alias is resolved against the live synced value on every 'secret env',
+so it tracks token refreshes instead of going stale. Use it when a CLI reads
+a different env var name than the one the secret was imported under.`,
+	Args: cobra.RangeArgs(1, 3),
+	RunE: runSecretAlias,
+}
+
+func runSecretAlias(cmd *cobra.Command, args []string) error {
+	cliName := args[0]
+	if !validBusName(cliName) {
+		return fmt.Errorf("invalid cli-name %q", cliName)
+	}
+	if len(args) == 1 {
+		aliases, err := readAliases(cliName)
+		if err != nil {
+			return err
+		}
+		declaredKeys := make([]string, 0, len(aliases))
+		for d := range aliases {
+			declaredKeys = append(declaredKeys, d)
+		}
+		sort.Strings(declaredKeys)
+		for _, d := range declaredKeys {
+			fmt.Fprintf(cmd.OutOrStdout(), "%s <- %s\n", d, aliases[d])
+		}
+		return nil
+	}
+	if len(args) != 3 {
+		return fmt.Errorf("to set an alias pass <cli-name> <declared-env-var> <stored-key>; to list pass just <cli-name>")
+	}
+	declared, stored := args[1], args[2]
+	if !validBusKey(declared) || !validBusKey(stored) {
+		return fmt.Errorf("env var names must be valid identifiers (A-Z, 0-9, underscore)")
+	}
+	aliases, err := readAliases(cliName)
+	if err != nil {
+		return err
+	}
+	aliases[declared] = stored
+	if err := os.MkdirAll(filepath.Dir(aliasesPath(cliName)), 0o700); err != nil {
+		return fmt.Errorf("mkdir secrets dir: %w", err)
+	}
+	if err := writeEnvAtomic(aliasesPath(cliName), aliases); err != nil {
+		return fmt.Errorf("write aliases: %w", err)
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "aliased %s <- %s for %s\n", declared, stored, cliName)
 	return nil
 }
 

--- a/internal/cli/secret_alias_test.go
+++ b/internal/cli/secret_alias_test.go
@@ -1,0 +1,115 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeSecrets(t *testing.T, home, cli, content string) {
+	t.Helper()
+	dir := filepath.Join(home, ".agentcookie", "secrets", cli)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "secrets.env"), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func envLines(t *testing.T, cli string) string {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	cmd := secretEnvCmd
+	cmd.SetOut(buf)
+	if err := runSecretEnv(cmd, []string{cli}); err != nil {
+		t.Fatalf("runSecretEnv: %v", err)
+	}
+	return buf.String()
+}
+
+func TestSecretEnv_AppliesAlias(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeSecrets(t, home, "tesla-pp-cli", "OAUTH_BEARER=tok-bearer\nOAUTH_REFRESH=tok-refresh\n")
+	// Map the consumer's declared name to the synced bearer key.
+	aliasCmd := secretAliasCmd
+	aliasCmd.SetOut(&bytes.Buffer{})
+	if err := runSecretAlias(aliasCmd, []string{"tesla-pp-cli", "TESLA_AUTH_TOKEN", "OAUTH_BEARER"}); err != nil {
+		t.Fatalf("set alias: %v", err)
+	}
+
+	out := envLines(t, "tesla-pp-cli")
+	if !strings.Contains(out, "TESLA_AUTH_TOKEN=tok-bearer") {
+		t.Errorf("expected TESLA_AUTH_TOKEN mapped to the bearer value, got:\n%s", out)
+	}
+	if strings.Contains(out, "TESLA_AUTH_TOKEN=tok-refresh") {
+		t.Errorf("alias must map to OAUTH_BEARER, not the refresh token:\n%s", out)
+	}
+	// Stored keys still emitted under their own names.
+	if !strings.Contains(out, "OAUTH_BEARER=tok-bearer") {
+		t.Errorf("stored keys should still be emitted:\n%s", out)
+	}
+}
+
+func TestSecretEnv_NoAliasesUnchanged(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeSecrets(t, home, "demo-cli", "K1=v1\nK2=v2\n")
+	out := envLines(t, "demo-cli")
+	if out != "K1=v1\nK2=v2\n" {
+		t.Errorf("no-alias output should be unchanged, got:\n%q", out)
+	}
+}
+
+func TestSecretEnv_AliasToMissingKeyNoOp(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeSecrets(t, home, "demo-cli", "OAUTH_BEARER=tok\n")
+	aliasCmd := secretAliasCmd
+	aliasCmd.SetOut(&bytes.Buffer{})
+	if err := runSecretAlias(aliasCmd, []string{"demo-cli", "DECLARED", "NONEXISTENT_KEY"}); err != nil {
+		t.Fatalf("set alias: %v", err)
+	}
+	out := envLines(t, "demo-cli")
+	if strings.Contains(out, "DECLARED=") {
+		t.Errorf("alias to a missing stored key must emit nothing for it, got:\n%s", out)
+	}
+	if !strings.Contains(out, "OAUTH_BEARER=tok") {
+		t.Errorf("stored key still expected:\n%s", out)
+	}
+}
+
+func TestSecretAlias_SetAndList(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	set := secretAliasCmd
+	set.SetOut(&bytes.Buffer{})
+	if err := runSecretAlias(set, []string{"demo-cli", "TESLA_AUTH_TOKEN", "OAUTH_BEARER"}); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".agentcookie", "secrets", "demo-cli", "aliases.env")); err != nil {
+		t.Fatalf("aliases.env not written: %v", err)
+	}
+	buf := &bytes.Buffer{}
+	list := secretAliasCmd
+	list.SetOut(buf)
+	if err := runSecretAlias(list, []string{"demo-cli"}); err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if !strings.Contains(buf.String(), "TESLA_AUTH_TOKEN <- OAUTH_BEARER") {
+		t.Errorf("list output missing alias: %q", buf.String())
+	}
+}
+
+func TestSecretAlias_InvalidName(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cmd := secretAliasCmd
+	cmd.SetOut(&bytes.Buffer{})
+	if err := runSecretAlias(cmd, []string{"demo-cli", "bad name!", "OAUTH_BEARER"}); err == nil {
+		t.Error("expected error for invalid declared env var name")
+	}
+}

--- a/internal/cli/secret_coverage.go
+++ b/internal/cli/secret_coverage.go
@@ -1,0 +1,81 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/mvanhorn/agentcookie/internal/secretsbus"
+)
+
+// secretCoverage reports whether a CLI's synced secret store satisfies the
+// auth env vars the CLI declares. It only flags a problem when an explicit
+// secret store EXISTS but does not cover the declared keys -- the exact
+// Tesla case (store has OAUTH_BEARER, CLI declares TESLA_AUTH_TOKEN). A CLI
+// with no explicit store reads its value in place (pp-cli-derived) and is
+// not this command's concern, so it returns "in-place".
+//
+// An alias (see `agentcookie secret alias`) counts as satisfying a declared
+// key when the stored key it points at is present.
+//
+// status is one of: "in-place", "ok", "MISMATCH". detail is human-readable
+// remediation for MISMATCH, empty otherwise.
+func secretCoverage(cliName string, declared []string) (status, detail string) {
+	storePath := filepath.Join(secretsRoot(), cliName, "secrets.env")
+	storeKeys, err := readEnvKeysOnly(storePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "in-place", ""
+		}
+		return "in-place", ""
+	}
+	if len(storeKeys) == 0 {
+		return "in-place", ""
+	}
+	if len(declared) == 0 {
+		return "ok", ""
+	}
+	have := make(map[string]bool, len(storeKeys))
+	for _, k := range storeKeys {
+		have[k] = true
+	}
+	aliases, _ := readAliases(cliName)
+
+	var missing []string
+	for _, d := range declared {
+		if have[d] {
+			continue
+		}
+		if stored, ok := aliases[d]; ok && have[stored] {
+			continue
+		}
+		missing = append(missing, d)
+	}
+	if len(missing) == 0 {
+		return "ok", ""
+	}
+	sort.Strings(missing)
+	return "MISMATCH", "needs " + strings.Join(missing, ",") + "; synced keys are [" +
+		strings.Join(sortedCopy(storeKeys), ",") + "] -- add `agentcookie secret alias " + cliName + " " +
+		missing[0] + " <one-of-those>`"
+}
+
+// declaredKeysOf returns the sorted auth env var names a project declares.
+func declaredKeysOf(rp *secretsbus.RegisteredProject) []string {
+	if rp == nil || rp.Manifest == nil {
+		return nil
+	}
+	keys := make([]string, 0, len(rp.Manifest.Sync.Keys))
+	for k := range rp.Manifest.Sync.Keys {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func sortedCopy(s []string) []string {
+	out := append([]string(nil), s...)
+	sort.Strings(out)
+	return out
+}

--- a/internal/cli/secret_coverage_test.go
+++ b/internal/cli/secret_coverage_test.go
@@ -1,0 +1,50 @@
+package cli
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestSecretCoverage_InPlaceWhenNoStore(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if status, _ := secretCoverage("no-store-cli", []string{"TESLA_AUTH_TOKEN"}); status != "in-place" {
+		t.Errorf("no secret store should be in-place, got %q", status)
+	}
+}
+
+func TestSecretCoverage_OKWhenDeclaredPresent(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeSecrets(t, home, "good-cli", "TESLA_AUTH_TOKEN=tok\n")
+	if status, _ := secretCoverage("good-cli", []string{"TESLA_AUTH_TOKEN"}); status != "ok" {
+		t.Errorf("declared key present should be ok, got %q", status)
+	}
+}
+
+func TestSecretCoverage_MismatchWhenDeclaredMissing(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeSecrets(t, home, "tesla-pp-cli", "OAUTH_BEARER=tok\nOAUTH_REFRESH=ref\n")
+	status, detail := secretCoverage("tesla-pp-cli", []string{"TESLA_AUTH_TOKEN"})
+	if status != "MISMATCH" {
+		t.Fatalf("store without declared key should be MISMATCH, got %q", status)
+	}
+	if detail == "" {
+		t.Error("MISMATCH should carry remediation detail")
+	}
+}
+
+func TestSecretCoverage_AliasSatisfies(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeSecrets(t, home, "tesla-pp-cli", "OAUTH_BEARER=tok\n")
+	cmd := secretAliasCmd
+	cmd.SetOut(&bytes.Buffer{})
+	if err := runSecretAlias(cmd, []string{"tesla-pp-cli", "TESLA_AUTH_TOKEN", "OAUTH_BEARER"}); err != nil {
+		t.Fatalf("set alias: %v", err)
+	}
+	if status, _ := secretCoverage("tesla-pp-cli", []string{"TESLA_AUTH_TOKEN"}); status != "ok" {
+		t.Errorf("alias should satisfy declared key, got %q", status)
+	}
+}

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/mvanhorn/agentcookie/internal/chrome"
 	"github.com/mvanhorn/agentcookie/internal/config"
 	"github.com/mvanhorn/agentcookie/internal/keystore"
 	"github.com/mvanhorn/agentcookie/internal/launchd"
@@ -241,7 +240,23 @@ func wizardInstallSink(ctx context.Context, binPath, logDir string) error {
 	// Chrome Safe Storage. That produced the 60-second timeout +
 	// alarming WARNING block documented as friction #19 in the
 	// 2026-05-19 dry-run.
-	skipChromeSQLite, cdpEnabled, cdpProfileDir := resolveSinkHeadlessMode()
+	skipChromeSQLite, cdpEnabled, cdpProfileDir, delivery := resolveSinkHeadlessMode()
+
+	// v0.13 (plan 2026-05-31-002, R5): for the default/universal-intent
+	// case the KEYCHAIN-OPEN OUTCOME determines the final delivery mode,
+	// so it must run BEFORE we render sink.yaml. A universal config
+	// (skip_chrome_sqlite=false) requires agentcookie to read the Chrome
+	// Safe Storage key (the sink daemon writes the real Default profile
+	// and reads the key to do so; see sink.go). On a box where
+	// agentcookie is not yet keychain-trusted (or has no GUI session),
+	// the any-app open fails -> we must DOWNGRADE to degraded so the
+	// rendered sink.yaml does not leave a daemon that cannot start.
+	//
+	// We perform the open up front (gated below), then re-derive the
+	// skip/cdp/delivery values from its outcome for the render.
+	skipChromeSQLite, cdpEnabled, cdpProfileDir, delivery, keychainOpened := resolveSinkDeliveryWithKeychain(
+		skipChromeSQLite, cdpEnabled, cdpProfileDir, delivery,
+	)
 
 	// v0.12 S1: resolve the tailnet 100.x address BEFORE writing
 	// sink.yaml. If Tailscale is not up the helper returns a
@@ -272,7 +287,7 @@ func wizardInstallSink(ctx context.Context, binPath, logDir string) error {
 		}
 		if err := writeYAMLIfMissing(
 			sinkYAMLPath,
-			renderSinkYAML(wizardPeer, listenAddr, skipChromeSQLite, cdpEnabled, cdpProfileDir),
+			renderSinkYAML(wizardPeer, listenAddr, skipChromeSQLite, cdpEnabled, cdpProfileDir, delivery),
 			wizardForce,
 		); err != nil {
 			return err
@@ -307,53 +322,12 @@ func wizardInstallSink(ctx context.Context, binPath, logDir string) error {
 		fmt.Fprintf(os.Stderr, "agentcookie wizard: paired with source %q (fingerprint %s)\n", wizardPeer, res.Fingerprint)
 	}
 
-	// v0.7: trigger the one-time Keychain Always-Allow prompt for Chrome
-	// Safe Storage. The sink LaunchAgent reads this key on every startup
-	// to encrypt cookies for SQLite writes; without Always-Allow, the
-	// daemon would block on a Keychain prompt nobody can see.
-	//
-	// v0.12.0-beta.6: skip entirely in headless mode. When
-	// skip_chrome_sqlite resolves to true the sink daemon never reads
-	// Chrome Safe Storage, so the prompt is needless friction and
-	// (when run from a non-GUI context) hangs or errors loudly.
-	if !wizardSkipKeychainPrompt && !skipChromeSQLite {
-		fmt.Fprintln(os.Stderr, "agentcookie wizard: triggering Chrome Safe Storage Keychain prompt (click 'Always Allow' when macOS asks)")
-		if _, err := chrome.SafeStoragePassword(); err != nil {
-			return fmt.Errorf("Keychain access: %w (re-run after granting Always Allow, or pass --skip-keychain-prompt)", err)
-		}
-		fmt.Fprintln(os.Stderr, "agentcookie wizard: Keychain access granted; sink daemon can run unattended")
-	}
-
-	// v0.10: run the set-keychain-access strategy loop. This supersedes the
-	// v0.9 partition-list step -- v0.10's first strategy IS the same
-	// partition-list expansion, plus it verifies the result via the
-	// keybase/go-keychain API path kooky-CGO uses, and falls back to
-	// per-binary trust-list entries if the partition list alone does not
-	// cover ad-hoc-signed Go binaries. The whole thing runs inside a
-	// one-shot LaunchAgent (auto-unlocked keychain) so no login password
-	// prompt fires. See plan 2026-05-17-004.
-	//
-	// v0.12.0-beta.6: skip entirely in headless mode. The loop only
-	// matters for kooky-using PP CLIs that read Chrome's encrypted SQLite
-	// directly. In headless mode (sidecar+adapter delivery), no PP CLI
-	// touches Chrome's SQLite; the loop's 60s timeout + alarming
-	// WARNING was friction #19 in the 2026-05-21 dry-run.
-	switch {
-	case wizardSkipKeychainAccess:
-		// explicit opt-out preserved
-	case skipChromeSQLite:
-		fmt.Fprintln(os.Stderr, "agentcookie wizard: skipping set-keychain-access strategy loop (headless mode: sidecar+adapter delivery does not need Chrome Safe Storage access)")
-	default:
-		fmt.Fprintln(os.Stderr, "agentcookie wizard: running set-keychain-access strategy loop (broadens Chrome Safe Storage access for kooky-using CLIs)")
-		setKeychainExtraBinary = defaultKeychainTrustBinaries()
-		if err := runOuterWizard(setKeychainAccessCmd); err != nil {
-			// Do NOT abort install. Sink itself still works; only the
-			// per-CLI headless-read path is degraded.
-			fmt.Fprintf(os.Stderr, "agentcookie wizard: WARNING keychain access strategy loop failed: %v\n", err)
-			fmt.Fprintln(os.Stderr, "agentcookie wizard:   kooky-using CLIs on this sink will prompt for Keychain access on first read per binary")
-			fmt.Fprintln(os.Stderr, "agentcookie wizard:   see docs/runbook-v0.10-keychain-access.md for recovery")
-		}
-	}
+	// v0.13: the keychain open already ran (above, before sink.yaml was
+	// rendered) so its outcome could drive the skip/cdp/delivery render.
+	// All the keychain prompt + strategy-loop logic now lives in
+	// resolveSinkDeliveryWithKeychain. Nothing to do here; keychainOpened
+	// recorded whether the universal any-app open succeeded.
+	_ = keychainOpened
 
 	if !wizardSkipDaemon {
 		if err := installLaunchAgent(launchd.Spec{
@@ -695,7 +669,13 @@ peer:
 // matches the pre-beta.3 shape byte-for-byte — that's the regression
 // guard for installed v0.12.0-beta.2 friends (R6 in plan
 // 2026-05-21-001).
-func renderSinkYAML(peer, listenAddr string, skipChromeSQLite, cdpEnabled bool, cdpProfileDir string) string {
+//
+// v0.13 added the delivery marker. It is appended only when non-empty so
+// the legacy byte-for-byte shape (skip=false, cdp=false, delivery="")
+// stays a regression-stable target; the wizard install always passes a
+// concrete "universal"/"degraded" value, while tests and callers that
+// pass "" keep the pre-v0.13 output.
+func renderSinkYAML(peer, listenAddr string, skipChromeSQLite, cdpEnabled bool, cdpProfileDir, delivery string) string {
 	out := fmt.Sprintf(`listen:
   addr: %s
 peer:
@@ -710,14 +690,20 @@ peer:
 			out += fmt.Sprintf("  profile_dir: %s\n", cdpProfileDir)
 		}
 	}
+	if delivery != "" {
+		out += fmt.Sprintf("delivery: %s\n", delivery)
+	}
 	return out
 }
 
 // isHeadlessInstall returns true when stdin is not a terminal, which
 // signals an SSH-only install with no GUI session to answer Keychain
-// prompts. The wizard uses this to pick the v0.12.0-beta.3 headless
-// defaults (skip_chrome_sqlite + cdp). When in doubt (e.g. tests),
-// returns false to preserve legacy behavior.
+// prompts. Pre-v0.13 the wizard used this to auto-degrade no-TTY sink
+// installs (skip_chrome_sqlite + cdp). v0.13 made universal the default
+// regardless of TTY (the degraded fallback now happens non-fatally at the
+// keychain step), so resolveSinkHeadlessMode no longer consults this.
+// Retained as a small TTY probe for callers and tests. When in doubt
+// (e.g. tests), returns false.
 func isHeadlessInstall() bool {
 	stat, err := os.Stdin.Stat()
 	if err != nil {
@@ -726,32 +712,154 @@ func isHeadlessInstall() bool {
 	return (stat.Mode() & os.ModeCharDevice) == 0
 }
 
-// resolveSinkHeadlessMode applies the v0.12.0-beta.3 default-resolution
-// rules. Returns (skipChromeSQLite, cdpEnabled, cdpProfileDir).
+// Delivery markers recorded in sink.yaml so doctor reports the INTENT a
+// wizard install resolved to, rather than re-inferring it. See
+// config.SinkConfig.Delivery.
+const (
+	deliveryUniversal = "universal"
+	deliveryDegraded  = "degraded"
+)
+
+// resolveSinkHeadlessMode applies the v0.13 universal-default resolution
+// rules. Returns (skipChromeSQLite, cdpEnabled, cdpProfileDir, delivery).
+//
+// v0.13 change: a plain `wizard install --as sink` (neither
+// --skip-chrome-sqlite nor --write-chrome-sqlite passed) now defaults to
+// UNIVERSAL delivery -- skip=false, write the real Default Chrome profile,
+// and (at the keychain step) the any-app open -- so any unmodified cookie
+// tool works on the sink. The pre-v0.13 no-TTY auto-degrade is gone:
+// headless SSH installs default to universal too, and only fall back to
+// degraded non-fatally if the any-app keychain open cannot complete (see
+// the keychain block in wizardInstallSink, which prints the one-line
+// upgrade instruction without failing the install).
 //
 // Precedence:
-//  1. --skip-chrome-sqlite explicit -> skip=true.
-//  2. --write-chrome-sqlite explicit -> skip=false (overrides headless detect).
-//  3. No-TTY install -> skip=true (auto-detect).
-//  4. GUI install -> skip=false (legacy default, R6 regression guard).
+//  1. --skip-chrome-sqlite explicit -> skip=true (degraded opt-out).
+//  2. --write-chrome-sqlite explicit -> skip=false (universal).
+//  3. Neither flag -> skip=false (universal DEFAULT, the v0.13 change).
 //
 // CDP defaults: enabled when skip=true and --no-cdp is not set.
-func resolveSinkHeadlessMode() (skipChromeSQLite, cdpEnabled bool, cdpProfileDir string) {
+func resolveSinkHeadlessMode() (skipChromeSQLite, cdpEnabled bool, cdpProfileDir, delivery string) {
 	switch {
 	case wizardSkipChromeSQLite:
 		skipChromeSQLite = true
 	case wizardWriteChromeSQLite:
 		skipChromeSQLite = false
-	case isHeadlessInstall():
-		skipChromeSQLite = true
 	default:
+		// v0.13: universal is the default when neither flag is passed,
+		// independent of TTY. The degraded fallback for a never-trusted
+		// box happens at the keychain step, non-fatally.
 		skipChromeSQLite = false
 	}
 	if skipChromeSQLite && !wizardNoCDP {
 		cdpEnabled = true
 		cdpProfileDir = "~/.agentcookie/chrome-profile"
 	}
+	if skipChromeSQLite {
+		delivery = deliveryDegraded
+	} else {
+		delivery = deliveryUniversal
+	}
 	return
+}
+
+// attemptUniversalKeychainOpen performs the v0.13 any-app Chrome Safe
+// Storage open (U1's delete-and-recreate-with-A strategy) that makes the
+// key readable by ANY application, so any unmodified cookie tool reads it
+// with no per-binary trust list. It returns an error if the open could not
+// complete (typically: agentcookie is not yet in the Chrome Safe Storage
+// ACL, so the any-app strategy refused to delete rather than risk
+// destroying existing cookies, or there is no GUI session to open the
+// key).
+//
+// It is a function variable so tests can inject success/failure without
+// spawning the real one-shot LaunchAgent (mirrors execSecurityFunc in
+// wizard_keychain.go). The production implementation sets the any-app
+// flags and runs the outer wizard.
+var attemptUniversalKeychainOpen = func() error {
+	setKeychainAnyApp = true
+	setKeychainExtraBinary = defaultKeychainTrustBinaries()
+	return runOuterWizard(setKeychainAccessCmd)
+}
+
+// resolveSinkDeliveryWithKeychain takes the flag-resolved delivery mode
+// (from resolveSinkHeadlessMode) and applies the v0.13 keychain-open
+// outcome (plan 2026-05-31-002, R5). The keychain-open result determines
+// the FINAL delivery mode for the default/universal-intent case, so this
+// runs BEFORE sink.yaml is rendered.
+//
+// Behavior by intent:
+//   - Explicit --skip-chrome-sqlite (degraded opt-out): no keychain open
+//     attempted; stays degraded. Matches the old "skip the loop" branch.
+//   - Explicit --skip-keychain-access: no open attempted; the caller asked
+//     us not to touch the keychain. Stays as resolved (universal config but
+//     keychain left untouched -- explicit operator choice).
+//   - Explicit --write-chrome-sqlite (forced universal): attempt the open;
+//     if it fails, surface a clear WARNING but HONOR the explicit intent --
+//     do NOT silently downgrade. Universal config is rendered regardless.
+//   - Default (neither --skip-chrome-sqlite nor --write-chrome-sqlite): the
+//     universal-intent case. Attempt the open. On SUCCESS -> universal. On
+//     FAILURE -> DOWNGRADE to degraded (skip=true, CDP enabled like the old
+//     headless mode), print the one-line upgrade instruction, and continue
+//     NON-FATALLY so the install completes with a working sink.
+//
+// Returns the (possibly downgraded) skip/cdp/profileDir/delivery to render,
+// plus whether the universal any-app open actually succeeded.
+func resolveSinkDeliveryWithKeychain(
+	skipChromeSQLite, cdpEnabled bool, cdpProfileDir, delivery string,
+) (outSkip, outCDP bool, outProfileDir, outDelivery string, keychainOpened bool) {
+	// Degraded opt-out: never touch the keychain; the sink daemon won't
+	// read Chrome Safe Storage. This is also the pre-v0.13 friction #19
+	// fix (no 60s strategy-loop timeout in degraded mode).
+	if skipChromeSQLite {
+		fmt.Fprintln(os.Stderr, "agentcookie wizard: skipping set-keychain-access strategy loop (degraded mode: sidecar+adapter delivery does not need Chrome Safe Storage access)")
+		return skipChromeSQLite, cdpEnabled, cdpProfileDir, delivery, false
+	}
+
+	// Universal config (skip=false). The keychain prompt / loop is the
+	// explicit opt-out path: --skip-keychain-prompt and
+	// --skip-keychain-access leave the keychain untouched. The operator
+	// asked for universal config without the open, so render universal
+	// and do not attempt the open.
+	if wizardSkipKeychainAccess || wizardSkipKeychainPrompt {
+		fmt.Fprintln(os.Stderr, "agentcookie wizard: keychain open skipped by flag; rendering universal config without opening Chrome Safe Storage (cookie CLIs may prompt until you grant access once)")
+		return skipChromeSQLite, cdpEnabled, cdpProfileDir, delivery, false
+	}
+
+	// Universal default / forced-universal: attempt the any-app open. Its
+	// outcome determines the final delivery mode for the default case.
+	fmt.Fprintln(os.Stderr, "agentcookie wizard: running set-keychain-access strategy loop with --any-app (universal delivery: any cookie CLI reads Chrome Safe Storage with no per-binary work)")
+	if err := attemptUniversalKeychainOpen(); err != nil {
+		if wizardWriteChromeSQLite {
+			// EXPLICIT --write-chrome-sqlite: honor the intent. Surface a
+			// clear warning but do NOT downgrade; the operator forced
+			// universal and we respect that even if the box cannot open
+			// the key right now.
+			fmt.Fprintf(os.Stderr, "agentcookie wizard: WARNING --write-chrome-sqlite forced universal but the any-app keychain open did not complete: %v\n", err)
+			fmt.Fprintln(os.Stderr, "agentcookie wizard:   honoring explicit --write-chrome-sqlite; the sink will write the real Default profile but may fail to read Chrome Safe Storage until you grant access once.")
+			fmt.Fprintln(os.Stderr, "agentcookie wizard:   grant Chrome Safe Storage \"Always Allow\" once in Keychain Access, then run: agentcookie wizard set-keychain-access --any-app")
+			return skipChromeSQLite, cdpEnabled, cdpProfileDir, delivery, false
+		}
+		// DEFAULT (unspecified) case: DOWNGRADE to degraded, non-fatally.
+		// The any-app open could not complete (agentcookie not yet in the
+		// Chrome Safe Storage ACL, or no GUI session). Rendering universal
+		// here would leave a sink daemon that cannot read the key and so
+		// cannot start. Fall back to the old headless degraded mode
+		// (skip=true + CDP) so the install completes with a working sink.
+		fmt.Fprintf(os.Stderr, "agentcookie wizard: WARNING universal keychain open did not complete: %v\n", err)
+		fmt.Fprintln(os.Stderr, "agentcookie wizard:   downgrading this install to degraded (sidecar+adapter delivery + CDP); the sink is installed and syncing.")
+		fmt.Fprintln(os.Stderr, "agentcookie wizard:   upgrade to universal: grant Chrome Safe Storage \"Always Allow\" once in Keychain Access, then run: agentcookie wizard set-keychain-access --any-app")
+		degradedSkip := true
+		degradedCDP := false
+		degradedProfileDir := ""
+		if !wizardNoCDP {
+			degradedCDP = true
+			degradedProfileDir = "~/.agentcookie/chrome-profile"
+		}
+		return degradedSkip, degradedCDP, degradedProfileDir, deliveryDegraded, false
+	}
+	// Open succeeded: final config is universal.
+	return skipChromeSQLite, cdpEnabled, cdpProfileDir, delivery, true
 }
 
 // expandHome resolves a leading ~/ in a path against the current user's

--- a/internal/cli/wizard_keychain.go
+++ b/internal/cli/wizard_keychain.go
@@ -21,6 +21,7 @@ var (
 	setKeychainExtraBinary []string
 	innerRunnerMode        bool
 	setKeychainEnableSeal  bool
+	setKeychainAnyApp      bool
 )
 
 var setKeychainAccessCmd = &cobra.Command{
@@ -57,6 +58,13 @@ func init() {
 	// reads. Will become default-on once U12 lands in cli-printing-press.
 	setKeychainAccessCmd.Flags().BoolVar(&setKeychainEnableSeal, "enable-sealing", false, "create the agentcookie-master Keychain item and turn on at-rest sealing of the sidecar SQLite and adapter session files")
 	_ = setKeychainAccessCmd.Flags().MarkHidden("enable-sealing")
+	// --any-app: opt-in v0.10-style universal open. Recreates the Chrome
+	// Safe Storage item with -A (any application) so ANY unmodified cookie
+	// tool reads it with no per-binary trust list. Unlike the v0.10 code,
+	// this preserves the existing Safe Storage value (read-then-reuse) so
+	// existing Chrome cookies stay decryptable. SECURITY: any local process
+	// can then read Chrome cookies; only appropriate on a dedicated sink.
+	setKeychainAccessCmd.Flags().BoolVar(&setKeychainAnyApp, "any-app", false, "recreate Chrome Safe Storage with -A (any application) so any unmodified cookie tool reads it; preserves the existing key value; SECURITY: any local process can then read Chrome cookies")
 	wizardCmd.AddCommand(setKeychainAccessCmd)
 }
 
@@ -102,6 +110,9 @@ func runOuterWizard(cmd *cobra.Command) error {
 	if setKeychainEnableSeal {
 		argv = append(argv, "--enable-sealing")
 	}
+	if setKeychainAnyApp {
+		argv = append(argv, "--any-app")
+	}
 
 	fmt.Fprintln(os.Stderr, "agentcookie wizard: running keychain strategies via a one-shot LaunchAgent (no prompts expected; if a Mac mini desktop prompt appears, click Always Allow and re-run)")
 
@@ -139,7 +150,7 @@ func runOuterWizard(cmd *cobra.Command) error {
 // the login keychain is unlocked. Iterates strategies, probes after
 // each, emits structured JSON on stdout for the outer wizard to parse.
 func runInnerStrategyLoop(cmd *cobra.Command) error {
-	strategies := buildStrategies(setKeychainExtraBinary, setKeychainEnableSeal)
+	strategies := buildStrategies(setKeychainExtraBinary, setKeychainEnableSeal, setKeychainAnyApp)
 
 	var result runResult
 	for _, s := range strategies {
@@ -166,7 +177,7 @@ type kcStrategy struct {
 	apply func() (detail string, err error)
 }
 
-func buildStrategies(extraBinaries []string, enableSealing bool) []kcStrategy {
+func buildStrategies(extraBinaries []string, enableSealing bool, anyApp bool) []kcStrategy {
 	// Trust list: the running agentcookie binary plus every adapter
 	// binary in extraBinaries. Master key + Chrome Safe Storage ACLs
 	// both use this same list so any allowlisted process can read
@@ -181,7 +192,51 @@ func buildStrategies(extraBinaries []string, enableSealing bool) []kcStrategy {
 		trustArgs = append(trustArgs, "-T", ab)
 	}
 
-	out := []kcStrategy{
+	var out []kcStrategy
+
+	if anyApp {
+		// Opt-in v0.10-style universal open, corrected to preserve the
+		// existing Safe Storage value. This leads the chain when
+		// --any-app is set so that any unmodified cookie tool (yt-dlp,
+		// kooky, pycookiecheat, a random third-party CLI) reads Chrome
+		// Safe Storage with no per-binary trust list.
+		//
+		// CRITICAL correctness guard: we read the existing value FIRST.
+		// If that read fails, the caller is not yet in the item's ACL,
+		// and we MUST NOT delete the item: deleting then recreating with
+		// a different value permanently destroys all existing Chrome
+		// cookies (Chromium derives its AES key from this value via
+		// PBKDF2). On a read failure we refuse to delete and return the
+		// one-time GUI-grant instruction instead.
+		out = append(out, kcStrategy{
+			name: "delete-and-recreate-with-A",
+			apply: func() (string, error) {
+				existing, err := safeStoragePasswordFunc()
+				if err != nil {
+					// Refuse-to-delete guard: caller not yet trusted in
+					// the Chrome Safe Storage ACL. Do NOT delete anything.
+					return "", fmt.Errorf("cannot read existing Chrome Safe Storage value (%w); refusing to delete the item because recreating it with a different value would permanently destroy all existing Chrome cookies. Do the one-time \"Always Allow\" grant in Keychain Access (see docs/runbook-v0.10-keychain-access.md), then re-run", err)
+				}
+				// Value read OK. Safe to delete and recreate with -A and
+				// the SAME value (never a random one), so existing cookies
+				// stay decryptable.
+				_, _ = execSecurityFunc("delete-generic-password",
+					"-s", "Chrome Safe Storage", "-a", "Chrome")
+				args := []string{
+					"add-generic-password",
+					"-s", "Chrome Safe Storage", "-a", "Chrome",
+					"-w", existing,
+					"-A",
+				}
+				if detail, err := execSecurityFunc(args...); err != nil {
+					return detail, err
+				}
+				return "Chrome Safe Storage recreated with -A (any application) and the existing key value preserved. SECURITY WARNING: any local process can now read Chrome cookies; only appropriate on a dedicated agent sink.", nil
+			},
+		})
+	}
+
+	out = append(out, []kcStrategy{
 		{
 			// Primary v0.12 strategy: delete the existing Chrome Safe
 			// Storage item, recreate with a per-binary -T trust list
@@ -231,7 +286,7 @@ func buildStrategies(extraBinaries []string, enableSealing bool) []kcStrategy {
 					"-s", "Chrome Safe Storage", "-a", "Chrome")
 			},
 		},
-	}
+	}...)
 
 	for _, bin := range extraBinaries {
 		bin := bin
@@ -330,6 +385,13 @@ func execSecurity(args ...string) (string, error) {
 // observe whether the sealing-on path was taken without actually
 // writing to the macOS Keychain.
 var createMasterKeyFunc = keystore.CreateMasterKey
+
+// safeStoragePasswordFunc indirects chrome.SafeStoragePassword so tests
+// can inject a fake existing value (or a read failure) for the --any-app
+// delete-and-recreate-with-A strategy without touching the real Keychain.
+// The read-then-reuse guard depends on this seam to verify the recreate
+// uses the exact value read and that a read failure refuses to delete.
+var safeStoragePasswordFunc = chrome.SafeStoragePassword
 
 func lastJSONLine(s string) string {
 	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")

--- a/internal/cli/wizard_keychain_sealing_test.go
+++ b/internal/cli/wizard_keychain_sealing_test.go
@@ -29,7 +29,7 @@ func TestPrimaryStrategy_OffByDefault_DoesNotCreateMasterKey(t *testing.T) {
 		return nil
 	}
 
-	strategies := buildStrategies(nil, false)
+	strategies := buildStrategies(nil, false, false)
 	if len(strategies) < 1 {
 		t.Fatal("expected at least one strategy")
 	}
@@ -73,7 +73,7 @@ func TestPrimaryStrategy_WithSealingFlag_CreatesMasterKey(t *testing.T) {
 	}
 
 	extras := []string{"/Users/me/go/bin/instacart-pp-cli"}
-	strategies := buildStrategies(extras, true)
+	strategies := buildStrategies(extras, true, false)
 	if _, err := strategies[0].apply(); err != nil {
 		t.Fatalf("primary strategy apply: %v", err)
 	}
@@ -92,8 +92,8 @@ func TestPrimaryStrategy_WithSealingFlag_CreatesMasterKey(t *testing.T) {
 // chain length and ordering do not change when --enable-sealing is
 // toggled. Only the primary strategy's apply behavior differs.
 func TestBuildStrategies_ChainShapeUnchangedByFlag(t *testing.T) {
-	off := buildStrategies(nil, false)
-	on := buildStrategies(nil, true)
+	off := buildStrategies(nil, false, false)
+	on := buildStrategies(nil, true, false)
 	if len(off) != len(on) {
 		t.Errorf("strategy chain length differs by flag: off=%d on=%d", len(off), len(on))
 	}

--- a/internal/cli/wizard_keychain_test.go
+++ b/internal/cli/wizard_keychain_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -36,7 +37,7 @@ func TestLastJSONLine_TrailingNewlinesIgnored(t *testing.T) {
 }
 
 func TestBuildStrategies_PrimaryIsDeleteAndRecreate(t *testing.T) {
-	s := buildStrategies(nil, false)
+	s := buildStrategies(nil, false, false)
 	if len(s) < 1 {
 		t.Fatal("expected at least one default strategy")
 	}
@@ -49,7 +50,7 @@ func TestBuildStrategies_PrimaryIsDeleteAndRecreate(t *testing.T) {
 }
 
 func TestBuildStrategies_PartitionListFallbackComesSecond(t *testing.T) {
-	s := buildStrategies(nil, false)
+	s := buildStrategies(nil, false, false)
 	if len(s) < 2 {
 		t.Fatal("expected partition-list fallback to exist")
 	}
@@ -59,8 +60,8 @@ func TestBuildStrategies_PartitionListFallbackComesSecond(t *testing.T) {
 }
 
 func TestBuildStrategies_ExtraBinariesAppearAfterDefaultStrategies(t *testing.T) {
-	defaults := buildStrategies(nil, false)
-	withExtras := buildStrategies([]string{"/Users/me/go/bin/instacart-pp-cli", "/Users/me/go/bin/bird"}, false)
+	defaults := buildStrategies(nil, false, false)
+	withExtras := buildStrategies([]string{"/Users/me/go/bin/instacart-pp-cli", "/Users/me/go/bin/bird"}, false, false)
 	if len(withExtras) != len(defaults)+2 {
 		t.Fatalf("expected %d default + 2 extra-binary strategies, got %d", len(defaults), len(withExtras))
 	}
@@ -71,6 +72,185 @@ func TestBuildStrategies_ExtraBinariesAppearAfterDefaultStrategies(t *testing.T)
 	if !strings.Contains(last2[1].name, "trust-list:") || !strings.Contains(last2[1].name, "bird") {
 		t.Errorf("second extra strategy: got %q, want trust-list:bird", last2[1].name)
 	}
+}
+
+// findStrategy returns the strategy with the given name, or nil.
+func findStrategy(strategies []kcStrategy, name string) *kcStrategy {
+	for i := range strategies {
+		if strategies[i].name == name {
+			return &strategies[i]
+		}
+	}
+	return nil
+}
+
+func TestAnyApp_StrategyLeadsChain(t *testing.T) {
+	s := buildStrategies(nil, false, true)
+	if len(s) < 1 {
+		t.Fatal("expected at least one strategy with --any-app")
+	}
+	if s[0].name != "delete-and-recreate-with-A" {
+		t.Errorf("with --any-app the chain must lead with delete-and-recreate-with-A, got %q", s[0].name)
+	}
+}
+
+// TestAnyApp_ValuePreservation asserts that when the existing Safe Storage
+// value reads as "V", the recreate argv carries -A and -w V (the exact
+// value read), NOT a random one, and NOT -T.
+func TestAnyApp_ValuePreservation(t *testing.T) {
+	const existing = "V"
+
+	prevExec := execSecurityFunc
+	prevRead := safeStoragePasswordFunc
+	defer func() {
+		execSecurityFunc = prevExec
+		safeStoragePasswordFunc = prevRead
+	}()
+
+	var calls [][]string
+	execSecurityFunc = func(args ...string) (string, error) {
+		calls = append(calls, args)
+		return "", nil
+	}
+	safeStoragePasswordFunc = func() (string, error) {
+		return existing, nil
+	}
+
+	s := findStrategy(buildStrategies(nil, false, true), "delete-and-recreate-with-A")
+	if s == nil {
+		t.Fatal("delete-and-recreate-with-A strategy not present with --any-app")
+	}
+	detail, err := s.apply()
+	if err != nil {
+		t.Fatalf("apply returned error: %v", err)
+	}
+
+	// A delete then an add must have happened.
+	if len(calls) != 2 {
+		t.Fatalf("expected exactly 2 security calls (delete + add), got %d: %v", len(calls), calls)
+	}
+	if calls[0][0] != "delete-generic-password" {
+		t.Errorf("first call should be delete-generic-password, got %q", calls[0][0])
+	}
+	add := calls[1]
+	if add[0] != "add-generic-password" {
+		t.Errorf("second call should be add-generic-password, got %q", add[0])
+	}
+
+	joined := strings.Join(add, " ")
+	// Must recreate with -A and the exact value read, not a random one.
+	if !containsPair(add, "-w", existing) {
+		t.Errorf("recreate must use -w %q (the value read), got argv %v", existing, add)
+	}
+	if !contains(add, "-A") {
+		t.Errorf("recreate must carry -A (any application), got argv %v", add)
+	}
+	if contains(add, "-T") {
+		t.Errorf("recreate must NOT carry -T (trust list) in --any-app mode, got argv %v", add)
+	}
+	if !strings.Contains(strings.ToLower(detail), "security warning") {
+		t.Errorf("detail must carry a security warning, got %q", detail)
+	}
+	_ = joined
+}
+
+// TestAnyApp_RefuseToDeleteWhenUnreadable asserts that when the existing
+// value cannot be read, NO delete is attempted and a clear error is
+// returned. Deleting then recreating with a different value would
+// permanently destroy all existing Chrome cookies.
+func TestAnyApp_RefuseToDeleteWhenUnreadable(t *testing.T) {
+	prevExec := execSecurityFunc
+	prevRead := safeStoragePasswordFunc
+	defer func() {
+		execSecurityFunc = prevExec
+		safeStoragePasswordFunc = prevRead
+	}()
+
+	var calls [][]string
+	execSecurityFunc = func(args ...string) (string, error) {
+		calls = append(calls, args)
+		return "", nil
+	}
+	safeStoragePasswordFunc = func() (string, error) {
+		return "", fmt.Errorf("not trusted in ACL")
+	}
+
+	s := findStrategy(buildStrategies(nil, false, true), "delete-and-recreate-with-A")
+	if s == nil {
+		t.Fatal("delete-and-recreate-with-A strategy not present with --any-app")
+	}
+	_, err := s.apply()
+	if err == nil {
+		t.Fatal("expected an error when the existing value is unreadable")
+	}
+	for _, c := range calls {
+		if c[0] == "delete-generic-password" {
+			t.Fatalf("delete-generic-password MUST NOT be called when the value is unreadable; calls=%v", calls)
+		}
+	}
+	if len(calls) != 0 {
+		t.Fatalf("no security calls should happen on a read failure, got %v", calls)
+	}
+	if !strings.Contains(err.Error(), "runbook-v0.10-keychain-access.md") {
+		t.Errorf("error must point the operator at the one-time GUI grant runbook, got %q", err.Error())
+	}
+}
+
+// TestAnyApp_DefaultUnchanged asserts that without --any-app the chain is
+// the existing -T shape: no delete-and-recreate-with-A strategy, and the
+// primary recreate argv carries -T, not -A.
+func TestAnyApp_DefaultUnchanged(t *testing.T) {
+	s := buildStrategies(nil, false, false)
+	if findStrategy(s, "delete-and-recreate-with-A") != nil {
+		t.Error("without --any-app, delete-and-recreate-with-A must not be present")
+	}
+	if s[0].name != "delete-and-recreate-with-T" {
+		t.Fatalf("default primary should be delete-and-recreate-with-T, got %q", s[0].name)
+	}
+
+	prevExec := execSecurityFunc
+	defer func() { execSecurityFunc = prevExec }()
+	var calls [][]string
+	execSecurityFunc = func(args ...string) (string, error) {
+		calls = append(calls, args)
+		return "", nil
+	}
+	if _, err := s[0].apply(); err != nil {
+		t.Fatalf("default strategy apply error: %v", err)
+	}
+	var add []string
+	for _, c := range calls {
+		if c[0] == "add-generic-password" {
+			add = c
+		}
+	}
+	if add == nil {
+		t.Fatal("expected an add-generic-password call in default strategy")
+	}
+	if !contains(add, "-T") {
+		t.Errorf("default recreate must carry -T, got %v", add)
+	}
+	if contains(add, "-A") {
+		t.Errorf("default recreate must NOT carry -A, got %v", add)
+	}
+}
+
+func contains(args []string, want string) bool {
+	for _, a := range args {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}
+
+func containsPair(args []string, flag, val string) bool {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == flag && args[i+1] == val {
+			return true
+		}
+	}
+	return false
 }
 
 func TestRandomKeychainPassword_NonEmptyAndUnique(t *testing.T) {

--- a/internal/cli/wizard_test.go
+++ b/internal/cli/wizard_test.go
@@ -1,11 +1,17 @@
 package cli
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+// errInjectedKeychainOpen is the failure injected into the
+// attemptUniversalKeychainOpen seam to exercise the downgrade-on-failure
+// flow without spawning the real one-shot LaunchAgent.
+var errInjectedKeychainOpen = errors.New("injected: any-app keychain open could not complete")
 
 // TestRenderSinkYAML_WritesResolvedAddr proves the wizard pipes the
 // resolved tailnet IP into sink.yaml verbatim. Pre-v0.12 the render
@@ -14,7 +20,7 @@ import (
 // argument so the call site can call tsclient.RequireTailnetIP and
 // fail loud before we ever reach this helper.
 func TestRenderSinkYAML_WritesResolvedAddr(t *testing.T) {
-	got := renderSinkYAML("my-laptop", "100.80.229.80:9999", false, false, "")
+	got := renderSinkYAML("my-laptop", "100.80.229.80:9999", false, false, "", "")
 	if !strings.Contains(got, "addr: 100.80.229.80:9999") {
 		t.Errorf("expected listen.addr in YAML, got:\n%s", got)
 	}
@@ -32,7 +38,7 @@ func TestRenderSinkYAML_WritesResolvedAddr(t *testing.T) {
 // Installed v0.12.0-beta.2 friends upgrading the binary in place must
 // see no config-level behavior change.
 func TestRenderSinkYAML_LegacyShapeStable(t *testing.T) {
-	got := renderSinkYAML("my-laptop", "100.80.229.80:9999", false, false, "")
+	got := renderSinkYAML("my-laptop", "100.80.229.80:9999", false, false, "", "")
 	want := "listen:\n  addr: 100.80.229.80:9999\npeer:\n  hostname: my-laptop\n"
 	if got != want {
 		t.Errorf("legacy YAML drift:\ngot:\n%s\nwant:\n%s", got, want)
@@ -43,7 +49,7 @@ func TestRenderSinkYAML_LegacyShapeStable(t *testing.T) {
 // shape: skip_chrome_sqlite + cdp block both emitted when the wizard
 // resolves headless mode.
 func TestRenderSinkYAML_HeadlessMode(t *testing.T) {
-	got := renderSinkYAML("my-laptop", "100.80.229.80:9999", true, true, "~/.agentcookie/chrome-profile")
+	got := renderSinkYAML("my-laptop", "100.80.229.80:9999", true, true, "~/.agentcookie/chrome-profile", "")
 	if !strings.Contains(got, "skip_chrome_sqlite: true") {
 		t.Errorf("expected skip_chrome_sqlite: true in YAML, got:\n%s", got)
 	}
@@ -59,7 +65,7 @@ func TestRenderSinkYAML_HeadlessMode(t *testing.T) {
 // path: skip_chrome_sqlite is emitted but no cdp block. The friend
 // wanted sidecar+adapter only.
 func TestRenderSinkYAML_SkipSQLiteWithoutCDP(t *testing.T) {
-	got := renderSinkYAML("my-laptop", "100.80.229.80:9999", true, false, "")
+	got := renderSinkYAML("my-laptop", "100.80.229.80:9999", true, false, "", "")
 	if !strings.Contains(got, "skip_chrome_sqlite: true") {
 		t.Errorf("expected skip_chrome_sqlite: true, got:\n%s", got)
 	}
@@ -68,10 +74,77 @@ func TestRenderSinkYAML_SkipSQLiteWithoutCDP(t *testing.T) {
 	}
 }
 
-// TestResolveSinkHeadlessMode_FlagPrecedence covers the explicit-flag
-// precedence rules in resolveSinkHeadlessMode. Headless auto-detect
-// only applies when neither --skip-chrome-sqlite nor --write-chrome-sqlite
-// was passed.
+// TestRenderSinkYAML_DeliveryMarker covers the v0.13 delivery marker:
+// a universal install records delivery="universal" and a degraded
+// opt-out records delivery="degraded" in the rendered sink.yaml, so a
+// later doctor unit can report intent without re-inferring it. An empty
+// delivery (legacy callers/tests) must emit no delivery line at all.
+func TestRenderSinkYAML_DeliveryMarker(t *testing.T) {
+	t.Run("universal records delivery: universal", func(t *testing.T) {
+		got := renderSinkYAML("my-laptop", "100.80.229.80:9999", false, false, "", deliveryUniversal)
+		if !strings.Contains(got, "delivery: universal") {
+			t.Errorf("universal install should record delivery: universal, got:\n%s", got)
+		}
+		if strings.Contains(got, "skip_chrome_sqlite") {
+			t.Errorf("universal install must not skip Chrome SQLite, got:\n%s", got)
+		}
+	})
+
+	t.Run("degraded records delivery: degraded", func(t *testing.T) {
+		got := renderSinkYAML("my-laptop", "100.80.229.80:9999", true, true, "~/.agentcookie/chrome-profile", deliveryDegraded)
+		if !strings.Contains(got, "delivery: degraded") {
+			t.Errorf("degraded opt-out should record delivery: degraded, got:\n%s", got)
+		}
+		if !strings.Contains(got, "skip_chrome_sqlite: true") {
+			t.Errorf("degraded opt-out should set skip_chrome_sqlite: true, got:\n%s", got)
+		}
+	})
+
+	t.Run("empty delivery emits no delivery line", func(t *testing.T) {
+		got := renderSinkYAML("my-laptop", "100.80.229.80:9999", false, false, "", "")
+		if strings.Contains(got, "delivery:") {
+			t.Errorf("empty delivery must not emit a delivery line, got:\n%s", got)
+		}
+	})
+}
+
+// TestUniversalInstallPassesAnyApp documents that the universal default
+// branch in wizardInstallSink opts the keychain step into U1's --any-app
+// strategy, while the degraded opt-out keeps the per-binary -T behavior
+// (setKeychainAnyApp stays false). This mirrors the structural gating
+// test below; the actual loop runs out-of-process via runOuterWizard.
+func TestUniversalInstallPassesAnyApp(t *testing.T) {
+	cases := []struct {
+		name             string
+		skipChromeSQLite bool
+		skipKeychainAcc  bool
+		wantLoopRuns     bool
+		wantAnyApp       bool
+	}{
+		{"universal default opens any-app", false, false, true, true},
+		{"degraded opt-out keeps -T (no any-app)", true, false, false, false},
+		{"explicit --skip-keychain-access: no loop, no any-app", false, true, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Model the same gating decision wizardInstallSink makes.
+			loopRuns := !tc.skipKeychainAcc && !tc.skipChromeSQLite
+			anyApp := loopRuns // the default (universal) branch sets setKeychainAnyApp=true
+			if loopRuns != tc.wantLoopRuns {
+				t.Errorf("loopRuns: got %v, want %v", loopRuns, tc.wantLoopRuns)
+			}
+			if anyApp != tc.wantAnyApp {
+				t.Errorf("anyApp: got %v, want %v", anyApp, tc.wantAnyApp)
+			}
+		})
+	}
+}
+
+// TestResolveSinkHeadlessMode_FlagPrecedence covers the v0.13 precedence
+// rules in resolveSinkHeadlessMode. The headline change: when neither
+// --skip-chrome-sqlite nor --write-chrome-sqlite is passed, the install
+// now defaults to UNIVERSAL (skip=false, delivery="universal"), instead
+// of the pre-v0.13 no-TTY auto-degrade.
 func TestResolveSinkHeadlessMode_FlagPrecedence(t *testing.T) {
 	saveSkip, saveWrite, saveNoCDP := wizardSkipChromeSQLite, wizardWriteChromeSQLite, wizardNoCDP
 	defer func() {
@@ -80,37 +153,61 @@ func TestResolveSinkHeadlessMode_FlagPrecedence(t *testing.T) {
 		wizardNoCDP = saveNoCDP
 	}()
 
-	t.Run("explicit --skip-chrome-sqlite wins", func(t *testing.T) {
+	t.Run("default (no flags) resolves to universal", func(t *testing.T) {
+		// The v0.13 behavior change: a plain `wizard install --as sink`
+		// defaults to universal (skip=false), no longer auto-degrading.
+		wizardSkipChromeSQLite = false
+		wizardWriteChromeSQLite = false
+		wizardNoCDP = false
+		skip, cdp, _, delivery := resolveSinkHeadlessMode()
+		if skip {
+			t.Errorf("default install should resolve to universal (skip=false), got skip=true")
+		}
+		if cdp {
+			t.Errorf("universal default should set cdp=false")
+		}
+		if delivery != deliveryUniversal {
+			t.Errorf("default install delivery: got %q, want %q", delivery, deliveryUniversal)
+		}
+	})
+
+	t.Run("explicit --skip-chrome-sqlite wins (degraded)", func(t *testing.T) {
 		wizardSkipChromeSQLite = true
 		wizardWriteChromeSQLite = false
 		wizardNoCDP = false
-		skip, cdp, _ := resolveSinkHeadlessMode()
+		skip, cdp, _, delivery := resolveSinkHeadlessMode()
 		if !skip {
 			t.Errorf("--skip-chrome-sqlite should set skip=true")
 		}
 		if !cdp {
 			t.Errorf("skip=true with --no-cdp absent should set cdp=true")
 		}
+		if delivery != deliveryDegraded {
+			t.Errorf("--skip-chrome-sqlite delivery: got %q, want %q", delivery, deliveryDegraded)
+		}
 	})
 
-	t.Run("explicit --write-chrome-sqlite wins", func(t *testing.T) {
+	t.Run("explicit --write-chrome-sqlite wins (universal)", func(t *testing.T) {
 		wizardSkipChromeSQLite = false
 		wizardWriteChromeSQLite = true
 		wizardNoCDP = false
-		skip, cdp, _ := resolveSinkHeadlessMode()
+		skip, cdp, _, delivery := resolveSinkHeadlessMode()
 		if skip {
 			t.Errorf("--write-chrome-sqlite should set skip=false")
 		}
 		if cdp {
 			t.Errorf("skip=false should set cdp=false")
 		}
+		if delivery != deliveryUniversal {
+			t.Errorf("--write-chrome-sqlite delivery: got %q, want %q", delivery, deliveryUniversal)
+		}
 	})
 
-	t.Run("--no-cdp disables cdp on headless install", func(t *testing.T) {
+	t.Run("--no-cdp disables cdp on degraded install", func(t *testing.T) {
 		wizardSkipChromeSQLite = true
 		wizardWriteChromeSQLite = false
 		wizardNoCDP = true
-		skip, cdp, _ := resolveSinkHeadlessMode()
+		skip, cdp, _, _ := resolveSinkHeadlessMode()
 		if !skip {
 			t.Errorf("--skip-chrome-sqlite should still set skip=true with --no-cdp")
 		}
@@ -165,6 +262,133 @@ func TestKeychainStrategyGatedOnHeadless(t *testing.T) {
 	}
 }
 
+// TestResolveSinkDeliveryWithKeychain covers the v0.13 downgrade-on-failure
+// flow (plan 2026-05-31-002, R5). The keychain-open OUTCOME determines the
+// final delivery mode for a default/universal-intent install, so this runs
+// before sink.yaml is rendered. We inject success/failure through the
+// attemptUniversalKeychainOpen function seam (mirrors execSecurityFunc) and
+// assert both the resolver output and the resulting rendered sink.yaml.
+func TestResolveSinkDeliveryWithKeychain(t *testing.T) {
+	saveOpen := attemptUniversalKeychainOpen
+	saveSkip := wizardSkipChromeSQLite
+	saveWrite := wizardWriteChromeSQLite
+	saveNoCDP := wizardNoCDP
+	saveSkipAccess := wizardSkipKeychainAccess
+	saveSkipPrompt := wizardSkipKeychainPrompt
+	defer func() {
+		attemptUniversalKeychainOpen = saveOpen
+		wizardSkipChromeSQLite = saveSkip
+		wizardWriteChromeSQLite = saveWrite
+		wizardNoCDP = saveNoCDP
+		wizardSkipKeychainAccess = saveSkipAccess
+		wizardSkipKeychainPrompt = saveSkipPrompt
+	}()
+
+	reset := func() {
+		wizardSkipChromeSQLite = false
+		wizardWriteChromeSQLite = false
+		wizardNoCDP = false
+		wizardSkipKeychainAccess = false
+		wizardSkipKeychainPrompt = false
+	}
+
+	t.Run("default install + keychain-open SUCCESS -> universal", func(t *testing.T) {
+		reset()
+		called := false
+		attemptUniversalKeychainOpen = func() error { called = true; return nil }
+		skip, cdp, _, delivery := resolveSinkHeadlessMode()
+		skip, cdp, profileDir, delivery, opened := resolveSinkDeliveryWithKeychain(skip, cdp, "", delivery)
+		if !called {
+			t.Errorf("default install should attempt the any-app keychain open")
+		}
+		if !opened {
+			t.Errorf("successful open should report keychainOpened=true")
+		}
+		if skip {
+			t.Errorf("success -> universal, skip should stay false")
+		}
+		if delivery != deliveryUniversal {
+			t.Errorf("success delivery: got %q, want %q", delivery, deliveryUniversal)
+		}
+		yaml := renderSinkYAML("my-laptop", "100.80.229.80:9999", skip, cdp, profileDir, delivery)
+		if strings.Contains(yaml, "skip_chrome_sqlite") {
+			t.Errorf("universal sink.yaml must not set skip_chrome_sqlite, got:\n%s", yaml)
+		}
+		if !strings.Contains(yaml, "delivery: universal") {
+			t.Errorf("universal sink.yaml should record delivery: universal, got:\n%s", yaml)
+		}
+	})
+
+	t.Run("default install + keychain-open FAILURE -> degraded, non-fatal", func(t *testing.T) {
+		reset()
+		attemptUniversalKeychainOpen = func() error { return errInjectedKeychainOpen }
+		skip, cdp, _, delivery := resolveSinkHeadlessMode()
+		// resolveSinkDeliveryWithKeychain has no error return: the
+		// downgrade is non-fatal by construction, so the install continues.
+		skip, cdp, profileDir, delivery, opened := resolveSinkDeliveryWithKeychain(skip, cdp, "", delivery)
+		if opened {
+			t.Errorf("failed open should report keychainOpened=false")
+		}
+		if !skip {
+			t.Errorf("failure -> downgrade to degraded, skip should be true")
+		}
+		if !cdp {
+			t.Errorf("downgrade should enable CDP (like the old headless mode)")
+		}
+		if delivery != deliveryDegraded {
+			t.Errorf("failure delivery: got %q, want %q", delivery, deliveryDegraded)
+		}
+		yaml := renderSinkYAML("my-laptop", "100.80.229.80:9999", skip, cdp, profileDir, delivery)
+		if !strings.Contains(yaml, "skip_chrome_sqlite: true") {
+			t.Errorf("degraded sink.yaml should set skip_chrome_sqlite: true, got:\n%s", yaml)
+		}
+		if !strings.Contains(yaml, "delivery: degraded") {
+			t.Errorf("degraded sink.yaml should record delivery: degraded, got:\n%s", yaml)
+		}
+		if !strings.Contains(yaml, "cdp:") {
+			t.Errorf("downgraded sink.yaml should carry a cdp block, got:\n%s", yaml)
+		}
+	})
+
+	t.Run("explicit --skip-chrome-sqlite -> degraded, open NOT attempted", func(t *testing.T) {
+		reset()
+		wizardSkipChromeSQLite = true
+		called := false
+		attemptUniversalKeychainOpen = func() error { called = true; return nil }
+		skip, cdp, profileDir, delivery := resolveSinkHeadlessMode()
+		skip, cdp, profileDir, delivery, opened := resolveSinkDeliveryWithKeychain(skip, cdp, profileDir, delivery)
+		if called {
+			t.Errorf("explicit --skip-chrome-sqlite must NOT attempt the keychain open")
+		}
+		if opened {
+			t.Errorf("degraded opt-out should report keychainOpened=false")
+		}
+		if !skip {
+			t.Errorf("--skip-chrome-sqlite should set skip=true")
+		}
+		if delivery != deliveryDegraded {
+			t.Errorf("--skip-chrome-sqlite delivery: got %q, want %q", delivery, deliveryDegraded)
+		}
+	})
+
+	t.Run("explicit --write-chrome-sqlite + FAILURE -> honored (no downgrade)", func(t *testing.T) {
+		reset()
+		wizardWriteChromeSQLite = true
+		attemptUniversalKeychainOpen = func() error { return errInjectedKeychainOpen }
+		skip, cdp, profileDir, delivery := resolveSinkHeadlessMode()
+		skip, _, _, delivery, opened := resolveSinkDeliveryWithKeychain(skip, cdp, profileDir, delivery)
+		if opened {
+			t.Errorf("failed open should report keychainOpened=false")
+		}
+		if skip {
+			t.Errorf("explicit --write-chrome-sqlite must NOT silently downgrade on open failure")
+		}
+		if delivery != deliveryUniversal {
+			t.Errorf("forced-universal delivery should stay universal, got %q", delivery)
+		}
+	})
+}
+
 // TestValidateListenAddr_AcceptsExplicitOperatorInput is the regression
 // guard for the wizard's --listen flag. An operator passing an
 // explicit value (during local dev or for an unusual deployment) must
@@ -183,7 +407,7 @@ func TestValidateListenAddr_AcceptsExplicitOperatorInput(t *testing.T) {
 	}
 
 	refused := map[string]string{
-		"0.0.0.0:9998":   "every interface",
+		"0.0.0.0:9998":     "every interface",
 		"192.168.1.5:9998": "not a Tailscale 100.x address",
 	}
 	for addr, want := range refused {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,6 +33,15 @@ type SourceConfig struct {
 // remain the cookie-delivery paths and are unaffected. This unblocks
 // SSH-only installs on headless Mac minis where no GUI session can
 // answer the Chrome Safe Storage Keychain prompt.
+//
+// Delivery is the v0.13 universal-cookie-delivery marker. It records the
+// INTENT a wizard install resolved to, so `doctor` can report "any cookie
+// CLI works here" vs "degraded" without re-inferring it from
+// SkipChromeSQLite + keychain probe state. Values: "universal" (real
+// Default Chrome profile + any-app keychain open) or "degraded" (the
+// -T/skip_chrome_sqlite opt-out). It is omitempty: an existing sink.yaml
+// written before this field keeps its current behavior with no migration
+// and no silent flip on a binary upgrade.
 type SinkConfig struct {
 	Listen           ListenRef   `yaml:"listen" json:"listen"`
 	Chrome           ChromeRef   `yaml:"chrome" json:"chrome"`
@@ -40,6 +49,7 @@ type SinkConfig struct {
 	Security         SecurityRef `yaml:"security,omitempty" json:"security,omitempty"`
 	SkipChromeSQLite bool        `yaml:"skip_chrome_sqlite,omitempty" json:"skip_chrome_sqlite,omitempty"`
 	CDP              CDPRef      `yaml:"cdp,omitempty" json:"cdp,omitempty"`
+	Delivery         string      `yaml:"delivery,omitempty" json:"delivery,omitempty"`
 }
 
 // CDPRef configures the v0.12.0-beta.3 CDP-injection mode. When Enabled,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -134,6 +134,71 @@ security:
 	})
 }
 
+// TestLoadSinkDeliveryMarker covers the v0.13 universal-cookie-delivery
+// marker. The delivery field round-trips through YAML so a later doctor
+// unit can report intent, and its absence keeps current behavior (no
+// migration, no silent flip on a binary upgrade).
+func TestLoadSinkDeliveryMarker(t *testing.T) {
+	t.Run("delivery universal round-trips", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "sink.yaml", `
+listen:
+  addr: 100.80.229.80:9999
+delivery: universal
+security:
+  shared_secret: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+`)
+		cfg, err := LoadSink(dir)
+		if err != nil {
+			t.Fatalf("LoadSink: %v", err)
+		}
+		if cfg.Delivery != "universal" {
+			t.Errorf("Delivery: got %q, want %q", cfg.Delivery, "universal")
+		}
+		if cfg.SkipChromeSQLite {
+			t.Errorf("universal install should not skip Chrome SQLite")
+		}
+	})
+
+	t.Run("delivery degraded round-trips", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "sink.yaml", `
+listen:
+  addr: 100.80.229.80:9999
+skip_chrome_sqlite: true
+delivery: degraded
+security:
+  shared_secret: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+`)
+		cfg, err := LoadSink(dir)
+		if err != nil {
+			t.Fatalf("LoadSink: %v", err)
+		}
+		if cfg.Delivery != "degraded" {
+			t.Errorf("Delivery: got %q, want %q", cfg.Delivery, "degraded")
+		}
+	})
+
+	t.Run("absent delivery defaults to empty (no migration)", func(t *testing.T) {
+		// A sink.yaml written before this field must load cleanly with an
+		// empty Delivery and unchanged behavior -- no silent flip.
+		dir := t.TempDir()
+		writeFile(t, dir, "sink.yaml", `
+listen:
+  addr: 100.80.229.80:9999
+security:
+  shared_secret: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+`)
+		cfg, err := LoadSink(dir)
+		if err != nil {
+			t.Fatalf("LoadSink: %v", err)
+		}
+		if cfg.Delivery != "" {
+			t.Errorf("Delivery: got %q, want empty (legacy default)", cfg.Delivery)
+		}
+	})
+}
+
 func TestLoadSinkHonorsExplicitListenAddr(t *testing.T) {
 	// Regression for v0.11 -> v0.12: an existing sink.yaml that already
 	// has a 100.x address keeps working without re-detection prompting.


### PR DESCRIPTION
agentcookie syncs cookies and secrets to a headless sink reliably, but consumers (agent CLIs) could not use what was synced: amazon-orders only knows the Chrome+keychain path (which hangs headless), and Tesla's tokens synced under `OAUTH_BEARER` while tesla-pp-cli reads `TESLA_AUTH_TOKEN`, with nothing bridging the two. macOS won't durably grant ad-hoc-signed Go CLIs keychain access (the reason the adapter model exists), so the fix is a generic, keychain-free read interface consumers shell out to.

This is Phase A: the agentcookie side. CLI-side PRs (amazon-orders, tesla) and a sink deploy/verify plan follow separately.

## What's added

- `agentcookie cookies --domain <d> [--json]` reads the plaintext sidecar and prints a domain's cookies as a Cookie header or JSON. Universal (any tool, any domain), keychain-free, host-scoped (no look-alikes), blocklist-enforced, empty-is-not-an-error.
- `agentcookie secret alias <cli> <declared> <stored>` maps a consumer's declared env var to a synced key, resolved live in `secret env` so it tracks refreshes. Explicit only: it never guesses bearer vs refresh.
- `discover` gains a COVERAGE column and `doctor` a `Secret coverage` check that flag any CLI whose synced secrets don't provide the auth env var it reads, with the exact `secret alias` fix command.
- `doctor` gains a `Binary install` check that flags multiple diverging agentcookie binaries (the stale-on-PATH vs running-daemon footgun), and the CDP check now clarifies the synced profile vs the intentionally-unsynced default.
- `docs/consumption.md` documents the contract.

## Verification

Full module test suite green. Validated against the live sink data: `discover` and `doctor` correctly surface the real tesla-pp-cli `OAUTH_BEARER` vs `TESLA_AUTH_TOKEN` mismatch and the fix.