### PR TITLE
feat(secretsbus): sealed file-carriage over the bus ([[files]] manifest)

### DIFF
--- a/docs/spec-agentcookie-secrets-bus-v2-adoption.md
+++ b/docs/spec-agentcookie-secrets-bus-v2-adoption.md
@@ -80,6 +80,15 @@ FROM_BROWSER = false
 # wired automatically, with no per-user `agentcookie secret alias` command.
 [aliases]
 TESLA_AUTH_TOKEN = "OAUTH_BEARER"             # CLI reads TESLA_AUTH_TOKEN; bus stores it as OAUTH_BEARER
+
+# Optional. Carry arbitrary files (a multiline PEM, a TOML config) sealed, and
+# materialize them on the sink as 0600 files under ~/.agentcookie/. Coexists
+# with the single [secrets.*] block; not a second [secrets.*] block. See 5.4.
+[[files]]
+source = "~/.config/tesla-pp-cli/config.toml" # file to read + base64 into the bus
+key = "TESLA_CONFIG_TOML"                      # wire key the base64 payload rides under
+target = "tesla-pp-cli/config.toml"            # materialization path, relative, under ~/.agentcookie/
+optional = false                              # true = opt-in (not carried unless enabled)
 ```
 
 ### 2.3.1 Aliases
@@ -168,6 +177,49 @@ Reserved schema slot. v2.0 parsers reject with "exec source not yet supported."
 
 Reserved schema slot. v2.0 parsers reject with "keychain source not yet supported."
 
+### 5.4 `[[files]]` carried-file items
+
+The `[secrets.*]` block carries `KEY=VALUE` env pairs. Some secrets are not env-shaped: a multiline EC private-key PEM or a TOML `config.toml` cannot ride as a single `KEY=VALUE` value. The `[[files]]` array carries arbitrary files from source to sink, sealed in transit and at rest, and materializes them on the sink as mode-0600 files under `~/.agentcookie/`.
+
+`[[files]]` is a NEW construct that COEXISTS with the single `[secrets.*]` block. It is not a second `[secrets.*]` block, so the "exactly one `[secrets.*]`" rule (section 5) is unaffected. A manifest may declare zero or more `[[files]]` items alongside its one `[secrets.*]` block.
+
+```toml
+[[files]]
+source = "~/.config/tesla-pp-cli/config.toml"   # required; file to read + base64 into the bus. ~/ expands.
+key = "TESLA_CONFIG_TOML"                        # required; the wire key the base64 payload rides under.
+target = "tesla-pp-cli/config.toml"              # required; materialization path, RELATIVE, under ~/.agentcookie/.
+optional = false                                 # optional; default false. true = opt-in (see below).
+
+[[files]]
+source = "~/.tesla/fleet-private.pem"
+key = "TESLA_FLEET_KEY_PEM"
+target = "tesla-pp-cli/fleet-key.pem"
+optional = true                                  # opt-in: NOT carried unless the user enables it.
+```
+
+#### Carriage mechanism
+
+Because the wire envelope is a flat `map[string]map[string]string` (per-CLI -> key -> value), a carried file rides as a SINGLE key whose value is the **base64** encoding of the file bytes (single-line, dotenv-safe). Multiline values are never put on the wire. Each item adds two keys to its CLI's env map:
+
+- `key` -> the base64 payload of the file bytes.
+- `_FILE_<key>` -> the relative `target`. This reserved companion key (underscore-prefixed, per the v1 dotenv grammar) is the materialization instruction, so the sink needs no copy of the manifest.
+
+On the sink, the secrets writer decodes each `_FILE_<key>`/`key` pair, writes the decoded bytes 0600 to `target` under `~/.agentcookie/`, and strips both keys from the per-CLI `secrets.env` (a carried file does not also leak as an env var).
+
+#### Validation
+
+- `source` is required and MUST NOT contain `..`. `~/` expands to the user's home.
+- `key` is required and MUST be a valid environment variable name (initial letter or underscore, then letters/digits/underscores). Duplicate `key` across items is a hard error.
+- `target` is required, MUST be relative (not absolute), MUST NOT contain `..`, and MUST resolve to a path strictly inside `~/.agentcookie/`. The sink re-validates the target and refuses to write (rather than write insecurely) if it escapes the root, the base64 is malformed, or the decoded payload exceeds 256 KB.
+
+#### Opt-in (`optional = true`)
+
+An item with `optional = true` is opt-in: discovery does NOT carry it unless the user enables it. Enabled item keys live one-per-line in `~/.agentcookie/file-optin/<name>.keys` (blank lines and `#` comments ignored). A default item (`optional = false`) is always carried. This gates deliberate exposures (e.g. a command-signing key landing on a headless sink) behind explicit per-user consent.
+
+#### Security posture ("sealed")
+
+Carried files are encrypted in transit over the tailnet AND at rest in the bus (the existing v0.12 sealed-envelope path). The materialized file on the sink is a 0600 plaintext file owned by the sink user: on-sink protection is file permissions. Files are written only under `~/.agentcookie/`, never world/group-readable, never outside that directory.
+
 ## 6. Sync policy
 
 Identical semantics to v1 `[sync]` table.
@@ -241,7 +293,9 @@ This is the user's window into auto-discovery.
 
 ## 9. Wire envelope
 
-No changes. The v1 `Secrets map[string]map[string]string` field carries the merged payload (v1 bus + read-in-place discovery results). Sinks running v0.13 accept v0.14 source pushes transparently.
+No envelope-shape changes. The v1 `Secrets map[string]map[string]string` field carries the merged payload (v1 bus + read-in-place discovery results). Sinks running v0.13 accept v0.14 source pushes transparently.
+
+Carried files (section 5.4) ride inside this same flat map as ordinary keys: the base64 payload under `key` and the relative target under the reserved companion `_FILE_<key>`. No new envelope field is introduced; a sink that does not understand `_FILE_*` companions simply persists them as env keys (forward-degradation), while a current sink materializes and strips them.
 
 ## 10. Read-in-place vs copy-to-bus
 

