### PR TITLE
feat(secretsbus): [[files]] env field points a CLI at the carried file

### DIFF
--- a/internal/secretsbus/filecarriage.go
+++ b/internal/secretsbus/filecarriage.go
@@ -32,6 +32,19 @@ import (
 // target path for the carried payload under key K.
 const fileTargetKeyPrefix = "_FILE_"
 
+// fileEnvKeyPrefix is the reserved prefix for the optional companion key that
+// names an env var to set to the materialized ABSOLUTE path. _FILEENV_<K> holds
+// the env var name for the carried payload under key K, so the sink can emit
+// e.g. TESLA_CONFIG=/Users/x/.agentcookie/tesla-pp-cli/config.toml and point a
+// path-reading CLI at the carried file with no per-machine path hardcoding.
+const fileEnvKeyPrefix = "_FILEENV_"
+
+// CarryFileEnvKey returns the reserved companion key carrying the env-var name
+// for a carried-file payload key.
+func CarryFileEnvKey(payloadKey string) string {
+	return fileEnvKeyPrefix + payloadKey
+}
+
 // maxCarriedFileBytes caps a single carried file at 256 KB (decoded), matching
 // the v1 secrets.env size cap. Oversized payloads are refused, not written, so
 // a runaway file cannot swamp the sink.
@@ -100,6 +113,9 @@ func CarryFiles(files []ManifestV2File, enabled map[string]bool, homeDir string)
 		}
 		out[f.Key] = base64.StdEncoding.EncodeToString(data)
 		out[CarryFileKey(f.Key)] = f.Target
+		if f.Env != "" {
+			out[CarryFileEnvKey(f.Key)] = f.Env
+		}
 	}
 	return out, errs
 }
@@ -133,6 +149,11 @@ func LoadEnabledFileKeys(homeDir, cliName string) map[string]bool {
 type MaterializeResult struct {
 	// FilesWritten is the count of carried files materialized to 0600 files.
 	FilesWritten int
+	// EnvAdditions maps an env var name to the ABSOLUTE materialized path of a
+	// carried file that declared an `env` companion. The caller merges these
+	// into the CLI's secrets.env so `secret env` emits them, pointing a
+	// path-reading consumer CLI at the carried file.
+	EnvAdditions map[string]string
 }
 
 // MaterializeFiles scans a per-CLI env map for carried-file companion keys
@@ -210,6 +231,29 @@ func MaterializeFiles(homeDir string, cliName string, env map[string]string) (Ma
 		result.FilesWritten++
 		consumed[payloadKey] = true
 		consumed[k] = true
+
+		// Optional env companion: emit <ENV>=<abs materialized path> so a
+		// path-reading CLI is pointed at the carried file. The env var name is
+		// re-validated (the sink does not trust the wire).
+		if envName, ok := env[CarryFileEnvKey(payloadKey)]; ok {
+			consumed[CarryFileEnvKey(payloadKey)] = true
+			if validKeyName(envName) {
+				if result.EnvAdditions == nil {
+					result.EnvAdditions = map[string]string{}
+				}
+				result.EnvAdditions[envName] = dest
+			} else {
+				errs = append(errs, fmt.Errorf("%s: file %q env companion %q is not a valid env var name; ignored", cliName, payloadKey, envName))
+			}
+		}
+	}
+
+	// Strip any dangling _FILEENV_ companions (e.g. for a payload that failed to
+	// materialize) so they never leak into secrets.env as raw keys.
+	for k := range env {
+		if strings.HasPrefix(k, fileEnvKeyPrefix) {
+			consumed[k] = true
+		}
 	}
 
 	return result, consumed, errs

--- a/internal/secretsbus/filecarriage_test.go
+++ b/internal/secretsbus/filecarriage_test.go
@@ -116,6 +116,58 @@ func TestMaterializeFiles_OverwriteIsAtomicAndValuePreserved(t *testing.T) {
 	}
 }
 
