### PR TITLE
feat(secretsbus): manifest-declared env aliases auto-wire consumer CLIs

### DIFF
--- a/docs/spec-agentcookie-secrets-bus-v2-adoption.md
+++ b/docs/spec-agentcookie-secrets-bus-v2-adoption.md
@@ -74,7 +74,21 @@ default = true                                # optional; defaults to true
 [sync.keys]
 SETUP_COMPLETE = false                        # optional per-key overrides
 FROM_BROWSER = false
+
+# Optional. Declare consumer-env-var -> synced-bus-key mappings so a CLI that
+# reads a different env var name than the key its secret was imported under is
+# wired automatically, with no per-user `agentcookie secret alias` command.
+[aliases]
+TESLA_AUTH_TOKEN = "OAUTH_BEARER"             # CLI reads TESLA_AUTH_TOKEN; bus stores it as OAUTH_BEARER
 ```
+
+### 2.3.1 Aliases
+
+The optional `[aliases]` table maps a consumer's declared env var name (the key) to the synced bus key that holds its value (the value). `agentcookie secret env <name>` applies these live on every call, so the mapping tracks token refreshes rather than going stale, and a CLI like `tesla-pp-cli` (which reads `TESLA_AUTH_TOKEN`) auto-connects to a bearer that agentcookie imported as `OAUTH_BEARER` for any user, with no manual command.
+
+- Both the declared var (key) and the bus key (value) must be valid environment variable names: an initial letter or underscore, then letters, digits, or underscores. Invalid names are a hard parse error.
+- An explicit local `agentcookie secret alias` entry for the same declared var overrides the manifest alias, so a user can always redirect the mapping.
+- An alias whose bus key is absent emits nothing for that declared var (no-op), matching the local-alias behavior.
 
 ### 2.4 Reserved fields
 

--- a/internal/cli/secret.go
+++ b/internal/cli/secret.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/mvanhorn/agentcookie/internal/keystore"
+	"github.com/mvanhorn/agentcookie/internal/secretsbus"
 )
 
 var secretCmd = &cobra.Command{
@@ -604,10 +605,7 @@ func runSecretEnv(cmd *cobra.Command, args []string) error {
 	// TESLA_AUTH_TOKEN) is emitted carrying the live value of the synced key
 	// it maps to (e.g. OAUTH_BEARER). Resolved on every call so it tracks
 	// token refreshes rather than going stale.
-	aliases, err := readAliases(cliName)
-	if err != nil {
-		return fmt.Errorf("read aliases: %w", err)
-	}
+	aliases := effectiveAliases(cliName)
 	for declared, stored := range aliases {
 		if v, ok := kv[stored]; ok {
 			kv[declared] = v
@@ -642,6 +640,45 @@ func readAliases(cliName string) (map[string]string, error) {
 		return nil, err
 	}
 	return m, nil
+}
+
+// manifestAliases returns the [aliases] mapping declared in the CLI's
+// agentcookie.toml, discovered from the v2 registry. These ship with the CLI
+// so any user gets the mapping automatically, with no `secret alias` command.
+// A discovery failure or absent manifest yields an empty map (not an error):
+// alias resolution must never break `secret env`.
+func manifestAliases(cliName string) map[string]string {
+	out := map[string]string{}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return out
+	}
+	reg, _ := secretsbus.Discover(secretsbus.DiscoveryConfig{HomeDir: home})
+	if reg == nil {
+		return out
+	}
+	rp, ok := reg.Projects[cliName]
+	if !ok || rp.Manifest == nil {
+		return out
+	}
+	for declared, stored := range rp.Manifest.Aliases {
+		out[declared] = stored
+	}
+	return out
+}
+
+// effectiveAliases merges the automatic, ship-with-the-CLI manifest aliases
+// (base) with explicit local `secret alias` entries from aliases.env (override).
+// A local alias for the same declared var wins over the manifest, so a user can
+// always override the default mapping. This is what makes a CLI like
+// tesla-pp-cli auto-connect for any user without a manual alias command.
+func effectiveAliases(cliName string) map[string]string {
+	merged := manifestAliases(cliName)
+	local, _ := readAliases(cliName)
+	for declared, stored := range local {
+		merged[declared] = stored
+	}
+	return merged
 }
 
 var secretAliasCmd = &cobra.Command{

--- a/internal/cli/secret_alias_test.go
+++ b/internal/cli/secret_alias_test.go
@@ -54,6 +54,68 @@ func TestSecretEnv_AppliesAlias(t *testing.T) {
 	}
 }
 
+// writeManifest drops a v2 adoption manifest at the priority-1 discovery path
+// so secret env / coverage pick up its declared [aliases].
+func writeManifest(t *testing.T, home, cli, body string) {
+	t.Helper()
+	dir := filepath.Join(home, ".agentcookie", "manifests")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, cli+".toml"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSecretEnv_AppliesManifestAlias(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeSecrets(t, home, "tesla-pp-cli", "OAUTH_BEARER=tok-bearer\nOAUTH_REFRESH=tok-refresh\n")
+	// No local `secret alias`; the mapping ships in the manifest.
+	writeManifest(t, home, "tesla-pp-cli", `
+schema_version = 2
+name = "tesla-pp-cli"
+display_name = "Tesla"
+
+[secrets.file]
+path = "~/.config/tesla-pp-cli/config.toml"
+
+[aliases]
+TESLA_AUTH_TOKEN = "OAUTH_BEARER"
+`)
+	out := envLines(t, "tesla-pp-cli")
+	if !strings.Contains(out, "TESLA_AUTH_TOKEN=tok-bearer") {
+		t.Errorf("manifest alias should auto-wire TESLA_AUTH_TOKEN with no local alias, got:\n%s", out)
+	}
+}
+
+func TestSecretEnv_LocalAliasOverridesManifest(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeSecrets(t, home, "tesla-pp-cli", "OAUTH_BEARER=tok-bearer\nALT=tok-alt\n")
+	writeManifest(t, home, "tesla-pp-cli", `
+schema_version = 2
+name = "tesla-pp-cli"
+display_name = "Tesla"
+
+[secrets.file]
+path = "~/.config/tesla-pp-cli/config.toml"
+
+[aliases]
+TESLA_AUTH_TOKEN = "OAUTH_BEARER"
+`)
+	// Local alias points the same declared var at a different stored key.
+	aliasCmd := secretAliasCmd
+	aliasCmd.SetOut(&bytes.Buffer{})
+	if err := runSecretAlias(aliasCmd, []string{"tesla-pp-cli", "TESLA_AUTH_TOKEN", "ALT"}); err != nil {
+		t.Fatalf("set local alias: %v", err)
+	}
+	out := envLines(t, "tesla-pp-cli")
+	if !strings.Contains(out, "TESLA_AUTH_TOKEN=tok-alt") {
+		t.Errorf("local alias should override the manifest mapping, got:\n%s", out)
+	}
+}
+
 func TestSecretEnv_NoAliasesUnchanged(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/cli/secret_coverage.go
+++ b/internal/cli/secret_coverage.go
@@ -40,7 +40,7 @@ func secretCoverage(cliName string, declared []string) (status, detail string) {
 	for _, k := range storeKeys {
 		have[k] = true
 	}
-	aliases, _ := readAliases(cliName)
+	aliases := effectiveAliases(cliName)
 
 	var missing []string
 	for _, d := range declared {

--- a/internal/secretsbus/manifest_v2.go
+++ b/internal/secretsbus/manifest_v2.go
@@ -28,6 +28,17 @@ type ManifestV2 struct {
 
 	Secrets ManifestV2Secrets `toml:"secrets"`
 	Sync    ManifestV2Sync    `toml:"sync,omitempty"`
+
+	// Aliases declares consumer-env-var -> synced-bus-key mappings so a CLI
+	// that reads a different env var name than the key its secret was imported
+	// under is wired automatically, with no per-user `secret alias` command.
+	// Example: a Tesla CLI reads TESLA_AUTH_TOKEN but agentcookie imports the
+	// bearer as OAUTH_BEARER, so the manifest declares
+	//   [aliases]
+	//   TESLA_AUTH_TOKEN = "OAUTH_BEARER"
+	// `secret env` applies these live on every call (tracking refreshes), and
+	// an explicit local `secret alias` still overrides a manifest alias.
+	Aliases map[string]string `toml:"aliases,omitempty"`
 }
 
 // ManifestV2Secrets carries exactly one of File / Command / Keychain.
@@ -214,7 +225,40 @@ func validateManifestV2(m *ManifestV2, sourcePath string) error {
 		}
 	}
 
+	for declared, stored := range m.Aliases {
+		if !validEnvKey(declared) {
+			return fmt.Errorf("[aliases] key %q is not a valid env var name (A-Z, 0-9, underscore; not starting with a digit)", declared)
+		}
+		if !validEnvKey(stored) {
+			return fmt.Errorf("[aliases] %q maps to %q, which is not a valid env var name", declared, stored)
+		}
+	}
+
 	return nil
+}
+
+// validEnvKey reports whether s is a shell-safe environment variable name:
+// an initial letter or underscore followed by letters, digits, or underscores.
+// Used to validate manifest [aliases] entries (both the declared consumer var
+// and the synced bus key it maps from).
+func validEnvKey(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i, r := range s {
+		isLetter := (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z')
+		isDigit := r >= '0' && r <= '9'
+		if i == 0 {
+			if !isLetter && r != '_' {
+				return false
+			}
+			continue
+		}
+		if !isLetter && !isDigit && r != '_' {
+			return false
+		}
+	}
+	return true
 }
 
 // ResolveSecretsPath expands ~/ in [secrets.file].path against the given

--- a/internal/secretsbus/manifest_v2_test.go
+++ b/internal/secretsbus/manifest_v2_test.go
@@ -100,6 +100,53 @@ path = "~/.config/demo/.env"
 	}
 }
 
+func TestParseManifestV2_ParsesAliases(t *testing.T) {
+	body := `
+schema_version = 2
+name = "tesla-pp-cli"
+display_name = "Tesla"
+
+[secrets.file]
+path = "~/.config/tesla-pp-cli/config.toml"
+
+[aliases]
+TESLA_AUTH_TOKEN = "OAUTH_BEARER"
+`
+	m, warnings, err := parseManifestV2Bytes([]byte(body), "test.toml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, w := range warnings {
+		if strings.Contains(w.Message, "aliases") {
+			t.Errorf("aliases should not warn as unknown: %v", w)
+		}
+	}
+	if got := m.Aliases["TESLA_AUTH_TOKEN"]; got != "OAUTH_BEARER" {
+		t.Errorf("alias = %q, want OAUTH_BEARER", got)
+	}
+}
+
+func TestParseManifestV2_RejectsInvalidAliasName(t *testing.T) {
+	body := `
+schema_version = 2
+name = "demo"
+display_name = "Demo"
+
+[secrets.file]
+path = "~/.config/demo/.env"
+
+[aliases]
+"not a valid var" = "OAUTH_BEARER"
+`
+	_, _, err := parseManifestV2Bytes([]byte(body), "test.toml")
+	if err == nil {
+		t.Fatal("expected error rejecting invalid alias env var name")
+	}
+	if !strings.Contains(err.Error(), "aliases") {
+		t.Errorf("error should reference aliases: %v", err)
+	}
+}
+
 func TestParseManifestV2_RejectsV1Schema(t *testing.T) {
 	body := `
 schema_version = 1