--- a/internal/cli/sink.go
+++ b/internal/cli/sink.go
@@ -273,8 +273,8 @@ func runSink(cmd *cobra.Command, args []string) error {
 			for _, e := range secErrs {
 				fmt.Fprintf(os.Stderr, "agentcookie sink: secrets-bus: %v\n", e)
 			}
-			fmt.Fprintf(os.Stderr, "agentcookie sink: secrets-bus wrote %d cli(s), %d key(s), %d sealed\n",
-				secResult.CLIsWritten, secResult.KeysWritten, secResult.SealedWritten)
+			fmt.Fprintf(os.Stderr, "agentcookie sink: secrets-bus wrote %d cli(s), %d key(s), %d sealed, %d file(s) materialized\n",
+				secResult.CLIsWritten, secResult.KeysWritten, secResult.SealedWritten, secResult.FilesMaterialized)
 		}
 
 		_ = stateWriter.Save(sinkState)

--- a/internal/secretsbus/discover_merge.go
+++ b/internal/secretsbus/discover_merge.go
@@ -54,6 +54,21 @@ func LoadPayloadWithDiscovery(homeDir string) (*Payload, []error) {
 				filtered[k] = v
 			}
 		}
+
+		// Carry any declared [[files]] items: read each enabled file, base64
+		// it into its declared key, and add the companion target so the sink
+		// materializes it. Optional items are carried only when opted in.
+		if len(rp.Manifest.Files) > 0 {
+			enabled := LoadEnabledFileKeys(homeDir, slug)
+			carried, carryErrs := CarryFiles(rp.Manifest.Files, enabled, homeDir)
+			for _, e := range carryErrs {
+				errs = append(errs, fmt.Errorf("discovered project %q: %w", slug, e))
+			}
+			for k, v := range carried {
+				filtered[k] = v
+			}
+		}
+
 		if len(filtered) == 0 {
 			continue
 		}

