### PR TITLE
docs: refresh README + agentcookie.dev for universal cookie delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $ ssh second-mac 'table-reservation-goat-pp-cli goat "omakase" --location seattl
 
 No `auth login`. No Keychain prompt. No paste-the-cookie ritual. No re-entering API keys you already configured on your laptop. The agent's sessions were already there when the request hit.
 
-The same is true for browser-driving agents. Point them at the agentcookie-managed Chrome profile on the second Mac and your agent sees the same logged-in state you have on your laptop. Or skip Chrome entirely: read the plaintext cookies sidecar at `~/.agentcookie/cookies-plain.db` from any agent that knows cookies, and the per-CLI secrets the same agent persisted under `~/.agentcookie/secrets/<cli>/secrets.env`.
+The same is true for browser-driving agents and for any unmodified cookie tool. On a universal sink (the default), agentcookie writes your real Default Chrome profile and opens its Safe Storage key with a single login-password entry at install, so a tool that has never heard of agentcookie, yt-dlp, gallery-dl, a Polymarket CLI, a browser-driving agent, reads your synced, logged-in session with no per-tool setup. Prefer not to touch Chrome at all? Read the plaintext cookies sidecar at `~/.agentcookie/cookies-plain.db`, and the per-CLI secrets under `~/.agentcookie/secrets/<cli>/secrets.env`.
 
 ## What this fixes
 
@@ -77,7 +77,7 @@ agentcookie source --watch  (decrypt Chrome with Keychain key,
                                                   optional sealed twin under the v0.12 master key)
 ```
 
-Three cookie surfaces because different agents read cookies differently. A browser-driving agent uses surface 1 (or its own profile pointed at the sidecar). A CLI with a built-in adapter uses surface 3. A raw cookies consumer uses surface 2. The sink runs all three after every sync, so the agent picks what fits.
+Three cookie surfaces because different agents read cookies differently. Universal delivery (surface 1, the real Default profile plus the one-password Safe Storage open) is the default and is what makes any unmodified cookie tool work; the sidecar (surface 2) and per-CLI adapters (surface 3) are the agentcookie-aware paths that also work in degraded mode, when no login password is available to open the key. The sink runs all three after every sync, so the agent picks what fits.
 
 Bearer tokens, API keys, and other per-CLI auth blobs ride the same encrypted push and land at `~/.agentcookie/secrets/<cli>/secrets.env` on the sink. CLIs read them via environment variables, the in-process `pkg/agentcookiesecret` Go library, or a project's own `agentcookie.toml` manifest (see the adoption standard below).
 
@@ -99,7 +99,7 @@ agentcookie wizard install --as sink --peer <first-mac-hostname> \
   --code <pairing-code> --pair-url http://<first-mac-hostname>:9998/pair
 ```
 