+func TestFileCarriage_EnvPointsConsumerAtMaterializedPath(t *testing.T) {
+	home := t.TempDir()
+	// Source file to carry.
+	srcDir := filepath.Join(home, ".config", "tesla-pp-cli")
+	if err := os.MkdirAll(srcDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	src := filepath.Join(srcDir, "config.toml")
+	if err := os.WriteFile(src, []byte("access_token=abc\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	files := []ManifestV2File{{
+		Source: "~/.config/tesla-pp-cli/config.toml",
+		Key:    "TESLA_CONFIG_TOML",
+		Target: "tesla-pp-cli/config.toml",
+		Env:    "TESLA_CONFIG",
+	}}
+	carried, errs := CarryFiles(files, nil, home)
+	if len(errs) != 0 {
+		t.Fatalf("carry errs: %v", errs)
+	}
+	// The env companion travels in the envelope.
+	if carried[CarryFileEnvKey("TESLA_CONFIG_TOML")] != "TESLA_CONFIG" {
+		t.Fatalf("env companion not carried: %v", carried)
+	}
+
+	res, consumed, merrs := MaterializeFiles(home, "tesla-pp-cli", carried)
+	if len(merrs) != 0 {
+		t.Fatalf("materialize errs: %v", merrs)
+	}
+	if res.FilesWritten != 1 {
+		t.Fatalf("FilesWritten = %d, want 1", res.FilesWritten)
+	}
+	wantPath := filepath.Join(home, ".agentcookie", "tesla-pp-cli", "config.toml")
+	if got := res.EnvAdditions["TESLA_CONFIG"]; got != wantPath {
+		t.Errorf("EnvAdditions[TESLA_CONFIG] = %q, want %q", got, wantPath)
+	}
+	// The materialized file exists at the pointed path, 0600.
+	info, err := os.Stat(wantPath)
+	if err != nil {
+		t.Fatalf("materialized file missing: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("materialized mode = %v, want 0600", info.Mode().Perm())
+	}
+	// The env companion is consumed so it never leaks as a raw secrets.env key.
+	if !consumed[CarryFileEnvKey("TESLA_CONFIG_TOML")] {
+		t.Errorf("env companion should be consumed/stripped")
+	}
+}
+
 func TestMaterializeFiles_RefusesTargetEscapingRoot(t *testing.T) {
 	home := t.TempDir()
 	cases := map[string]string{

--- a/internal/secretsbus/manifest_v2.go
+++ b/internal/secretsbus/manifest_v2.go
@@ -249,11 +249,11 @@ func validateManifestV2(m *ManifestV2, sourcePath string) error {
 	if m.Secrets.Keychain != nil {
 		srcCount++
 	}
-	if srcCount == 0 {
-		return errors.New("exactly one [secrets.*] block required; none found")
+	if srcCount == 0 && len(m.Files) == 0 {
+		return errors.New("a secret source is required: one [secrets.*] block or at least one [[files]] item")
 	}
 	if srcCount > 1 {
-		return fmt.Errorf("exactly one [secrets.*] block required; %d found", srcCount)
+		return fmt.Errorf("at most one [secrets.*] block allowed; %d found", srcCount)
 	}
 
 	if m.Secrets.Command != nil {

--- a/internal/secretsbus/manifest_v2.go
+++ b/internal/secretsbus/manifest_v2.go
@@ -80,6 +80,12 @@ type ManifestV2File struct {
 	// Optional marks the item as opt-in. When true, discovery does not carry
 	// it unless the user explicitly enables it. Default false (carried).
 	Optional bool `toml:"optional,omitempty"`
+	// Env, when set, names an environment variable that `secret env` emits on
+	// the sink carrying the ABSOLUTE materialized path of this file, so a
+	// consumer CLI that reads a file by path (e.g. a Tesla CLI reading
+	// TESLA_CONFIG / TESLA_FLEET_KEY_FILE) is pointed at the carried file with
+	// no per-machine path hardcoding. Must be a valid env-var name. Optional.
+	Env string `toml:"env,omitempty"`
 }
 
 // ManifestV2Secrets carries exactly one of File / Command / Keychain.
@@ -296,6 +302,9 @@ func validateManifestV2(m *ManifestV2, sourcePath string) error {
 		seenFileKeys[f.Key] = true
 		if err := validateMaterializeTarget(f.Target); err != nil {
 			return fmt.Errorf("[[files]] item %d (key %q): %w", i, f.Key, err)
+		}
+		if f.Env != "" && !validEnvKey(f.Env) {
+			return fmt.Errorf("[[files]] item %d (key %q): env %q is not a valid env var name", i, f.Key, f.Env)
 		}
 	}
 

--- a/internal/secretsbus/manifest_v2_test.go
+++ b/internal/secretsbus/manifest_v2_test.go
@@ -391,8 +391,37 @@ exec = ["echo", "hi"]
 	if err == nil {
 		t.Fatal("expected error on multi-block")
 	}
-	if !strings.Contains(err.Error(), "exactly one") {
-		t.Errorf("error should mention 'exactly one': %v", err)
+	if !strings.Contains(err.Error(), "at most one") {
+		t.Errorf("error should reject multiple blocks: %v", err)
+	}
+}
+
+func TestParseManifestV2_FilesOnlyIsValid(t *testing.T) {
+	// A CLI whose secret source is a carried file (no env-shaped [secrets.*]).
+	body := `
+schema_version = 2
+name = "tesla-pp-cli"
+display_name = "Tesla"
+
+[[files]]
+source = "~/.config/tesla-pp-cli/config.toml"
+key = "TESLA_CONFIG_TOML"
+target = "tesla-pp-cli/config.toml"
+env = "TESLA_CONFIG"
+`
+	if _, _, err := parseManifestV2Bytes([]byte(body), "test.toml"); err != nil {
+		t.Fatalf("[[files]]-only manifest should be valid: %v", err)
+	}
+}
+
+func TestParseManifestV2_RejectsNoSource(t *testing.T) {
+	body := `
+schema_version = 2
+name = "demo"
+display_name = "Demo"
+`
+	if _, _, err := parseManifestV2Bytes([]byte(body), "test.toml"); err == nil {
+		t.Fatal("a manifest with no [secrets.*] and no [[files]] must be rejected")
 	}
 }
 

--- a/internal/secretsbus/writer.go
+++ b/internal/secretsbus/writer.go
@@ -95,6 +95,12 @@ func WritePayload(homeDir string, payload map[string]map[string]string, sealingE
 		for k := range consumed {
 			delete(safe, k)
 		}
+		// Point path-reading CLIs at the carried files: a [[files]] item with an
+		// `env` set emits <ENV>=<abs materialized path> into secrets.env so
+		// `secret env` surfaces it (e.g. TESLA_CONFIG, TESLA_FLEET_KEY_FILE).
+		for envName, absPath := range matRes.EnvAdditions {
+			safe[envName] = absPath
+		}
 
 		if len(safe) == 0 {
 			if matRes.FilesWritten > 0 {


### PR DESCRIPTION
Completes the file-carriage so a path-reading consumer CLI finds its carried file with no per-machine path hardcoding. A `[[files]]` item gains an optional `env`; on the sink, `secret env` emits `<ENV>=<absolute materialized path>` (e.g. TESLA_CONFIG, TESLA_FLEET_KEY_FILE). Companion keys are stripped so they never leak. 584 tests. Part of plan 008 (Tesla works-for-everyone).