--- a/internal/secretsbus/filecarriage.go
+++ b/internal/secretsbus/filecarriage.go
@@ -1,0 +1,253 @@
+package secretsbus
+
+import (
+	"bufio"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// File carriage lets the secrets bus carry an arbitrary FILE (a multiline PEM,
+// a TOML config) from source to sink and materialize it on the sink as a
+// mode-0600 file under ~/.agentcookie/.
+//
+// The wire envelope is a flat map[string]map[string]string (per-CLI -> key ->
+// value), so a file cannot ride as a raw multiline value. Each carried file
+// rides as TWO single-line keys in the CLI's env map:
+//
+//   - the declared key K, whose value is the base64 encoding of the file bytes
+//     (single-line, dotenv-safe);
+//   - a reserved companion key _FILE_<K>, whose value is the relative target
+//     path (under ~/.agentcookie/) the sink materializes K to.
+//
+// The companion key is the carriage instruction: it travels in the same flat
+// envelope so the sink needs no copy of the manifest (manifests stay
+// source-side per the v2 spec). Reserved keys are underscore-prefixed and pass
+// through the v1 dotenv grammar unchanged.
+
+// fileTargetKeyPrefix is the reserved prefix for the companion key that tells
+// the sink where to materialize a carried file. _FILE_<K> holds the relative
+// target path for the carried payload under key K.
+const fileTargetKeyPrefix = "_FILE_"
+
+// maxCarriedFileBytes caps a single carried file at 256 KB (decoded), matching
+// the v1 secrets.env size cap. Oversized payloads are refused, not written, so
+// a runaway file cannot swamp the sink.
+const maxCarriedFileBytes = 256 * 1024
+
+// CarryFileKey returns the reserved companion key for a carried-file payload
+// key. The sink scans for keys with this prefix to find materialization
+// instructions.
+func CarryFileKey(payloadKey string) string {
+	return fileTargetKeyPrefix + payloadKey
+}
+
+// CarryFiles reads each enabled [[files]] item from a manifest, base64-encodes
+// its source file, and returns the per-key additions to inject into the CLI's
+// env map: the base64 payload under item.Key plus the companion target under
+// _FILE_<item.Key>.
+//
+// enabled is the set of opt-in (Optional=true) item keys the user has turned
+// on. A default item (Optional=false) is always carried; an optional item is
+// carried only when enabled[item.Key] is true. This implements the opt-in /
+// discovery-does-not-carry-unless-enabled rule.
+//
+// homeDir expands a leading ~/ in each item's Source. Missing source files,
+// oversized files, and invalid targets accumulate as non-fatal errors so one
+// bad item does not abort the push; the returned map omits failed items.
+func CarryFiles(files []ManifestV2File, enabled map[string]bool, homeDir string) (map[string]string, []error) {
+	out := map[string]string{}
+	var errs []error
+	for i := range files {
+		f := &files[i]
+		if f.Optional && !enabled[f.Key] {
+			continue // opt-in item the user has not enabled: do not carry.
+		}
+		// Re-validate the target defensively even though parse validated it;
+		// a manifest could be hand-built and reach here without ParseManifestV2.
+		if err := validateMaterializeTarget(f.Target); err != nil {
+			errs = append(errs, fmt.Errorf("file item %q: %w", f.Key, err))
+			continue
+		}
+		if !validKeyName(f.Key) {
+			errs = append(errs, fmt.Errorf("file item %q: invalid carry key", f.Key))
+			continue
+		}
+		src := expandHome(f.Source, homeDir)
+		info, err := os.Stat(src)
+		if err != nil {
+			if os.IsNotExist(err) {
+				errs = append(errs, fmt.Errorf("file item %q: source missing: %s", f.Key, src))
+			} else {
+				errs = append(errs, fmt.Errorf("file item %q: stat %s: %w", f.Key, src, err))
+			}
+			continue
+		}
+		if info.IsDir() {
+			errs = append(errs, fmt.Errorf("file item %q: source %s is a directory", f.Key, src))
+			continue
+		}
+		if info.Size() > maxCarriedFileBytes {
+			errs = append(errs, fmt.Errorf("file item %q: source %s is %d bytes, over the %d byte limit; not carrying", f.Key, src, info.Size(), maxCarriedFileBytes))
+			continue
+		}
+		data, err := os.ReadFile(src)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("file item %q: read %s: %w", f.Key, src, err))
+			continue
+		}
+		out[f.Key] = base64.StdEncoding.EncodeToString(data)
+		out[CarryFileKey(f.Key)] = f.Target
+	}
+	return out, errs
+}
+
+// LoadEnabledFileKeys reads the per-CLI opt-in set for carried files. Opt-in
+// keys live one-per-line in ~/.agentcookie/file-optin/<cli>.keys; blank lines
+// and # comments are ignored. A missing file means "nothing opted in" (the
+// default), so an optional [[files]] item is not carried until the user adds
+// its key here. This is the discovery-does-not-carry-unless-enabled gate for
+// opt-in items; default (non-optional) items ignore this set entirely.
+func LoadEnabledFileKeys(homeDir, cliName string) map[string]bool {
+	enabled := map[string]bool{}
+	p := filepath.Join(agentcookieRoot(homeDir), "file-optin", cliName+".keys")
+	f, err := os.Open(p)
+	if err != nil {
+		return enabled // missing or unreadable: nothing opted in.
+	}
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		enabled[line] = true
+	}
+	return enabled
+}
+
+// MaterializeResult reports the outcome of MaterializeFiles for sink logging.
+type MaterializeResult struct {
+	// FilesWritten is the count of carried files materialized to 0600 files.
+	FilesWritten int
+}
+
+// MaterializeFiles scans a per-CLI env map for carried-file companion keys
+// (_FILE_<K>), decodes the base64 payload under K, and writes the bytes to a
+// 0600 file under ~/.agentcookie/ at the companion's relative target. It
+// returns the decoded payload key set so the caller can strip those keys (and
+// their companions) from the env map before it is written as plaintext
+// secrets.env (a carried file should not also leak as an env var).
+//
+// Security invariants (refuse rather than write insecurely):
+//   - The target is resolved under ~/.agentcookie/ ONLY. A target that is
+//     absolute, contains "..", or otherwise resolves outside ~/.agentcookie/
+//     is refused with an error and nothing is written.
+//   - The file is written mode 0600 (never group/world readable) via the
+//     atomic write path (sibling .tmp + fsync + rename), so an existing file
+//     is overwritten value-preserved/atomically.
+//   - An oversized decoded payload is refused.
+//
+// The returned consumedKeys set contains both the payload key K and its
+// companion _FILE_<K> for every successfully materialized file.
+func MaterializeFiles(homeDir string, cliName string, env map[string]string) (MaterializeResult, map[string]bool, []error) {
+	var result MaterializeResult
+	consumed := map[string]bool{}
+	var errs []error
+
+	root := agentcookieRoot(homeDir)
+
+	// Deterministic-ish: collect companion keys first.
+	for k, target := range env {
+		if !strings.HasPrefix(k, fileTargetKeyPrefix) {
+			continue
+		}
+		payloadKey := strings.TrimPrefix(k, fileTargetKeyPrefix)
+		if payloadKey == "" {
+			errs = append(errs, fmt.Errorf("%s: companion key %q has no payload key", cliName, k))
+			continue
+		}
+		b64, ok := env[payloadKey]
+		if !ok {
+			errs = append(errs, fmt.Errorf("%s: companion key %q present but payload key %q missing", cliName, k, payloadKey))
+			// Still consume the dangling companion so it does not leak.
+			consumed[k] = true
+			continue
+		}
+
+		// The sink does NOT trust the wire: re-validate the target.
+		if err := validateMaterializeTarget(target); err != nil {
+			errs = append(errs, fmt.Errorf("%s: refusing to materialize %q: %w", cliName, payloadKey, err))
+			continue
+		}
+
+		decoded, err := base64.StdEncoding.DecodeString(b64)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%s: payload %q is not valid base64: %w", cliName, payloadKey, err))
+			continue
+		}
+		if len(decoded) > maxCarriedFileBytes {
+			errs = append(errs, fmt.Errorf("%s: payload %q decodes to %d bytes, over the %d byte limit; not writing", cliName, payloadKey, len(decoded), maxCarriedFileBytes))
+			continue
+		}
+
+		dest, err := safeJoinUnderRoot(root, target)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%s: refusing to materialize %q: %w", cliName, payloadKey, err))
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(dest), 0o700); err != nil {
+			errs = append(errs, fmt.Errorf("%s: mkdir for %q: %w", cliName, payloadKey, err))
+			continue
+		}
+		if err := atomicWrite(dest, decoded, 0o600); err != nil {
+			errs = append(errs, fmt.Errorf("%s: write %q to %s: %w", cliName, payloadKey, dest, err))
+			continue
+		}
+		result.FilesWritten++
+		consumed[payloadKey] = true
+		consumed[k] = true
+	}
+
+	return result, consumed, errs
+}
+
+// agentcookieRoot returns the absolute ~/.agentcookie directory.
+func agentcookieRoot(homeDir string) string {
+	return filepath.Join(homeDir, ".agentcookie")
+}
+
+// safeJoinUnderRoot joins a relative target under root and verifies the result
+// stays inside root after symlink-agnostic path cleaning. Returns an error
+// rather than a path that escapes root.
+func safeJoinUnderRoot(root, rel string) (string, error) {
+	if filepath.IsAbs(rel) {
+		return "", fmt.Errorf("target %q must be relative", rel)
+	}
+	joined := filepath.Join(root, rel)
+	cleanRoot := filepath.Clean(root)
+	// Ensure joined is cleanRoot itself (rejected: must be a file under it) or
+	// a descendant separated by a path boundary.
+	if joined == cleanRoot {
+		return "", fmt.Errorf("target %q resolves to the agentcookie root itself", rel)
+	}
+	if !strings.HasPrefix(joined, cleanRoot+string(filepath.Separator)) {
+		return "", fmt.Errorf("target %q escapes ~/.agentcookie/", rel)
+	}
+	return joined, nil
+}
+
+// expandHome expands a leading ~/ (or bare ~) in p against homeDir. Other
+// paths are returned unchanged.
+func expandHome(p, homeDir string) string {
+	if strings.HasPrefix(p, "~/") {
+		return filepath.Join(homeDir, p[2:])
+	}
+	if p == "~" {
+		return homeDir
+	}
+	return p
+}

