### PR TITLE
fix(secretsbus): a [[files]]-only manifest's files actually carry on push

### DIFF
--- a/internal/secretsbus/discover_merge.go
+++ b/internal/secretsbus/discover_merge.go
@@ -36,23 +36,29 @@ func LoadPayloadWithDiscovery(homeDir string) (*Payload, []error) {
 		if rp.Kind == SourceKindLegacyV1 {
 			continue // already loaded via LoadPayload above
 		}
-		if rp.Manifest == nil || rp.ReadInPlacePath == "" {
+		if rp.Manifest == nil {
 			continue
 		}
-		kv, err := parseEnvFile(rp.ReadInPlacePath)
-		if err != nil {
-			if os.IsNotExist(err) {
-				errs = append(errs, fmt.Errorf("discovered project %q: read-in-place file missing: %s", slug, rp.ReadInPlacePath))
-			} else {
-				errs = append(errs, fmt.Errorf("discovered project %q: read %s: %w", slug, rp.ReadInPlacePath, err))
-			}
-			continue
-		}
-		// Apply manifest sync policy: drop keys the manifest says no to.
 		filtered := map[string]string{}
-		for k, v := range kv {
-			if rp.Manifest.ShouldShipKey(k) {
-				filtered[k] = v
+		// Read-in-place env source, when the manifest declares one. A
+		// [[files]]-only manifest (no [secrets.file]) has an empty
+		// ReadInPlacePath and ships its secrets entirely via carried files
+		// below, so the env read is skipped rather than treated as missing.
+		if rp.ReadInPlacePath != "" {
+			kv, err := parseEnvFile(rp.ReadInPlacePath)
+			if err != nil {
+				if os.IsNotExist(err) {
+					errs = append(errs, fmt.Errorf("discovered project %q: read-in-place file missing: %s", slug, rp.ReadInPlacePath))
+				} else {
+					errs = append(errs, fmt.Errorf("discovered project %q: read %s: %w", slug, rp.ReadInPlacePath, err))
+				}
+				continue
+			}
+			// Apply manifest sync policy: drop keys the manifest says no to.
+			for k, v := range kv {
+				if rp.Manifest.ShouldShipKey(k) {
+					filtered[k] = v
+				}
 			}
 		}
 

--- a/internal/secretsbus/discover_merge_files_test.go
+++ b/internal/secretsbus/discover_merge_files_test.go
@@ -1,0 +1,62 @@
+package secretsbus
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestLoadPayloadWithDiscovery_CarriesFilesOnlyManifest covers the fix for a
+// [[files]]-only manifest (no [secrets.file], so ReadInPlacePath==""): its
+// carried files must still ship, where previously the empty read-in-place path
+// short-circuited the loop before reaching the carry.
+func TestLoadPayloadWithDiscovery_CarriesFilesOnlyManifest(t *testing.T) {
+	home := t.TempDir()
+	// A source file to carry.
+	cfgDir := filepath.Join(home, ".config", "demo-cli")
+	if err := os.MkdirAll(cfgDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.toml"), []byte("k = \"v\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// A [[files]]-only manifest at the priority-1 discovery path.
+	mdir := filepath.Join(home, ".agentcookie", "manifests")
+	if err := os.MkdirAll(mdir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	manifest := `
+schema_version = 2
+name = "demo-cli"
+display_name = "Demo"
+
+[[files]]
+source = "~/.config/demo-cli/config.toml"
+key = "DEMO_CONFIG"
+target = "demo-cli/config.toml"
+env = "DEMO_CONFIG_PATH"
+`
+	if err := os.WriteFile(filepath.Join(mdir, "demo-cli.toml"), []byte(manifest), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	p, _ := LoadPayloadWithDiscovery(home)
+	kv := p.CLIs["demo-cli"]
+	if kv["DEMO_CONFIG"] == "" {
+		t.Fatalf("[[files]]-only manifest did not carry the file; payload keys: %v", keysOf(kv))
+	}
+	if kv[CarryFileKey("DEMO_CONFIG")] != "demo-cli/config.toml" {
+		t.Errorf("missing target companion: %v", keysOf(kv))
+	}
+	if kv[CarryFileEnvKey("DEMO_CONFIG")] != "DEMO_CONFIG_PATH" {
+		t.Errorf("missing env companion: %v", keysOf(kv))
+	}
+}
+
+func keysOf(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}


### PR DESCRIPTION
A discovered project with a [[files]]-only manifest (no [secrets.file], so an empty read-in-place path) was skipped before its carried files were reached, so nothing shipped. Read the env source only when present, then always carry declared files. Verified live end-to-end: source carries config.toml + opt-in signing key, sink materializes both 0600 and emits TESLA_CONFIG / TESLA_FLEET_KEY_FILE. Completes the file-carriage path for plan 008.