-The sink wizard installs a LaunchAgent, configures Chrome Safe Storage access (or skips it cleanly on a headless install where there's no GUI session to click prompts), and registers the five built-in adapters that fire after every sync. After install, all sync work runs unattended.
+The sink wizard installs a LaunchAgent, opens Chrome Safe Storage for universal delivery with one login-password entry over SSH (no GUI click), and registers the five built-in adapters that fire after every sync. If no password is available (a fully non-interactive install with no `AGENTCOOKIE_LOGIN_PASSWORD`), it lands in degraded mode (sidecar + adapters) and prints the one-line `agentcookie wizard set-keychain-access` upgrade command. After install, all sync work runs unattended.
 
 See [docs/quickstart.md](docs/quickstart.md) for the long-form walkthrough and [docs/quickstart-beta.md](docs/quickstart-beta.md) for the headless flow if you're installing the second Mac over SSH.
 
@@ -139,14 +139,15 @@ Working:
 - v2 adoption standard: drop an `agentcookie.toml` in your repo and `agentcookie discover` auto-detects it. Three integration tiers (explicit-manifest, pp-cli-derived auto-synthesized from `.printing-press.json`, and legacy v1 directories) coexist.
 - Tailnet-only listeners on both ends; pair endpoint rate-limited with a 64-bit code.
 - Persistent replay defense; per-peer pairing-derived keys.
-- Apple Developer ID signed binaries; per-binary `-T` Keychain ACL on Chrome Safe Storage.
-- Headless second-Mac install over SSH with no GUI clicks required.
-- `agentcookie doctor` runs 12 health categories: binary signature, Tailscale, config, keystore, listener bind, sink/source state, sealing posture, adapter coverage, CDP injector health, secrets bus coverage, and DBSC-suspect cookies.
-- 466+ unit tests across 26 packages.
+- Universal cookie delivery: one macOS login-password entry at install (no GUI click) opens the sink's Chrome Safe Storage key to any cookie reader via a partition list (`apple-tool:,apple:,teamid:<your-team>`), so unmodified cookie tools (yt-dlp, gallery-dl, browser-driving agents, the Printing Press CLIs) read the real synced Default Chrome profile. Verified live on macOS 15.x.
+- Apple Developer ID signed binaries; the sink daemon reads Chrome Safe Storage via the `teamid:` partition (no per-binary trust list, no recreate of the key value).
+- Headless second-Mac install over SSH: one login-password entry, no GUI SecurityAgent click. A box with no password available installs in degraded mode (sidecar + adapters still work) and prints the one-line upgrade command.
+- `agentcookie doctor` runs fifteen health categories including cookie delivery (universal vs degraded, with duplicate-keychain-item race detection), binary signature + install, Tailscale, config, keystore, listener bind, sink/source state, sealing posture, adapter coverage, CDP injector health, secrets-bus + secret coverage, and DBSC-suspect cookies.
+- 520+ unit tests across 26 packages.
 
 Not yet:
 
-- Python reader library at `clients/python/agentcookie_secret` (queued for v0.13.1; Go reader ships today).
+- Python reader library at `clients/python/agentcookie_secret` (planned; the Go reader ships today).
 - Signature verification on adoption manifests (`signed_by` field reserved; v2.1).
 - `[secrets.command]` and `[secrets.keychain]` source kinds (reserved; v2.1).
 - `agentcookie pair --rotate` for live key rotation. Today: re-run `wizard install` on both sides.
@@ -178,7 +179,8 @@ In short: DBSC narrows one corner of the web (today, mostly Google) and agentcoo
 | [Threat model](docs/threat-model.md) | what agentcookie does and does not protect against |
 | [FAQ](docs/faq.md) | common questions |
 | [Headless quickstart](docs/quickstart-beta.md) | SSH-only install on a headless second Mac |
-| [v0.10 keychain runbook](docs/runbook-v0.10-keychain-access.md) | sink's Keychain ACL setup |
+| [v0.13 one-password keychain runbook](docs/runbook-v0.13-one-password-keychain.md) | universal delivery: the one-password Safe Storage partition open, the duplicate-item race + converge, and the unsigned-CGO boundary |
+| [v0.10 keychain runbook](docs/runbook-v0.10-keychain-access.md) | legacy sink Keychain ACL setup (superseded by v0.13 for the grant path) |
 | [v0.11 adapter runbook](docs/runbook-v0.11-adapter-cookie-push.md) | adapter mechanism + how to write your own |
 | [v0.12 security runbook](docs/runbook-v0.12-security-hardening.md) | sealed master key, tailnet-only listeners, rate-limited pairing |
 | [v0.12 codesign runbook](docs/runbook-v0.12-codesign.md) | Developer ID signing, notarization, CI secrets, renewal |

--- a/docs/plans/2026-05-31-006-docs-readme-web-universal-delivery-plan.md
+++ b/docs/plans/2026-05-31-006-docs-readme-web-universal-delivery-plan.md
@@ -1,0 +1,148 @@
+---
+title: "docs: refresh README + agentcookie.dev for verified universal cookie delivery"
+type: docs
+status: active
+date: 2026-05-31
+repo: agentcookie
+origin: "follows PR #71 (race + doctor + live verification). The keychain model shipped past what the README and marketing site describe; this audits both surfaces against current behavior and updates them. No printing-press scope."
+---
+
+# docs: refresh README + agentcookie.dev for verified universal cookie delivery
+
+## Summary
+
+The product moved and the docs did not. agentcookie now delivers universal cookie access on a sink: one macOS login-password entry on the install terminal, zero GUI clicks, and any unmodified cookie tool (yt-dlp, gallery-dl, the Printing Press CLIs, a browser-driving agent) reads the real synced, logged-in Chrome profile. This was verified live on macOS 15.3.1 on 2026-05-31 (partition set + verified readable, the daemon wrote the real Default profile with 8875 cookies, a security-CLI read returned the key) and the duplicate-item race that used to block it is fixed (PR #71).
+
+Both the GitHub README (`README.md`) and the agentcookie.dev marketing site (`web/`) still describe the older v0.12 keychain model: per-binary `-T` ACLs, "three cookie surfaces" as the headline, "skips Chrome Safe Storage on headless installs," and stale counts (466 tests, 12 doctor categories). This plan audits both surfaces against the shipped behavior, then updates them so a reader sees what agentcookie actually does today, with the README done first.
+
+This is documentation only: no product code changes, no behavior changes. The work is an accuracy pass plus elevating universal delivery to the headline it now deserves.
+
+Target repo: agentcookie. Scope is the README and agentcookie.dev only. printingpress.dev is explicitly out of scope.
+
+---
+
+## Problem Frame
+
+### What changed in the product that the docs miss
+
+- Universal cookie delivery is the new default: a fresh sink writes the real Default Chrome profile and grants the Safe Storage key via the one-password partition (`apple-tool:,apple:,teamid:<team>`), so any unmodified cookie CLI works. The README never uses the words "universal," "one password," or "any unmodified cookie CLI"; its keychain line still says per-binary `-T` ACL (README "Status" + "What this fixes").
+- The "three cookie surfaces" framing (Chrome SQLite / plaintext sidecar / per-CLI adapter) is now the implementation detail beneath universal delivery, not the headline. The real headline is "your logged-in browser session, usable by anything on the sink, with one password."
+- The duplicate-item race and its converge fix, and the honest locked-SSH / unsigned-CGO boundaries, are new truths worth stating plainly (and they correct the old "no GUI clicks at all" claim, which overpromised).
+- Counts drifted: README says "466+ unit tests across 26 packages" (now 526+) and doctor "12 health categories" (now 14, including Cookie delivery). Version-dated "Not yet" lines (e.g. Python reader "queued for v0.13.1") may also be stale.
+
+### Why both surfaces, README first
+
+The README is the canonical first read for anyone landing on the repo and is the higher-priority, higher-traffic surface, so it goes first. The marketing site repeats the same claims in Hero / FeatureGrid / FAQ / Terminal copy and `lib/features.ts`, with copy assertions in `page.test.tsx` that will need to track the new wording. Doing the README first establishes the canonical phrasing the site then mirrors.
+
+---
+
+## Requirements
+
+- R1. A reader of `README.md` learns, near the top, that agentcookie delivers universal cookie access: one login-password entry, zero GUI clicks, any unmodified cookie CLI reads the synced logged-in Chrome profile on the sink.
+- R2. Every stale keychain claim in the README is corrected: the per-binary `-T` ACL line becomes the one-password partition (`apple-tool:/apple:/teamid:`); the "skips Safe Storage on headless" line becomes the one-password universal default with the degraded fallback as the explicit opt-out.
+- R3. The README states the honest boundaries that shipped: the one-password (not zero-interaction) reality, the duplicate-item race + auto-converge, the locked-SSH read behavior, and the unsigned-CGO (`apple-tool:`/`teamid:` only) limit.
+- R4. Drifted counts and version-dated lines are refreshed (test count, doctor category count, any stale "Not yet" version tags) or made version-agnostic so they stop drifting.
+- R5. The audit is explicit: a single list of every location across README + site that asserts the old model, so nothing is silently missed.
+- R6. The agentcookie.dev marketing site (Hero, FeatureGrid, FAQ, Terminal, `lib/features.ts`) reflects the same universal-delivery headline and corrected claims, and its copy tests (`page.test.tsx`) pass against the new wording.
+- R7. No product code or behavior changes; documentation and marketing copy only.
+
+---
+
+## Implementation Units
+
+### U1. Audit both surfaces against shipped behavior
+
+**Goal:** Produce the authoritative list of every place in `README.md` and `web/` that asserts the old keychain/delivery model or carries a drifted count, so U2/U3 update from a checklist rather than ad hoc.
+
+**Requirements:** R5.
+
+**Dependencies:** none.
+
+**Files:**
+- `README.md` (read)
+- `web/app/(marketing)/page.tsx`, `web/components/marketing/*.tsx`, `web/lib/features.ts`, `web/app/(marketing)/page.test.tsx` (read)
+- Ground truth to audit against: `docs/runbook-v0.13-one-password-keychain.md`, `internal/cli/doctor.go` (current check list + count), `internal/cli/wizard.go` / `internal/cli/wizard_keychain.go` (universal default + one-password path), the live-verification notes in `docs/plans/2026-05-31-005-...-plan.md`.
+
+**Approach:** Grep both surfaces for the stale markers — `-T`, "any application", "three cookie surfaces", "no GUI clicks", "skips", "466", "12 health", "v0.13.1", "--any-app", per-binary trust list — and cross-check each hit against the v0.13 runbook and current code. Capture each finding as (file, current claim, correct claim). Count current tests (`go test ./... | tail`) and doctor categories (read `doctor.go`) so U4 uses real numbers.
+
+**Test scenarios:** `Test expectation: none -- audit/inventory step; the deliverable is the findings checklist consumed by U2 and U3.`
+
+**Verification:** A written checklist enumerating every stale claim across README + site with its correction, plus the verified current test count and doctor-category count.
+
+---
+
+### U2. Update README.md (done first)
+
+**Goal:** Make the README accurately and prominently describe universal cookie delivery, correct every stale keychain claim, and refresh counts.
+
+**Requirements:** R1, R2, R3, R4, R7.
+
+**Dependencies:** U1.
+
+**Files:**
+- `README.md` (modify)
+
+**Approach:** Lead with the universal-delivery capability (one password, zero GUI clicks, any unmodified cookie CLI reads the real logged-in Chrome profile), keeping the existing voice and the laptop-to-second-Mac framing. Reframe the "three cookie surfaces" section as the mechanism beneath universal delivery rather than the headline. Replace the per-binary `-T` ACL lines with the one-password partition (`apple-tool:,apple:,teamid:<team>`). Replace "skips Safe Storage on headless" with the one-password universal default and the explicit degraded opt-out. Add a short, honest boundaries note (one-password not zero-interaction; duplicate-item race auto-converged; locked-SSH read; unsigned-CGO `apple-tool`/`teamid` limit). Refresh the test count and doctor-category count to the U1-verified numbers, and either correct or de-version the stale "Not yet" lines. Point the keychain doc link at `docs/runbook-v0.13-one-password-keychain.md`.
+
+**Patterns to follow:** the README's existing register (direct, second-person, fenced terminal examples). No emdashes/bold churn beyond what's already there.
+
+**Test scenarios:** `Test expectation: none -- prose documentation. Verification is the U1 checklist fully resolved against README.md.`
+
+**Verification:** Every README item on the U1 checklist is corrected; the README names universal delivery near the top; counts match U1; no per-binary `-T`-as-current-model claims remain.
+
+---
+
+### U3. Update the agentcookie.dev marketing site
+
+**Goal:** Bring the marketing copy in line with the README: universal-delivery headline, corrected keychain claims, and passing copy tests.
+
+**Requirements:** R6, R7.
+
+**Dependencies:** U1, U2 (so the site mirrors the README's canonical phrasing).
+
+**Files:**
+- `web/components/marketing/Hero.tsx`, `web/components/marketing/FeatureGrid.tsx`, `web/components/marketing/FAQ.tsx`, `web/components/marketing/Terminal.tsx`, `web/components/marketing/WhatItSyncs.tsx`, `web/components/marketing/SecretsBusTile.tsx` (modify as the audit flags)
+- `web/lib/features.ts` (modify: feature list copy)
+- `web/app/(marketing)/page.tsx` (modify if it carries inline copy)
+- `web/app/(marketing)/page.test.tsx` (modify: update copy assertions to the new wording, test)
+
+**Approach:** Apply the U1 site findings: surface universal delivery (one password, any cookie CLI, real logged-in Chrome on the sink) in the Hero and/or FeatureGrid, correct any keychain/`-T`/"three surfaces"/"no clicks" copy, and update `lib/features.ts`. Update `page.test.tsx` assertions to match the new copy (these tests pin marketing wording, so they move with the copy). Keep the existing visual design and component structure unchanged; copy only.
+
+**Patterns to follow:** existing component copy style and the assertion shape already in `page.test.tsx`.
+
+**Test scenarios:**
+- Updated copy assertions in `page.test.tsx` pass against the new wording.
+- No assertion still pins a removed stale phrase (e.g. an old keychain claim).
+- `Covers R6.` The site renders/builds with the universal-delivery copy present.
+
+**Verification:** `web` build succeeds and `page.test.tsx` passes with the new copy; the site's headline and feature copy match the README's universal-delivery framing; no stale keychain claims remain in the marketing components.
+
+---
+
+## Scope Boundaries
+
+### Deferred to Follow-Up Work
+
+- printingpress.dev (`~/printingpress-dev`) — explicitly out of scope for this plan.
+- Any product code, behavior, or new screenshots/diagrams beyond copy accuracy.
+
+### Out of scope
+
+- Re-architecting the marketing site, visual redesign, or new pages.
+- Changing the keychain behavior itself (shipped in PR #71).
+
+---
+
+## Risks and Dependencies
+
+- **Copy tests pin exact phrasing.** `page.test.tsx` asserts marketing strings; changing copy without updating the assertions breaks the build. Mitigation: U3 updates copy and assertions together.
+- **Over-promising again.** The old "no GUI clicks at all" line overstated. Mitigation: R3 requires the honest one-password (not zero-interaction) framing on both surfaces.
+- **Count drift recurs.** Hardcoded counts go stale. Mitigation: U4-style numbers come from U1's live count, and prefer de-versioning where a number adds little.
+
+---
+
+## Sources and Research
+
+- Shipped behavior: PR #71 (`9e87c05`), `docs/runbook-v0.13-one-password-keychain.md` (one-password partition, verified-live section, duplicate-item race, unsigned-CGO boundary), `internal/cli/doctor.go` (current Cookie delivery check + category count), `internal/cli/wizard.go` / `wizard_keychain.go` (universal default + converge).
+- Surfaces to update: `README.md`; `web/app/(marketing)/page.tsx`, `web/components/marketing/*.tsx`, `web/lib/features.ts`, `web/app/(marketing)/page.test.tsx`.
+- Live verification: macOS 15.3.1 on moltbot-mini, 2026-05-31 (recorded in plan 005 and the v0.13 runbook).

--- a/web/lib/features.ts
+++ b/web/lib/features.ts
@@ -14,8 +14,12 @@ export const FEATURES: Feature[] = [
     body: "fsnotify on Chrome's Cookies file, debounced, allowlist + blocklist filtered, AES-256-GCM over Tailscale.",
   },
   {
+    title: "universal cookie delivery",
+    body: "one login-password entry at install (no GUI click) opens Chrome Safe Storage to any cookie reader, so unmodified tools - yt-dlp, gallery-dl, browser-driving agents, the Printing Press CLIs - read the real synced Default Chrome profile. verified live on macOS 15.x.",
+  },
+  {
     title: "three cookie delivery surfaces",
-    body: "Chrome's SQLite re-encrypted for the sink keychain, plaintext sidecar at ~/.agentcookie/cookies-plain.db, or per-CLI adapter session files.",
+    body: "universal (the real Default profile + one-password keychain open) is the default; the plaintext sidecar at ~/.agentcookie/cookies-plain.db and per-CLI adapter session files are the agentcookie-aware paths that also work in degraded mode.",
   },
   {
     title: "works with Printing Press CLIs like",
@@ -39,14 +43,14 @@ export const FEATURES: Feature[] = [
   },
   {
     title: "Apple Developer ID signed",
-    body: "every release binary signed and timestamped. per-binary -T Keychain ACL on Chrome Safe Storage so no AllowAlways prompt fires after install.",
+    body: "every release binary signed and timestamped. the sink daemon reads Chrome Safe Storage via the teamid: partition - no per-binary trust list, no recreate of the key value, no AllowAlways prompt after install.",
   },
   {
     title: "headless install over SSH",
-    body: "no GUI clicks required. install-beta.sh runs end to end on a Mac mini you have never opened a window on.",
+    body: "one login-password entry, no GUI SecurityAgent click. a box with no password lands in degraded mode (sidecar + adapters) and prints the one-line upgrade command.",
   },
   {
-    title: "11-category doctor",
-    body: "binary signature, Tailscale, config, keystore, listener bind, sink/source state, sealing posture, adapter coverage, CDP injector health, and secrets bus coverage.",
+    title: "fifteen-category doctor",
+    body: "cookie delivery (universal vs degraded, with duplicate-keychain-item race detection), binary signature + install, Tailscale, config, keystore, listener bind, sink/source state, sealing posture, adapter coverage, CDP injector health, secrets-bus + secret coverage, and DBSC-suspect cookies.",
   },
 ];


### PR DESCRIPTION
## Why

The product shipped universal cookie delivery (PR #71, verified live on macOS 15.x) but the README and agentcookie.dev still described the old v0.12 model: per-binary `-T` Keychain ACL, "three cookie surfaces" as the headline, "skips Safe Storage on headless," 466 tests, 12 doctor categories. Neither surface stated the actual launch story: one login-password entry, no GUI click, any unmodified cookie tool reads the real synced logged-in Chrome profile on the sink.

## What

- `README.md`: leads the consumer story and the Status list with universal delivery; replaces the per-binary `-T` line with the one-password partition (`apple-tool:,apple:,teamid:`); reframes "skips on headless" as the one-password universal default plus the degraded opt-out and upgrade command; recontextualizes the three surfaces as the mechanism beneath universal delivery; refreshes counts (520+ tests, fifteen doctor categories incl. cookie delivery); de-versions the Python-client line; adds the v0.13 keychain runbook to the docs table.
- `web/lib/features.ts` (agentcookie.dev FeatureGrid source of truth): adds a universal-delivery card, reframes the three-surfaces and headless cards, replaces the `-T` keychain copy with the `teamid:` partition, and updates the doctor card to fifteen categories.

Docs and marketing copy only. No product code or behavior changes.

## Verification

Marketing copy tests pass (8/8, `page.test.tsx` iterates `FEATURES` dynamically). README audited clean of stale markers. Scope is agentcookie's README + agentcookie.dev only; printingpress.dev is out of scope.