--- a/internal/secretsbus/filecarriage_test.go
+++ b/internal/secretsbus/filecarriage_test.go
@@ -1,0 +1,262 @@
+package secretsbus
+
+import (
+	"bytes"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// pemFixture is a representative multiline secret that CANNOT ride as a raw
+// KEY=VALUE value: an EC private key PEM.
+const pemFixture = `-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIExampleExampleExampleExampleExampleExampleExampleoAoGCCqG
+SM49AwEHoUQDQgAEExampleExampleExampleExampleExampleExampleExampleEx
+ampleExampleExampleExampleExampleExampleExampleExampleExample==
+-----END EC PRIVATE KEY-----
+`
+
+func TestCarryFiles_Base64RoundTrip(t *testing.T) {
+	home := t.TempDir()
+	src := filepath.Join(home, ".config", "tesla-pp-cli", "fleet-key.pem")
+	writeFile(t, src, pemFixture)
+
+	files := []ManifestV2File{{
+		Source: "~/.config/tesla-pp-cli/fleet-key.pem",
+		Key:    "TESLA_FLEET_KEY_PEM",
+		Target: "tesla-pp-cli/fleet-key.pem",
+	}}
+	carried, errs := CarryFiles(files, nil, home)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	b64, ok := carried["TESLA_FLEET_KEY_PEM"]
+	if !ok {
+		t.Fatal("payload key not carried")
+	}
+	if strings.ContainsAny(b64, "\n") {
+		t.Error("base64 value must be single-line")
+	}
+	if got := carried[CarryFileKey("TESLA_FLEET_KEY_PEM")]; got != "tesla-pp-cli/fleet-key.pem" {
+		t.Errorf("companion target = %q", got)
+	}
+
+	// envelope round trip: bytes in == bytes out after encode -> decode.
+	decoded, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !bytes.Equal(decoded, []byte(pemFixture)) {
+		t.Error("round-trip mismatch: decoded bytes != source bytes")
+	}
+}
+
+func TestMaterializeFiles_Writes0600AndRoundTrips(t *testing.T) {
+	home := t.TempDir()
+	env := map[string]string{
+		"TESLA_FLEET_KEY_PEM":               base64.StdEncoding.EncodeToString([]byte(pemFixture)),
+		CarryFileKey("TESLA_FLEET_KEY_PEM"): "tesla-pp-cli/fleet-key.pem",
+		"OTHER_ENV":                         "keepme",
+	}
+	res, consumed, errs := MaterializeFiles(home, "tesla-pp-cli", env)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if res.FilesWritten != 1 {
+		t.Fatalf("FilesWritten = %d, want 1", res.FilesWritten)
+	}
+	dest := filepath.Join(home, ".agentcookie", "tesla-pp-cli", "fleet-key.pem")
+	info, err := os.Stat(dest)
+	if err != nil {
+		t.Fatalf("materialized file missing: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("mode = %v, want 0600", info.Mode().Perm())
+	}
+	got, _ := os.ReadFile(dest)
+	if !bytes.Equal(got, []byte(pemFixture)) {
+		t.Error("materialized content != source content")
+	}
+	// Both the payload key and its companion are consumed; the unrelated env
+	// var is not.
+	if !consumed["TESLA_FLEET_KEY_PEM"] || !consumed[CarryFileKey("TESLA_FLEET_KEY_PEM")] {
+		t.Errorf("payload + companion should be consumed: %v", consumed)
+	}
+	if consumed["OTHER_ENV"] {
+		t.Error("unrelated env var should not be consumed")
+	}
+}
+
+func TestMaterializeFiles_OverwriteIsAtomicAndValuePreserved(t *testing.T) {
+	home := t.TempDir()
+	dest := filepath.Join(home, ".agentcookie", "tesla-pp-cli", "config.toml")
+	writeFile(t, dest, "old contents\n")
+
+	newContent := "[fleet]\nbearer = \"fresh\"\n"
+	env := map[string]string{
+		"TESLA_CONFIG":               base64.StdEncoding.EncodeToString([]byte(newContent)),
+		CarryFileKey("TESLA_CONFIG"): "tesla-pp-cli/config.toml",
+	}
+	res, _, errs := MaterializeFiles(home, "tesla-pp-cli", env)
+	if len(errs) != 0 {
+		t.Fatalf("errors: %v", errs)
+	}
+	if res.FilesWritten != 1 {
+		t.Fatalf("FilesWritten = %d", res.FilesWritten)
+	}
+	got, _ := os.ReadFile(dest)
+	if string(got) != newContent {
+		t.Errorf("overwrite content = %q, want %q", got, newContent)
+	}
+	info, _ := os.Stat(dest)
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("overwritten file mode = %v, want 0600", info.Mode().Perm())
+	}
+}
+
+func TestMaterializeFiles_RefusesTargetEscapingRoot(t *testing.T) {
+	home := t.TempDir()
+	cases := map[string]string{
+		"traversal":      "../escape.pem",
+		"deep traversal": "tesla/../../escape.pem",
+		"absolute":       "/etc/cron.d/evil",
+	}
+	for name, target := range cases {
+		t.Run(name, func(t *testing.T) {
+			env := map[string]string{
+				"PAYLOAD":               base64.StdEncoding.EncodeToString([]byte("x")),
+				CarryFileKey("PAYLOAD"): target,
+			}
+			res, _, errs := MaterializeFiles(home, "cli", env)
+			if res.FilesWritten != 0 {
+				t.Errorf("should not write for target %q", target)
+			}
+			if len(errs) == 0 {
+				t.Errorf("expected refusal error for target %q", target)
+			}
+			// Nothing escaped the home dir.
+			if _, err := os.Stat(filepath.Join(home, "..", "escape.pem")); err == nil {
+				t.Errorf("file escaped root for target %q", target)
+			}
+		})
+	}
+}
+
+func TestMaterializeFiles_RejectsInvalidBase64(t *testing.T) {
+	home := t.TempDir()
+	env := map[string]string{
+		"PAYLOAD":               "!!!not base64!!!",
+		CarryFileKey("PAYLOAD"): "cli/file.bin",
+	}
+	res, _, errs := MaterializeFiles(home, "cli", env)
+	if res.FilesWritten != 0 {
+		t.Error("invalid base64 should not write")
+	}
+	if len(errs) == 0 {
+		t.Error("expected base64 error")
+	}
+}
+
+func TestMaterializeFiles_RejectsOversizedPayload(t *testing.T) {
+	home := t.TempDir()
+	big := bytes.Repeat([]byte("A"), maxCarriedFileBytes+1)
+	env := map[string]string{
+		"PAYLOAD":               base64.StdEncoding.EncodeToString(big),
+		CarryFileKey("PAYLOAD"): "cli/big.bin",
+	}
+	res, _, errs := MaterializeFiles(home, "cli", env)
+	if res.FilesWritten != 0 {
+		t.Error("oversized payload should not write")
+	}
+	if len(errs) == 0 {
+		t.Error("expected oversize error")
+	}
+	if _, err := os.Stat(filepath.Join(home, ".agentcookie", "cli", "big.bin")); err == nil {
+		t.Error("oversized file should not exist")
+	}
+}
+
+func TestCarryFiles_OptionalNotCarriedUnlessEnabled(t *testing.T) {
+	home := t.TempDir()
+	srcDefault := filepath.Join(home, "default.txt")
+	srcOpt := filepath.Join(home, "opt.txt")
+	writeFile(t, srcDefault, "default")
+	writeFile(t, srcOpt, "optional")
+
+	files := []ManifestV2File{
+		{Source: srcDefault, Key: "DEFAULT_FILE", Target: "cli/default.txt"},
+		{Source: srcOpt, Key: "OPT_FILE", Target: "cli/opt.txt", Optional: true},
+	}
+
+	// No opt-in: only the default item is carried.
+	carried, errs := CarryFiles(files, nil, home)
+	if len(errs) != 0 {
+		t.Fatalf("errors: %v", errs)
+	}
+	if _, ok := carried["DEFAULT_FILE"]; !ok {
+		t.Error("default item should be carried")
+	}
+	if _, ok := carried["OPT_FILE"]; ok {
+		t.Error("optional item should NOT be carried without opt-in")
+	}
+
+	// Opt-in: both carried.
+	carried2, errs2 := CarryFiles(files, map[string]bool{"OPT_FILE": true}, home)
+	if len(errs2) != 0 {
+		t.Fatalf("errors: %v", errs2)
+	}
+	if _, ok := carried2["OPT_FILE"]; !ok {
+		t.Error("opted-in optional item should be carried")
+	}
+}
+
+func TestCarryFiles_MissingSourceIsError(t *testing.T) {
+	home := t.TempDir()
+	files := []ManifestV2File{{Source: "~/does-not-exist.pem", Key: "K", Target: "cli/k.pem"}}
+	carried, errs := CarryFiles(files, nil, home)
+	if len(errs) == 0 {
+		t.Error("missing source should error")
+	}
+	if _, ok := carried["K"]; ok {
+		t.Error("missing source should not be carried")
+	}
+}
+
+func TestLoadEnabledFileKeys(t *testing.T) {
+	home := t.TempDir()
+	p := filepath.Join(home, ".agentcookie", "file-optin", "tesla-pp-cli.keys")
+	writeFile(t, p, "# opt-in keys\nTESLA_FLEET_KEY_PEM\n\n  SPACED_KEY  \n")
+	enabled := LoadEnabledFileKeys(home, "tesla-pp-cli")
+	if !enabled["TESLA_FLEET_KEY_PEM"] {
+		t.Error("declared key should be enabled")
+	}
+	if !enabled["SPACED_KEY"] {
+		t.Error("whitespace-trimmed key should be enabled")
+	}
+	if enabled["#"] {
+		t.Error("comment should be ignored")
+	}
+
+	// Missing file: empty set.
+	if len(LoadEnabledFileKeys(home, "no-such-cli")) != 0 {
+		t.Error("missing opt-in file should yield empty set")
+	}
+}
+
+func TestSafeJoinUnderRoot(t *testing.T) {
+	root := "/home/u/.agentcookie"
+	ok := []string{"a.pem", "tesla/config.toml", "a/b/c.bin"}
+	for _, rel := range ok {
+		if _, err := safeJoinUnderRoot(root, rel); err != nil {
+			t.Errorf("safeJoinUnderRoot(%q) unexpected err: %v", rel, err)
+		}
+	}
+	bad := []string{"../x", "a/../../x", "/etc/passwd", ".", ""}
+	for _, rel := range bad {
+		if _, err := safeJoinUnderRoot(root, rel); err == nil {
+			t.Errorf("safeJoinUnderRoot(%q) should have errored", rel)
+		}
+	}
+}

--- a/internal/secretsbus/manifest_v2.go
+++ b/internal/secretsbus/manifest_v2.go
@@ -39,6 +39,47 @@ type ManifestV2 struct {
 	// `secret env` applies these live on every call (tracking refreshes), and
 	// an explicit local `secret alias` still overrides a manifest alias.
 	Aliases map[string]string `toml:"aliases,omitempty"`
+
+	// Files declares carried-file items: arbitrary files (a multiline PEM,
+	// a TOML config) that the bus carries from source to sink sealed and
+	// materializes on the sink as a 0600 file under ~/.agentcookie/. Because
+	// the wire envelope is a flat map[string]map[string]string, each file
+	// rides as a SINGLE key whose value is the base64 encoding of the file
+	// bytes (single-line, dotenv-safe). This is a NEW manifest construct that
+	// COEXISTS with the single [secrets.*] block (it is not a second
+	// [secrets.*] block). See spec section 5.4.
+	Files []ManifestV2File `toml:"files,omitempty"`
+}
+
+// ManifestV2File is one carried-file item declared as a [[files]] array entry.
+//
+// Example:
+//
+//	[[files]]
+//	source = "~/.config/tesla-pp-cli/config.toml"
+//	key = "TESLA_CONFIG_TOML"
+//	target = "tesla-pp-cli/config.toml"
+//	optional = false
+//
+// The source file at Source is read and base64-encoded into the wire key Key.
+// On the sink, the decoded bytes are written 0600 to Target, resolved relative
+// to ~/.agentcookie/. Target must stay inside ~/.agentcookie/ (no traversal,
+// no absolute paths). When Optional is true the item is opt-in: discovery does
+// NOT carry it unless the user enables it (see CarryFiles' enabled set).
+type ManifestV2File struct {
+	// Source is the path to the file to read and base64 into the bus. May
+	// start with ~/ (expanded against the user's home). Required.
+	Source string `toml:"source"`
+	// Key is the wire envelope key the base64 payload rides under. Must be a
+	// valid env-var-shaped key. Required.
+	Key string `toml:"key"`
+	// Target is the materialization path on the sink, relative to
+	// ~/.agentcookie/. Required. Must not contain ".." and must not be
+	// absolute; the sink refuses to write outside ~/.agentcookie/.
+	Target string `toml:"target"`
+	// Optional marks the item as opt-in. When true, discovery does not carry
+	// it unless the user explicitly enables it. Default false (carried).
+	Optional bool `toml:"optional,omitempty"`
 }
 
 // ManifestV2Secrets carries exactly one of File / Command / Keychain.
@@ -234,6 +275,56 @@ func validateManifestV2(m *ManifestV2, sourcePath string) error {
 		}
 	}
 