### PR DESCRIPTION
## Why

A CLI that reads a different env var name than the key its secret was imported under needed a manual, per-machine `agentcookie secret alias`. The live case: tesla-pp-cli reads `TESLA_AUTH_TOKEN`, but agentcookie's importer stores the bearer as `OAUTH_BEARER`, so every user had to run the alias by hand and `discover` reported MISMATCH. For a device CLI to auto-connect for *everyone* who has agentcookie + that CLI, the mapping has to ship with the CLI, not live in per-user config.

## What

- New optional `[aliases]` table in the v2 adoption manifest (`agentcookie.toml`): consumer-env-var -> synced-bus-key. Validated as env var names; documented in the v2 spec.
- `secret env` and `secret coverage` now resolve aliases via `effectiveAliases` = manifest aliases (automatic base) merged with local `aliases.env` (explicit override wins). Resolved live on every call, so it tracks token refreshes and never goes stale. No persisted state; `discover` stays read-only.

This is the keystone for device-CLI auto-connect: once a CLI ships an `agentcookie.toml` declaring its alias, any user gets the right env var with zero manual steps.

## Verification

560 tests pass. New coverage: manifest `[aliases]` parse + invalid-name rejection; `secret env` auto-applies a manifest alias with no local alias; a local alias overrides the manifest mapping.

Part of the Tesla "works for everyone" plan; the tesla-pp-cli manifest, sealed signing-key carriage, and live verification land separately.