+	seenFileKeys := map[string]bool{}
+	for i := range m.Files {
+		f := &m.Files[i]
+		if f.Source == "" {
+			return fmt.Errorf("[[files]] item %d: source is required", i)
+		}
+		if strings.Contains(f.Source, "..") {
+			return fmt.Errorf("[[files]] item %d: source %q contains path-traversal segment", i, f.Source)
+		}
+		if f.Key == "" {
+			return fmt.Errorf("[[files]] item %d: key is required", i)
+		}
+		if !validEnvKey(f.Key) {
+			return fmt.Errorf("[[files]] item %d: key %q is not a valid env var name (A-Z, 0-9, underscore; not starting with a digit)", i, f.Key)
+		}
+		if seenFileKeys[f.Key] {
+			return fmt.Errorf("[[files]] duplicate key %q", f.Key)
+		}
+		seenFileKeys[f.Key] = true
+		if err := validateMaterializeTarget(f.Target); err != nil {
+			return fmt.Errorf("[[files]] item %d (key %q): %w", i, f.Key, err)
+		}
+	}
+
+	return nil
+}
+
+// validateMaterializeTarget enforces that a carried-file target is a relative
+// path that stays inside ~/.agentcookie/ after cleaning: non-empty, not
+// absolute, no ".." traversal segment, and no parent escape. This mirrors the
+// defense-in-depth posture of the [secrets.file].path validator and is the
+// authoritative check the sink also re-applies before writing.
+func validateMaterializeTarget(target string) error {
+	if target == "" {
+		return errors.New("target is required")
+	}
+	if filepath.IsAbs(target) {
+		return fmt.Errorf("target %q must be relative to ~/.agentcookie/, not absolute", target)
+	}
+	if strings.Contains(target, "..") {
+		return fmt.Errorf("target %q contains path-traversal segment", target)
+	}
+	// Defense in depth: after cleaning, the path must not escape the root.
+	clean := filepath.Clean(target)
+	if clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("target %q escapes ~/.agentcookie/", target)
+	}
+	if filepath.IsAbs(clean) {
+		return fmt.Errorf("target %q resolves to an absolute path", target)
+	}
 	return nil
 }
 

--- a/internal/secretsbus/manifest_v2_test.go
+++ b/internal/secretsbus/manifest_v2_test.go
@@ -147,6 +147,202 @@ path = "~/.config/demo/.env"
 	}
 }
 
+func TestParseManifestV2_ParsesFiles(t *testing.T) {
+	body := `
+schema_version = 2
+name = "tesla-pp-cli"
+display_name = "Tesla"
+
+[secrets.file]
+path = "~/.config/tesla-pp-cli/config.toml"
+
+[[files]]
+source = "~/.config/tesla-pp-cli/config.toml"
+key = "TESLA_CONFIG_TOML"
+target = "tesla-pp-cli/config.toml"
+
+[[files]]
+source = "~/.tesla/fleet-private.pem"
+key = "TESLA_FLEET_KEY_PEM"
+target = "tesla-pp-cli/fleet-key.pem"
+optional = true
+`
+	m, warnings, err := parseManifestV2Bytes([]byte(body), "test.toml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, w := range warnings {
+		if strings.Contains(w.Message, "files") {
+			t.Errorf("files should not warn as unknown: %v", w)
+		}
+	}
+	if len(m.Files) != 2 {
+		t.Fatalf("len(Files) = %d, want 2", len(m.Files))
+	}
+	if m.Files[0].Key != "TESLA_CONFIG_TOML" || m.Files[0].Optional {
+		t.Errorf("file[0] = %#v", m.Files[0])
+	}
+	if m.Files[1].Key != "TESLA_FLEET_KEY_PEM" || !m.Files[1].Optional {
+		t.Errorf("file[1] = %#v", m.Files[1])
+	}
+	// [[files]] coexists with the single [secrets.file] block (not a second
+	// [secrets.*] block), so the exactly-one rule is not tripped.
+	if m.Secrets.File == nil {
+		t.Error("[secrets.file] should still be present alongside [[files]]")
+	}
+}
+
+func TestParseManifestV2_RejectsFileTargetTraversal(t *testing.T) {
+	body := `
+schema_version = 2
+name = "demo"
+display_name = "Demo"
+
+[secrets.file]
+path = "~/x"
+
+[[files]]
+source = "~/a.pem"
+key = "K"
+target = "../../etc/passwd"
+`
+	_, _, err := parseManifestV2Bytes([]byte(body), "test.toml")
+	if err == nil {
+		t.Fatal("expected error on file target traversal")
+	}
+	if !strings.Contains(err.Error(), "files") {
+		t.Errorf("error should reference files: %v", err)
+	}
+}
+
+func TestParseManifestV2_RejectsFileTargetAbsolute(t *testing.T) {
+	body := `
+schema_version = 2
+name = "demo"
+display_name = "Demo"
+
+[secrets.file]
+path = "~/x"
+
+[[files]]
+source = "~/a.pem"
+key = "K"
+target = "/etc/evil"
+`
+	_, _, err := parseManifestV2Bytes([]byte(body), "test.toml")
+	if err == nil {
+		t.Fatal("expected error on absolute file target")
+	}
+}
+
+func TestParseManifestV2_RejectsFileSourceTraversal(t *testing.T) {
+	body := `
+schema_version = 2
+name = "demo"
+display_name = "Demo"
+
+[secrets.file]
+path = "~/x"
+
+[[files]]
+source = "~/../../../etc/shadow"
+key = "K"
+target = "demo/k"
+`
+	_, _, err := parseManifestV2Bytes([]byte(body), "test.toml")
+	if err == nil {
+		t.Fatal("expected error on file source traversal")
+	}
+}
+
+func TestParseManifestV2_RejectsFileMissingSource(t *testing.T) {
+	body := `
+schema_version = 2
+name = "demo"
+display_name = "Demo"
+
+[secrets.file]
+path = "~/x"
+
+[[files]]
+key = "K"
+target = "demo/k"
+`
+	_, _, err := parseManifestV2Bytes([]byte(body), "test.toml")
+	if err == nil {
+		t.Fatal("expected error on missing file source")
+	}
+	if !strings.Contains(err.Error(), "source is required") {
+		t.Errorf("error should mention missing source: %v", err)
+	}
+}
+
+func TestParseManifestV2_RejectsFileInvalidKey(t *testing.T) {
+	body := `
+schema_version = 2
+name = "demo"
+display_name = "Demo"
+
+[secrets.file]
+path = "~/x"
+
+[[files]]
+source = "~/a.pem"
+key = "not a valid key"
+target = "demo/k"
+`
+	_, _, err := parseManifestV2Bytes([]byte(body), "test.toml")
+	if err == nil {
+		t.Fatal("expected error on invalid file key")
+	}
+}
+
+func TestParseManifestV2_RejectsDuplicateFileKey(t *testing.T) {
+	body := `
+schema_version = 2
+name = "demo"
+display_name = "Demo"
+
+[secrets.file]
+path = "~/x"
+
+[[files]]
+source = "~/a.pem"
+key = "K"
+target = "demo/a"
+
+[[files]]
+source = "~/b.pem"
+key = "K"
+target = "demo/b"
+`
+	_, _, err := parseManifestV2Bytes([]byte(body), "test.toml")
+	if err == nil {
+		t.Fatal("expected error on duplicate file key")
+	}
+	if !strings.Contains(err.Error(), "duplicate") {
+		t.Errorf("error should mention duplicate: %v", err)
+	}
+}
+
+func TestParseManifestV2_NoFilesNoRegression(t *testing.T) {
+	body := `
+schema_version = 2
+name = "demo"
+display_name = "Demo"
+
+[secrets.file]
+path = "~/.config/demo/.env"
+`
+	m, _, err := parseManifestV2Bytes([]byte(body), "test.toml")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(m.Files) != 0 {
+		t.Errorf("manifest without [[files]] should have no Files; got %#v", m.Files)
+	}
+}
+
 func TestParseManifestV2_RejectsV1Schema(t *testing.T) {
 	body := `
 schema_version = 1

--- a/internal/secretsbus/writer.go
+++ b/internal/secretsbus/writer.go
@@ -24,6 +24,9 @@ type WriteResult struct {
 	SealedWritten int
 	// PlaintextWritten is the number of `secrets.env` files written.
 	PlaintextWritten int
+	// FilesMaterialized is the number of carried files written to 0600 files
+	// under ~/.agentcookie/ (the base64 file-carriage path).
+	FilesMaterialized int
 }
 
 // WritePayload persists the source-shipped secrets to disk under
@@ -82,7 +85,23 @@ func WritePayload(homeDir string, payload map[string]map[string]string, sealingE
 			}
 			safe[k] = v
 		}
+		// Carried-file materialization: decode any _FILE_<K>/K pairs to 0600
+		// files under ~/.agentcookie/ and strip those keys so a carried file
+		// never also leaks into the plaintext secrets.env. The sink does NOT
+		// trust the wire payload; MaterializeFiles re-validates every target.
+		matRes, consumed, matErrs := MaterializeFiles(homeDir, cliName, safe)
+		errs = append(errs, matErrs...)
+		result.FilesMaterialized += matRes.FilesWritten
+		for k := range consumed {
+			delete(safe, k)
+		}
+
 		if len(safe) == 0 {
+			if matRes.FilesWritten > 0 {
+				// Carried files only: count this CLI as written even though
+				// no env keys remain for secrets.env.
+				result.CLIsWritten++
+			}
 			continue
 		}
 

--- a/internal/secretsbus/writer_test.go
+++ b/internal/secretsbus/writer_test.go
@@ -1,6 +1,7 @@
 package secretsbus
 
 import (
+	"encoding/base64"
 	"os"
 	"path/filepath"
 	"strings"
@@ -33,6 +34,72 @@ func TestWritePayload_HappyPath(t *testing.T) {
 	}
 	if !strings.Contains(string(content), "KEY1=value1") || !strings.Contains(string(content), "KEY2=value2") {
 		t.Errorf("content mismatch: %s", string(content))
+	}
+}
+
+func TestWritePayload_MaterializesCarriedFileAndStripsKeys(t *testing.T) {
+	home := t.TempDir()
+	pem := "-----BEGIN EC PRIVATE KEY-----\nMHc...\n-----END EC PRIVATE KEY-----\n"
+	payload := map[string]map[string]string{
+		"tesla-pp-cli": {
+			"TESLA_AUTH_TOKEN":            base64.StdEncoding.EncodeToString([]byte("bearer")), // ordinary env key (not a file)
+			"FLEET_KEY_PEM":               base64.StdEncoding.EncodeToString([]byte(pem)),
+			CarryFileKey("FLEET_KEY_PEM"): "tesla-pp-cli/fleet-key.pem",
+		},
+	}
+	result, errs := WritePayload(home, payload, false)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if result.FilesMaterialized != 1 {
+		t.Errorf("FilesMaterialized = %d, want 1", result.FilesMaterialized)
+	}
+	// Materialized 0600 under ~/.agentcookie/.
+	dest := filepath.Join(home, ".agentcookie", "tesla-pp-cli", "fleet-key.pem")
+	info, err := os.Stat(dest)
+	if err != nil {
+		t.Fatalf("materialized file missing: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("materialized mode = %v, want 0600", info.Mode().Perm())
+	}
+	got, _ := os.ReadFile(dest)
+	if string(got) != pem {
+		t.Errorf("materialized content mismatch")
+	}
+	// The carried payload + companion are stripped from secrets.env; the
+	// ordinary env key remains.
+	envPath := filepath.Join(SecretsRoot(home), "tesla-pp-cli", "secrets.env")
+	content, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatalf("read secrets.env: %v", err)
+	}
+	if strings.Contains(string(content), "FLEET_KEY_PEM") {
+		t.Errorf("carried file key leaked into secrets.env: %s", content)
+	}
+	if !strings.Contains(string(content), "TESLA_AUTH_TOKEN=") {
+		t.Errorf("ordinary env key missing from secrets.env: %s", content)
+	}
+}
+
+func TestWritePayload_NoFileKeysNoRegression(t *testing.T) {
+	home := t.TempDir()
+	payload := map[string]map[string]string{
+		"demo-cli": {"KEY1": "value1"},
+	}
+	result, errs := WritePayload(home, payload, false)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if result.FilesMaterialized != 0 {
+		t.Errorf("FilesMaterialized = %d, want 0", result.FilesMaterialized)
+	}
+	if result.CLIsWritten != 1 || result.KeysWritten != 1 {
+		t.Errorf("regression in non-file payload: %+v", result)
+	}
+	// No ~/.agentcookie sub-file beyond the secrets dir.
+	if _, err := os.Stat(filepath.Join(home, ".agentcookie", "demo-cli")); err == nil {
+		t.Error("unexpected materialized dir for non-file payload")
 	}
 }
 


### PR DESCRIPTION
## Why

The Tesla "works for everyone" plan needs the secrets bus to carry a whole FILE to the sink, not just `KEY=VALUE` env pairs: the sink reads a synced `config.toml` (so it can refresh in place) and, opt-in, an EC private-key PEM for signed vehicle commands. The bus's flat env envelope cannot hold a multiline value, so a general file-carriage capability is required. (Plan: `docs/plans/2026-05-31-008`, U3.)

## What

- v2 adoption manifest `[[files]]` grammar (`source`, `key`, `target`, `optional`) that coexists with the single `[secrets.*]` block. Validated: source/key/target required, no `..` traversal, `target` relative and under `~/.agentcookie/`, valid env-key, no duplicate keys.
- Carriage: each file rides as a single base64 key (dotenv-safe, never multiline) plus a reserved `_FILE_<key>` companion carrying the relative target, so the sink materializes with no copy of the manifest.
- Source push gates optional items behind a per-CLI opt-in set; sink write decodes to a 0600 file under `~/.agentcookie/` (atomic), refuses any target escaping that root, and strips the carried keys from `secrets.env` so a file never also leaks as an env var.
- Spec section 5.4 documents the grammar, mechanism, validation, opt-in, and the honest on-sink security posture (materialized file is 0600 plaintext; protection is file permissions).

General capability only; Tesla-specific wiring is a separate printing-press change.

## Verification

583 tests pass (+23 new in `internal/secretsbus`): manifest parse + hard-error rejections (traversal, absolute target, missing source, dup key); base64 round-trip; materialization 0600; target-escape refusal (relative `..`, deep `..`, absolute); invalid/oversized base64 refused; atomic value-preserved overwrite; opt-in gating; no regression for manifests without file items.
