### PR TITLE
feat(cli): add accounts domain toggles

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Logging in twice. Once on your laptop, once again on the Mac your agent lives on
 
 Tools that ship cookies between machines today assume a human is going to click "merge" or unlock a vault or open the destination browser. They were built for switching accounts between two laptops the same person uses. They weren't built for "the agent on the headless Mac mini needs my session in 30 seconds and there's nobody home."
 
-agentcookie is the second pattern. One-way, continuous, unattended replication from the machine you live in to the machine your agents act from. Pairing-derived per-peer keys, allowlist + blocklist on both sides, AES-256-GCM over the Tailscale tailnet's WireGuard channel. The hard parts (macOS Keychain protections, Chrome's App-Bound Encryption, per-CLI auth conventions) are handled.
+agentcookie is the second pattern. One-way, continuous, unattended replication from the machine you live in to the machine your agents act from. Pairing-derived per-peer keys, blocklist filters on both sides, AES-256-GCM over the Tailscale tailnet's WireGuard channel. The hard parts (macOS Keychain protections, Chrome's App-Bound Encryption, per-CLI auth conventions) are handled.
 
 ## How it works
 
@@ -111,6 +111,14 @@ agentcookie wizard verify-adapters           # per-adapter results from the last
 agentcookie wizard verify-adapters --json    # same, structured for SSH agents
 ```
 
+Turn cookie sync off or back on for a site without editing YAML:
+
+~~~bash
+agentcookie accounts off x.com          # add x.com + subdomains to blocklist.yaml
+agentcookie accounts on x.com           # remove those blocklist entries
+agentcookie accounts list               # show disabled domains and custom patterns
+~~~
+
 Healthy output:
 
 ```
@@ -131,7 +139,7 @@ macOS only on both ends today. The source side reads Chrome on macOS via the Key
 
 Working:
 
-- Continuous laptop to second-Mac sync via fsnotify on Chrome's Cookies file, debounced, allowlist + blocklist filtered, AES-256-GCM over Tailscale.
+- Continuous laptop to second-Mac sync via fsnotify on Chrome's Cookies file, debounced, blocklist filtered, AES-256-GCM over Tailscale.
 - Three cookie delivery surfaces on the sink (Chrome SQLite, plaintext sidecar, per-CLI adapter session files).
 - Works with Printing Press CLIs like Stripe, Linear, Notion, Granola, Slack, Kalshi, ElevenLabs, Mercury, and dozens more: anything with a bearer token or API key reads the secrets bus, anything that reads cookies reads the plaintext sidecar. Five PP CLIs (instacart, airbnb, ebay, pagliacci, table-reservation-goat with OpenTable + Tock) additionally get a bespoke zero-config cookie adapter.
 - Per-CLI secrets bus: bearer tokens, API keys, and `KEY=VALUE` auth blobs ride the same encrypted push and land at `~/.agentcookie/secrets/<cli>/secrets.env` (mode 0600) with an optional sealed twin.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,8 +12,8 @@
    |  agentcookie source       |                    |  agentcookie sink (launchd) |
    |    - read SQLite (RO)     |                    |    - listen :9999/sync      |
    |    - decrypt w/ local key |     AES-GCM        |    - decrypt seal           |
-   |    - filter by allowlist  |    over HTTP       |    - check proto + seq      |
-   |    - wrap in envelope     | ================>  |    - filter by allowlist    |
+   |    - filter by blocklist  |    over HTTP       |    - check proto + seq      |
+   |    - wrap in envelope     | ================>  |    - filter by blocklist    |
    |    - seal w/ peer key     |    on tailnet      |    - write Chrome SQLite    |
    |                           |    (WireGuard)     |    - write sealed sidecar   |
    +---------------------------+                    +-----------------------------+
@@ -32,20 +32,20 @@
 | `internal/cli` | Subcommand implementations: `source`, `sink`, `pair`, `status`, `version`. |
 | `internal/chrome` | Read + decrypt Chrome cookies on macOS via Keychain Safe Storage + SQLite. Schema-aware INSERT for the write path. |
 | `internal/transport` | AES-GCM seal/open with key = SHA-256(secret). |
-| `internal/config` | YAML loaders for `source.yaml`, `sink.yaml`, `allowlist.yaml`. Tilde expansion, defaults, validation. |
+| `internal/config` | YAML loaders for `source.yaml`, `sink.yaml`, `blocklist.yaml`. Tilde expansion, defaults, validation. |
 | `internal/pairing` | X25519 + HKDF handshake. Source listens for pairing; sink connects with the printed code. Both sides derive identical 32-byte keys. |
 | `internal/keystore` | Per-peer key files at `~/.config/agentcookie/keys/<peer>.json` mode 0600. |
-| `internal/protocol` | `SyncEnvelope` (versioned), `SequenceTracker` (in-memory replay defense), `AllowlistMatcher` (SQLite-LIKE patterns, case-insensitive). |
+| `internal/protocol` | `SyncEnvelope` (versioned), `SequenceTracker` (in-memory replay defense), `BlocklistMatcher` (SQLite-LIKE patterns, case-insensitive). |
 | `internal/cdp` | Tiny Chrome DevTools Protocol client: `Probe` + `Dial` + `Call`. One method we care about: `Storage.setCookies`. |
 
 ## Lifecycle: one sync
 
 1. `agentcookie source --once` runs on the laptop.
 2. Reads `~/.config/agentcookie/source.yaml` for sink URL and `peer.hostname`.
-3. Reads `~/.config/agentcookie/allowlist.yaml` for domain patterns.
+3. Reads `~/.config/agentcookie/blocklist.yaml` for opt-out domain patterns.
 4. Loads the paired key for `peer.hostname` from `~/.config/agentcookie/keys/`.
 5. Calls `security find-generic-password` to get Chrome Safe Storage; derives the per-machine AES key.
-6. Opens Chrome's Cookies SQLite read-only with `immutable=1`. Selects rows matching each allowlist pattern.
+6. Opens Chrome's Cookies SQLite read-only with `immutable=1`. Drops rows matching each blocklist pattern.
 7. Decrypts each `encrypted_value` (v10 prefix, AES-128-CBC, IV = 16 spaces, PKCS#7).
 8. Wraps the cookies in a `SyncEnvelope` with version, hostname, monotonic Sequence.
 9. AES-GCM-seals the envelope with the paired key.
@@ -58,7 +58,7 @@ On the sink, in the `/sync` handler:
 3. JSON-unmarshals the `SyncEnvelope`.
 4. Checks `ProtocolVersion == 1`. Mismatch -> 400.
 5. Checks `Sequence` against the in-memory `SequenceTracker`. Replay -> 409.
-6. Filters cookies against the sink's own `allowlist.yaml`. Dropped hosts are counted for logging.
+6. Filters cookies against the sink's own `blocklist.yaml`. Dropped hosts are counted for logging.
 7. If `cdp.enabled`, probes `http://<host>:<port>/json/version`, dials the browser-level WebSocket, sends `Storage.setCookies`. On any failure, falls back to step 8.
 8. Otherwise opens the sink's Cookies SQLite read-write, re-encrypts each value with the SINK's Chrome Safe Storage key, upserts rows via a schema-aware INSERT ... ON CONFLICT (handles Chrome's `top_frame_site_key`, `source_type`, `has_cross_site_ancestor` columns dynamically).
 
@@ -78,7 +78,7 @@ On the sink, in the `/sync` handler:
 | Cookie value at rest | Chrome Safe Storage per-machine AES key + Keychain access prompt |
 | Cookie value in transit | AES-GCM with paired key + Tailscale WireGuard channel |
 | Pairing authenticity | Pairing code mixed into HKDF salt; MITM derives different key |
-| Sink-side opt-in | `allowlist.yaml` on sink; cookies for non-allowlisted hosts are dropped before writing |
+| Sink-side opt-out | `blocklist.yaml` on sink; cookies for blocklisted hosts are dropped before writing |
 | Replay defense | `SequenceTracker` in sink memory; rejects equal-or-lower Sequence |
 | Protocol stability | `ProtocolVersion` int in every envelope; breaking changes bump the number |
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -24,7 +24,7 @@ No. The source reads cookies with `immutable=1` (Chrome's recommended read-only 
 
 ## My agent gets logged out on a particular site after syncing - what happened?
 
-Two causes. First, a few sites bind a session to a device fingerprint (canvas, screen size, accept-language, sometimes TLS JA3); replicating the cookie alone is not enough and the site invalidates the session because the fingerprint differs. Second, the site may use Chrome's Device Bound Session Credentials (DBSC), which ties session refresh to a private key in the source Mac's Secure Enclave. In both cases the sink cannot reproduce the missing factor, so the session drops. Workarounds: remove the site from your allowlist and re-auth in the sink's Chrome directly, or use the pair-agent style remote-browser pattern for those sites. See the next entry for DBSC specifics.
+Two causes. First, a few sites bind a session to a device fingerprint (canvas, screen size, accept-language, sometimes TLS JA3); replicating the cookie alone is not enough and the site invalidates the session because the fingerprint differs. Second, the site may use Chrome's Device Bound Session Credentials (DBSC), which ties session refresh to a private key in the source Mac's Secure Enclave. In both cases the sink cannot reproduce the missing factor, so the session drops. Workarounds: run `agentcookie accounts off <domain>` and re-auth in the sink's Chrome directly, or use the pair-agent style remote-browser pattern for those sites. See the next entry for DBSC specifics.
 
 ## Does Chrome's device-bound cookie protection (DBSC) break agentcookie?
 
@@ -45,9 +45,9 @@ Not in v0.1. One-to-many fan-out is a planned v0.2 feature. The protocol envelop
 
 `~/.config/agentcookie/keys/<peer>.json` is a small JSON file at mode 0600 containing the 32-byte paired key (base64), the peer hostname, paired_at timestamp, key fingerprint, and protocol version. macOS Keychain storage is a v0.2 hardening item; today the file mode + your OS user separation is the protection.
 
-## Why is the sink's allowlist independent from the source's?
+## Why is the sink's blocklist independent from the source's?
 
-Defense in depth. The source filters cookies before sending (bandwidth + privacy optimization), but the sink owner ultimately controls what state lands in their Chrome. If the source machine is fully compromised and an attacker tries to push cookies for new domains, the sink-side allowlist drops them. Keep both allowlists in sync if you want the simplest behavior; let them diverge if you want the sink to be more conservative than the source.
+Defense in depth. The source filters cookies before sending (bandwidth + privacy optimization), but the sink owner ultimately controls what state lands in their Chrome. If the source machine is fully compromised and an attacker tries to push cookies for a blocked domain, the sink-side blocklist drops them. Keep both blocklists in sync if you want the simplest behavior; let them diverge if you want the sink to be more conservative than the source.
 
 ## What about durable replay defense?
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -32,31 +32,32 @@ Field-by-field:
 2. JSON-unmarshal the envelope. Reject `400 Bad Request` on failure.
 3. Check `protocol_version == 1`. Reject `400` with a clear message otherwise.
 4. Check `sequence` against the in-memory tracker for `source_hostname`. Reject `409 Conflict` if not strictly greater than the last seen value.
-5. Filter `cookies` against the sink's local `allowlist.yaml`. Cookies whose `host_key` matches no pattern are silently dropped; the sink logs the dropped host counts and reports them to the source via the response body.
+5. Filter `cookies` against the sink's local `blocklist.yaml`. Cookies whose `host_key` matches a pattern are silently dropped; the sink logs the dropped host counts and reports them to the source via the response body.
 6. Write the remaining cookies. CDP path first if `cdp.enabled` and Chrome reachable; otherwise SQLite path.
 
 ## Replay defense (v0.1 limits)
 
 The sequence tracker is in-memory only. Restarting the sink clears it; a captured payload could be replayed once after a restart. Durable replay defense is a v0.2 follow-up; the envelope is shaped so it can absorb a timestamp window or a server-issued nonce without breaking the version.
 
-## Allowlist (sink side, defense in depth)
+## Blocklist (sink side, defense in depth)
 
-The sink reads `~/.config/agentcookie/allowlist.yaml` independently of the source. If the source pushes a cookie for a host the sink has not allowlisted, the sink drops it. This means the sink owner has the final say on what state may land in their Chrome, even if the paired source is fully compromised. The source-side allowlist still runs first as a bandwidth and privacy optimization (no point sealing cookies that will be dropped).
+The sink reads `~/.config/agentcookie/blocklist.yaml` independently of the source. If the source pushes a cookie for a host the sink has blocked, the sink drops it. This means the sink owner has the final say on what state may land in their Chrome, even if the paired source is fully compromised. The source-side blocklist still runs first as a bandwidth and privacy optimization (no point sealing cookies that will be dropped).
 
-Allowlist schema:
+Blocklist schema:
 
 ```yaml
 version: 1
 domains:
-  - pattern: "%instacart.com"
-    description: ...
-  - pattern: "%granola.so"
+  - pattern: "instacart.com"
+    description: Instacart exact host
+  - pattern: "%.instacart.com"
+    description: Instacart subdomains
 ```
 
-Patterns use SQLite LIKE semantics (`%` wildcard). Matching is case-insensitive and matches against Chrome's `host_key` column, which includes a leading dot for subdomain cookies.
+Patterns use SQLite LIKE semantics (`%` wildcard). Matching is case-insensitive and matches against Chrome's `host_key` column, which includes a leading dot for subdomain cookies. Prefer `agentcookie accounts off <domain>` for normal site toggles; it writes the exact host plus a subdomain-safe `%.` pattern.
 
 ## Versioning
 
 - v1 is the current wire format. Source and sink must both speak it.
 - Future versions: bump `protocol_version` and update both source and sink. Sinks may carry compatibility shims for one prior version during transition windows.
-- Out-of-band fields (e.g. allowlist sync, signed bundles, cookie diffs) will arrive as additional optional envelope fields under v1 first, then potentially graduate to required in v2.
+- Out-of-band fields (e.g. filter sync, signed bundles, cookie diffs) will arrive as additional optional envelope fields under v1 first, then potentially graduate to required in v2.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -23,20 +23,20 @@ On the **source** (laptop):
 ```
 cd $(mktemp -d) && git clone https://github.com/mvanhorn/agentcookie.git
 cp agentcookie/examples/source.yaml ~/.config/agentcookie/source.yaml
-cp agentcookie/examples/allowlist.yaml ~/.config/agentcookie/allowlist.yaml
+cp agentcookie/examples/blocklist.yaml ~/.config/agentcookie/blocklist.yaml
 ```
 
 Edit `source.yaml`:
 - `sink.url`: the sink's tailnet URL, e.g. `http://my-mac-mini.tailnet.ts.net:9999/sync`
 - `peer.hostname`: the sink's tailnet hostname
 
-Edit `allowlist.yaml`: keep only the domains you want to sync. Comment out the rest.
+Edit `blocklist.yaml` or run `agentcookie accounts off <domain>` for sites you do not want to sync. Empty blocklist means sync everything.
 
 On the **sink** (Mac mini):
 
 ```
 cp agentcookie/examples/sink.yaml ~/.config/agentcookie/sink.yaml
-cp agentcookie/examples/allowlist.yaml ~/.config/agentcookie/allowlist.yaml
+cp agentcookie/examples/blocklist.yaml ~/.config/agentcookie/blocklist.yaml
 ```
 
 Edit `sink.yaml`:
@@ -110,7 +110,7 @@ Expected output:
 ```
 agentcookie source: %instacart.com -> 12 cookies
 agentcookie source: %granola.so -> 3 cookies
-agentcookie source: posted 15 cookies, sink replied: ok: wrote 15 cookies via cdp; dropped 0 non-allowlisted
+agentcookie source: posted 15 cookies, sink replied: ok: wrote 15 cookies via cdp; dropped 0 blocklisted cookies
 ```
 
 Check on the sink: open Chrome (or use the running one), visit a synced site, you should be logged in.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -4,7 +4,7 @@ This document captures what agentcookie does and does not protect against. Read 
 
 ## What agentcookie does
 
-Continuously replicates Chrome session cookies for a user-allowlisted set of domains from one macOS machine (the **source**, where the user logs in) to another (the **sink**, where AI agents run). The replication is one-way, opt-in per domain, and authenticated end-to-end with a pairing-derived symmetric key. Past v0.11, the sink also seals its on-disk cookie copies (sidecar SQLite and per-CLI session files) under a sink-local master key whose Keychain ACL pins the agentcookie binary plus each registered adapter binary.
+Continuously replicates Chrome session cookies from one macOS machine (the **source**, where the user logs in) to another (the **sink**, where AI agents run), with opt-out per-domain blocklists on both sides. The replication is one-way and authenticated end-to-end with a pairing-derived symmetric key. Past v0.11, the sink also seals its on-disk cookie copies (sidecar SQLite and per-CLI session files) under a sink-local master key whose Keychain ACL pins the agentcookie binary plus each registered adapter binary.
 
 ## Trust model
 
@@ -24,7 +24,7 @@ agentcookie trusts:
 - Online brute force of the pairing code. v0.12: 12 base32 characters (64 bits of entropy) and a per-IP token bucket capped at 5 attempts before a 429.
 - MITM during pairing. X25519 + HKDF salted with the pairing code means an attacker who intercepts the channel without knowing the code derives a different key, and the next AEAD message fails its tag check.
 - Replay of captured payloads across sink restarts. v0.12: the sequence tracker is persisted to `~/.agentcookie/sequence.json` and reloaded at sink boot.
-- Source pushing non-allowlisted cookies. The sink reads its own `allowlist.yaml` and drops cookies whose `host_key` matches no pattern, even if the source pushes them.
+- Source pushing blocklisted cookies. The sink reads its own `blocklist.yaml` and drops cookies whose `host_key` matches a blocked pattern, even if the source pushes them.
 - Source pushing cookies with control characters or path-traversal in name / value / host_key. v0.12 adds RFC 6265 token-character validation on name, control-char rejection on value, and a label-boundary suffix check that fixes the v0.11 unanchored match (e.g., `xopentable.com` no longer matched `opentable.com`).
 - Wrong-secret / unauthenticated requests. Both legacy `security.shared_secret` (now floored at 32 bytes) and paired keys gate every `/sync` call; AEAD tag mismatch returns 401.
 - DoS via slow-loris and oversize bodies on the sink and pair listeners. v0.12 sets ReadHeaderTimeout (5s), ReadTimeout (60s), WriteTimeout (60s), IdleTimeout (120s), and an `http.MaxBytesReader`-enforced body cap (256 MB for `/sync`, 16 KB for `/pair`).
@@ -38,10 +38,10 @@ agentcookie trusts:
 - Compromise of Chrome itself. A malicious extension on the source or sink, a NaCl exploit in Chrome, or a malicious .dylib injected into Chrome can already read cookie plaintext. agentcookie does not change that.
 - Compromise of the user's macOS account where the attacker can convince macOS that they ARE the agentcookie binary. The `-T` ACL pins the binary's Developer-ID-signed designated requirement, but a sufficiently sophisticated attacker with code-execution-as-user can re-sign their own binary with the same identity if they also stole the developer's signing identity. Out of scope; the bar is "stolen Developer ID Application certificate plus access to a private signing key".
 - Tailscale account takeover. Pairing-derived keys live below the Tailscale identity layer, so an attacker on the tailnet still cannot read or sign sync payloads. But they could exhaust ports, run their own sink, or hold the tailnet open for traffic analysis. Out of scope.
-- Device-fingerprint-bound sessions. Sites that bind a session to canvas fingerprint, accept-language, screen size, etc. will fail after replication. agentcookie does not (and likely cannot) sync fingerprint hints. Document affected sites in your allowlist comments and re-auth them in-browser on the sink.
+- Device-fingerprint-bound sessions. Sites that bind a session to canvas fingerprint, accept-language, screen size, etc. will fail after replication. agentcookie does not (and likely cannot) sync fingerprint hints. Document affected sites in your blocklist comments and re-auth them in-browser on the sink.
 - Device Bound Session Credentials (DBSC). Chrome's DBSC binds a session's refresh to a private key in the source Mac's Secure Enclave, which is non-exportable by design. For a site that has adopted DBSC, a replicated cookie works on the sink only until its short-lived window (minutes) lapses; the sink cannot sign the refresh challenge, so Chrome there logs the session out. agentcookie cannot defeat this and does not try. Scope of impact as of May 2026: DBSC is opt-in per site and the only broad adopter is Google's own account/Workspace cookies (GA on Chrome for Windows first, rolling out on macOS in the next release). Non-DBSC sites and the entire secrets bus (bearer tokens, API keys, OAuth refresh tokens) are unaffected. The source flags DBSC-suspect cookies in `agentcookie doctor` and ships them with a warning by default; `--skip-dbsc-suspect` drops them. For Google sessions, sign the sink's Chrome into the same account once instead of relying on copied cookies, and it establishes its own device-bound session locally.
 - Coercion of the user. If someone makes the user run `agentcookie pair --as sink` against a hostile source, the cookies will flow as designed.
-- Cookie value tampering by the source. The source is authoritative; if the source machine pushes cookies for an allowlisted domain, the sink writes them. There is no separate authorization layer per domain.
+- Cookie value tampering by the source. The source is authoritative; if the source machine pushes cookies for a non-blocklisted domain, the sink writes them. There is no separate authorization layer per domain.
 
 ## Cryptographic specifics
 

--- a/examples/blocklist.yaml
+++ b/examples/blocklist.yaml
@@ -11,6 +11,9 @@
 # insensitive and matches against Chrome's host_key (which includes a
 # leading dot for subdomain cookies).
 #
+# Prefer `agentcookie accounts off <domain>` for normal site toggles. It writes
+# both the exact host and subdomain-safe pattern without matching sibling domains.
+#
 # Both source and sink read this file independently. The sink owner has the
 # final say on what state lands on their machine.
 
@@ -18,22 +21,35 @@ version: 1
 
 domains:
   # Banking / brokerage / personal finance:
-  # - pattern: "%chase.com"
+  # - pattern: "chase.com"
   #   description: Chase bank
-  # - pattern: "%vanguard.com"
-  # - pattern: "%fidelity.com"
-  # - pattern: "%schwab.com"
-  # - pattern: "%bankofamerica.com"
+  # - pattern: "%.chase.com"
+  #   description: Chase bank
+  # - pattern: "vanguard.com"
+  # - pattern: "%.vanguard.com"
+  # - pattern: "fidelity.com"
+  # - pattern: "%.fidelity.com"
+  # - pattern: "schwab.com"
+  # - pattern: "%.schwab.com"
+  # - pattern: "bankofamerica.com"
+  # - pattern: "%.bankofamerica.com"
 
   # Password managers (almost certainly do not want synced):
-  # - pattern: "%1password.com"
-  # - pattern: "%bitwarden.com"
-  # - pattern: "%lastpass.com"
+  # - pattern: "1password.com"
+  # - pattern: "%.1password.com"
+  # - pattern: "bitwarden.com"
+  # - pattern: "%.bitwarden.com"
+  # - pattern: "lastpass.com"
+  # - pattern: "%.lastpass.com"
 
   # Tax / IRS:
-  # - pattern: "%irs.gov"
-  # - pattern: "%turbotax.intuit.com"
+  # - pattern: "irs.gov"
+  # - pattern: "%.irs.gov"
+  # - pattern: "turbotax.intuit.com"
+  # - pattern: "%.turbotax.intuit.com"
 
   # Health / insurance:
-  # - pattern: "%kaiserpermanente.org"
-  # - pattern: "%bcbs.com"
+  # - pattern: "kaiserpermanente.org"
+  # - pattern: "%.kaiserpermanente.org"
+  # - pattern: "bcbs.com"
+  # - pattern: "%.bcbs.com"

--- a/internal/cli/accounts.go
+++ b/internal/cli/accounts.go
@@ -1,0 +1,308 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"github.com/mvanhorn/agentcookie/internal/config"
+)
+
+var accountsCmd = &cobra.Command{
+	Use:   "accounts",
+	Short: "Turn cookie sync on or off for a domain",
+	Long: "accounts is a thin wrapper over blocklist.yaml. By default agentcookie\n" +
+		"syncs every cookie; accounts off adds safe exact+subdomain block patterns for a\n" +
+		"domain, and accounts on removes those patterns again.",
+}
+
+var accountsOffCmd = &cobra.Command{
+	Use:   "off <domain>",
+	Short: "Stop syncing cookies for a domain",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runAccountsToggle(cmd, args[0], false)
+	},
+}
+
+var accountsOnCmd = &cobra.Command{
+	Use:   "on <domain>",
+	Short: "Resume syncing cookies for a domain",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runAccountsToggle(cmd, args[0], true)
+	},
+}
+
+var accountsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List domains currently disabled by the local blocklist",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		bl, err := config.LoadBlocklist(common.ConfigDir)
+		if err != nil {
+			return err
+		}
+		return emitAccountsList(cmd, bl)
+	},
+}
+
+type accountsToggleResult struct {
+	Action     string   `json:"action"`
+	Domain     string   `json:"domain"`
+	Patterns   []string `json:"patterns"`
+	Changed    bool     `json:"changed"`
+	ConfigPath string   `json:"config_path"`
+}
+
+type accountsListResult struct {
+	Domains  []string `json:"domains"`
+	Patterns []string `json:"patterns,omitempty"`
+}
+
+func runAccountsToggle(cmd *cobra.Command, rawDomain string, enabled bool) error {
+	domain, err := normalizeAccountDomain(rawDomain)
+	if err != nil {
+		return err
+	}
+
+	bl, err := config.LoadBlocklist(common.ConfigDir)
+	if err != nil {
+		return err
+	}
+	patterns := accountBlockPatterns(domain)
+	changed := false
+	if enabled {
+		changed = removeAccountBlock(bl, domain)
+	} else {
+		changed = addAccountBlock(bl, domain)
+	}
+	if changed {
+		if err := writeAccountBlocklist(common.ConfigDir, bl); err != nil {
+			return err
+		}
+	}
+
+	action := "off"
+	if enabled {
+		action = "on"
+	}
+	return emitAccountsToggle(cmd, accountsToggleResult{
+		Action:     action,
+		Domain:     domain,
+		Patterns:   patterns,
+		Changed:    changed,
+		ConfigPath: filepath.Join(common.ConfigDir, "blocklist.yaml"),
+	})
+}
+
+func emitAccountsToggle(cmd *cobra.Command, result accountsToggleResult) error {
+	if common.JSON {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		return enc.Encode(result)
+	}
+	state := "enabled"
+	if result.Action == "off" {
+		state = "disabled"
+	}
+	if result.Changed {
+		_, err := fmt.Fprintf(cmd.OutOrStdout(), "agentcookie accounts: %s %s\n", result.Domain, state)
+		return err
+	}
+	_, err := fmt.Fprintf(cmd.OutOrStdout(), "agentcookie accounts: %s already %s\n", result.Domain, state)
+	return err
+}
+
+func emitAccountsList(cmd *cobra.Command, bl *config.Blocklist) error {
+	result := accountListResult(bl)
+	if common.JSON {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		return enc.Encode(result)
+	}
+	if len(result.Domains) == 0 && len(result.Patterns) == 0 {
+		_, err := fmt.Fprintln(cmd.OutOrStdout(), "agentcookie accounts: all domains enabled (blocklist empty)")
+		return err
+	}
+	for _, domain := range result.Domains {
+		if _, err := fmt.Fprintln(cmd.OutOrStdout(), domain); err != nil {
+			return err
+		}
+	}
+	if len(result.Patterns) > 0 {
+		if _, err := fmt.Fprintln(cmd.OutOrStdout(), "patterns:"); err != nil {
+			return err
+		}
+		for _, p := range result.Patterns {
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "  %s\n", p); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func accountListResult(bl *config.Blocklist) accountsListResult {
+	patterns := make(map[string]bool, len(bl.Domains))
+	for _, d := range bl.Domains {
+		patterns[d.Pattern] = true
+	}
+	consumed := make(map[string]bool, len(patterns))
+	domains := make([]string, 0)
+	for pattern := range patterns {
+		if strings.HasPrefix(pattern, "%.") {
+			domain := strings.TrimPrefix(pattern, "%.")
+			if patterns[domain] {
+				domains = append(domains, domain)
+				consumed[pattern] = true
+				consumed[domain] = true
+			}
+		}
+	}
+	others := make([]string, 0)
+	for pattern := range patterns {
+		if !consumed[pattern] {
+			others = append(others, pattern)
+		}
+	}
+	sort.Strings(domains)
+	sort.Strings(others)
+	return accountsListResult{Domains: domains, Patterns: others}
+}
+
+func addAccountBlock(bl *config.Blocklist, domain string) bool {
+	if bl.Version == 0 {
+		bl.Version = 1
+	}
+	existing := map[string]bool{}
+	for _, d := range bl.Domains {
+		existing[strings.ToLower(d.Pattern)] = true
+	}
+	changed := false
+	for _, pattern := range accountBlockPatterns(domain) {
+		if existing[strings.ToLower(pattern)] {
+			continue
+		}
+		bl.Domains = append(bl.Domains, config.BlocklistEntry{
+			Pattern:     pattern,
+			Description: "Disabled by agentcookie accounts off " + domain,
+		})
+		changed = true
+	}
+	return changed
+}
+
+func removeAccountBlock(bl *config.Blocklist, domain string) bool {
+	remove := map[string]bool{}
+	for _, pattern := range accountBlockPatterns(domain) {
+		remove[strings.ToLower(pattern)] = true
+	}
+	// Also remove the older broad pattern users may have hand-written from the
+	// examples. If they ask to turn a domain on, that is the intended reversal.
+	remove[strings.ToLower("%"+domain)] = true
+	remove[strings.ToLower("."+domain)] = true
+
+	kept := bl.Domains[:0]
+	changed := false
+	for _, d := range bl.Domains {
+		if remove[strings.ToLower(d.Pattern)] {
+			changed = true
+			continue
+		}
+		kept = append(kept, d)
+	}
+	bl.Domains = kept
+	return changed
+}
+
+func accountBlockPatterns(domain string) []string {
+	return []string{domain, "%." + domain}
+}
+
+func writeAccountBlocklist(dir string, bl *config.Blocklist) error {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create config dir: %w", err)
+	}
+	if bl.Version == 0 {
+		bl.Version = 1
+	}
+	if bl.Domains == nil {
+		bl.Domains = []config.BlocklistEntry{}
+	}
+	path := filepath.Join(dir, "blocklist.yaml")
+	f, err := os.CreateTemp(dir, ".blocklist-*.yaml")
+	if err != nil {
+		return fmt.Errorf("create temp blocklist in %s: %w", dir, err)
+	}
+	tmpPath := f.Name()
+	defer os.Remove(tmpPath)
+	if err := f.Chmod(0o600); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("chmod temp blocklist: %w", err)
+	}
+	enc := yaml.NewEncoder(f)
+	enc.SetIndent(2)
+	if err := enc.Encode(bl); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	if err := enc.Close(); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("close %s: %w", path, err)
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("sync %s: %w", tmpPath, err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close %s: %w", tmpPath, err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("rename %s to %s: %w", tmpPath, path, err)
+	}
+	return nil
+}
+
+var accountDomainPattern = regexp.MustCompile("^[a-z0-9][a-z0-9.-]*[a-z0-9]$")
+
+func normalizeAccountDomain(raw string) (string, error) {
+	domain := strings.TrimSpace(strings.ToLower(raw))
+	if domain == "" {
+		return "", fmt.Errorf("accounts: domain is required")
+	}
+	if strings.Contains(domain, "://") {
+		u, err := url.Parse(domain)
+		if err != nil {
+			return "", fmt.Errorf("accounts: parse domain: %w", err)
+		}
+		domain = u.Host
+	} else if i := strings.IndexByte(domain, '/'); i >= 0 {
+		domain = domain[:i]
+	}
+	if host, _, err := net.SplitHostPort(domain); err == nil {
+		domain = host
+	}
+	domain = strings.TrimPrefix(domain, "*.")
+	domain = strings.TrimPrefix(domain, ".")
+	domain = strings.TrimSuffix(domain, ".")
+	if domain == "" || strings.Contains(domain, "..") || !accountDomainPattern.MatchString(domain) {
+		return "", fmt.Errorf("accounts: invalid domain %q", raw)
+	}
+	for _, label := range strings.Split(domain, ".") {
+		if label == "" || strings.HasPrefix(label, "-") || strings.HasSuffix(label, "-") {
+			return "", fmt.Errorf("accounts: invalid domain %q", raw)
+		}
+	}
+	return domain, nil
+}
+
+func init() {
+	accountsCmd.AddCommand(accountsOffCmd, accountsOnCmd, accountsListCmd)
+}

--- a/internal/cli/accounts_test.go
+++ b/internal/cli/accounts_test.go
@@ -1,0 +1,227 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mvanhorn/agentcookie/internal/config"
+	"github.com/mvanhorn/agentcookie/internal/protocol"
+)
+
+func TestNormalizeAccountDomain(t *testing.T) {
+	cases := map[string]string{
+		"x.com":                    "x.com",
+		".x.com":                   "x.com",
+		"*.x.com":                  "x.com",
+		"https://www.amazon.com/a": "www.amazon.com",
+		"example.com:443":          "example.com",
+		"Example.COM.":             "example.com",
+	}
+	for in, want := range cases {
+		got, err := normalizeAccountDomain(in)
+		if err != nil {
+			t.Fatalf("normalizeAccountDomain(%q): %v", in, err)
+		}
+		if got != want {
+			t.Errorf("normalizeAccountDomain(%q) = %q, want %q", in, got, want)
+		}
+	}
+	for _, in := range []string{"", "https://", "bad domain.com", "-x.com", "x..com", "x.com?bad=1"} {
+		if _, err := normalizeAccountDomain(in); err == nil {
+			t.Errorf("normalizeAccountDomain(%q) should fail", in)
+		}
+	}
+}
+
+func TestAccountBlockPatternsAvoidSiblingDomains(t *testing.T) {
+	bl := &config.Blocklist{Version: 1}
+	if !addAccountBlock(bl, "amazon.com") {
+		t.Fatal("addAccountBlock should report changed on first add")
+	}
+	matcher := protocol.NewBlocklistMatcher(bl)
+	for _, host := range []string{"amazon.com", ".amazon.com", "www.amazon.com", "sellercentral.amazon.com"} {
+		if !matcher.MatchesHost(host) {
+			t.Errorf("%q should be blocked", host)
+		}
+	}
+	for _, host := range []string{"evilamazon.com", "amazon-adsystem.com", "amazon.co.uk"} {
+		if matcher.MatchesHost(host) {
+			t.Errorf("%q should not be blocked", host)
+		}
+	}
+}
+
+func TestAccountsToggleWritesBlocklist(t *testing.T) {
+	dir := t.TempDir()
+	oldDir := common.ConfigDir
+	oldJSON := common.JSON
+	common.ConfigDir = dir
+	common.JSON = false
+	t.Cleanup(func() {
+		common.ConfigDir = oldDir
+		common.JSON = oldJSON
+	})
+
+	offOut := &bytes.Buffer{}
+	if err := runAccountsToggle(commandWithOutput(offOut), "x.com", false); err != nil {
+		t.Fatalf("accounts off: %v", err)
+	}
+	if !strings.Contains(offOut.String(), "x.com disabled") {
+		t.Errorf("unexpected off output: %q", offOut.String())
+	}
+	bl, err := config.LoadBlocklist(dir)
+	if err != nil {
+		t.Fatalf("LoadBlocklist: %v", err)
+	}
+	if got := patternsFromBlocklist(bl); strings.Join(got, ",") != "%.x.com,x.com" {
+		t.Fatalf("patterns after off = %v", got)
+	}
+
+	offAgain := &bytes.Buffer{}
+	if err := runAccountsToggle(commandWithOutput(offAgain), "x.com", false); err != nil {
+		t.Fatalf("accounts off again: %v", err)
+	}
+	if !strings.Contains(offAgain.String(), "already disabled") {
+		t.Errorf("unexpected off-again output: %q", offAgain.String())
+	}
+
+	onOut := &bytes.Buffer{}
+	if err := runAccountsToggle(commandWithOutput(onOut), "x.com", true); err != nil {
+		t.Fatalf("accounts on: %v", err)
+	}
+	if !strings.Contains(onOut.String(), "x.com enabled") {
+		t.Errorf("unexpected on output: %q", onOut.String())
+	}
+	bl, err = config.LoadBlocklist(dir)
+	if err != nil {
+		t.Fatalf("LoadBlocklist after on: %v", err)
+	}
+	if len(bl.Domains) != 0 {
+		t.Fatalf("patterns after on = %v", patternsFromBlocklist(bl))
+	}
+
+	info, err := os.Stat(filepath.Join(dir, "blocklist.yaml"))
+	if err != nil {
+		t.Fatalf("stat blocklist: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("blocklist mode = %v, want 0600", info.Mode().Perm())
+	}
+}
+
+func TestAccountsOnRemovesLegacyBroadPattern(t *testing.T) {
+	bl := &config.Blocklist{Version: 1, Domains: []config.BlocklistEntry{
+		{Pattern: "%x.com"},
+		{Pattern: "%.keep.com"},
+	}}
+	if !removeAccountBlock(bl, "x.com") {
+		t.Fatal("removeAccountBlock should remove legacy broad pattern")
+	}
+	if got := patternsFromBlocklist(bl); strings.Join(got, ",") != "%.keep.com" {
+		t.Fatalf("patterns after remove = %v", got)
+	}
+}
+
+func TestAccountsToggleJSON(t *testing.T) {
+	dir := t.TempDir()
+	oldDir := common.ConfigDir
+	oldJSON := common.JSON
+	common.ConfigDir = dir
+	common.JSON = true
+	t.Cleanup(func() {
+		common.ConfigDir = oldDir
+		common.JSON = oldJSON
+	})
+
+	out := &bytes.Buffer{}
+	if err := runAccountsToggle(commandWithOutput(out), "x.com", false); err != nil {
+		t.Fatalf("accounts off json: %v", err)
+	}
+	var got accountsToggleResult
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("invalid JSON: %v (%s)", err, out.String())
+	}
+	if got.Action != "off" || got.Domain != "x.com" || !got.Changed || len(got.Patterns) != 2 {
+		t.Fatalf("unexpected JSON result: %+v", got)
+	}
+}
+
+func TestAccountsList(t *testing.T) {
+	oldJSON := common.JSON
+	common.JSON = false
+	t.Cleanup(func() { common.JSON = oldJSON })
+
+	bl := &config.Blocklist{Version: 1, Domains: []config.BlocklistEntry{
+		{Pattern: "%.x.com"},
+		{Pattern: "x.com"},
+		{Pattern: "%custom.test"},
+	}}
+	out := &bytes.Buffer{}
+	if err := emitAccountsList(commandWithOutput(out), bl); err != nil {
+		t.Fatalf("emitAccountsList: %v", err)
+	}
+	if got := out.String(); got != "x.com\npatterns:\n  %custom.test\n" {
+		t.Errorf("list output = %q", got)
+	}
+	common.JSON = true
+	out.Reset()
+	if err := emitAccountsList(commandWithOutput(out), bl); err != nil {
+		t.Fatalf("emitAccountsList json: %v", err)
+	}
+	if !strings.Contains(out.String(), "\"domains\"") || !strings.Contains(out.String(), "\"patterns\"") {
+		t.Errorf("expected JSON list, got %q", out.String())
+	}
+}
+
+func TestAccountsCommandHonorsConfigDirFlag(t *testing.T) {
+	dir := t.TempDir()
+	oldDir := common.ConfigDir
+	oldJSON := common.JSON
+	common.JSON = false
+	t.Cleanup(func() {
+		common.ConfigDir = oldDir
+		common.JSON = oldJSON
+	})
+
+	root := &cobra.Command{Use: "agentcookie", SilenceUsage: true, SilenceErrors: true}
+	root.PersistentFlags().StringVar(&common.ConfigDir, "config-dir", defaultConfigDir(), "config dir")
+	root.PersistentFlags().BoolVar(&common.JSON, "json", false, "json")
+	root.AddCommand(accountsCmd)
+	t.Cleanup(func() { root.RemoveCommand(accountsCmd) })
+
+	out := &bytes.Buffer{}
+	root.SetOut(out)
+	root.SetArgs([]string{"--config-dir", dir, "accounts", "off", "x.com"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("root accounts off: %v", err)
+	}
+	bl, err := config.LoadBlocklist(dir)
+	if err != nil {
+		t.Fatalf("LoadBlocklist: %v", err)
+	}
+	if got := patternsFromBlocklist(bl); strings.Join(got, ",") != "%.x.com,x.com" {
+		t.Fatalf("patterns after root command = %v", got)
+	}
+}
+
+func commandWithOutput(out *bytes.Buffer) *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.SetOut(out)
+	return cmd
+}
+
+func patternsFromBlocklist(bl *config.Blocklist) []string {
+	patterns := make([]string, 0, len(bl.Domains))
+	for _, d := range bl.Domains {
+		patterns = append(patterns, d.Pattern)
+	}
+	sort.Strings(patterns)
+	return patterns
+}

--- a/internal/cli/cookies_test.go
+++ b/internal/cli/cookies_test.go
@@ -102,7 +102,7 @@ func TestCollectDomainCookies_Blocklist(t *testing.T) {
 		{".amazon.com", "x-main", "xm"},
 	})
 	matcher := protocol.NewBlocklistMatcher(&config.Blocklist{
-		Domains: []config.BlocklistEntry{{Pattern: "%amazon.com"}},
+		Domains: []config.BlocklistEntry{{Pattern: "amazon.com"}, {Pattern: "%.amazon.com"}},
 	})
 	got, err := collectDomainCookies(path, ".amazon.com", matcher)
 	if err != nil {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -43,10 +43,10 @@ See examples/ in this repo for sample config files.`,
 
 // Execute runs the root command. Called from main.
 func Execute() {
-	rootCmd.PersistentFlags().StringVar(&common.ConfigDir, "config-dir", defaultConfigDir(), "directory holding source.yaml, sink.yaml, allowlist.yaml")
+	rootCmd.PersistentFlags().StringVar(&common.ConfigDir, "config-dir", defaultConfigDir(), "directory holding source.yaml, sink.yaml, blocklist.yaml")
 	rootCmd.PersistentFlags().BoolVar(&common.JSON, "json", false, "emit machine-readable JSON output where the subcommand supports it")
 
-	rootCmd.AddCommand(sourceCmd, sinkCmd, pairCmd, statusCmd, versionCmd, wizardCmd, doctorCmd, secretCmd, discoverCmd, cookiesCmd)
+	rootCmd.AddCommand(sourceCmd, sinkCmd, pairCmd, statusCmd, versionCmd, wizardCmd, doctorCmd, secretCmd, discoverCmd, cookiesCmd, accountsCmd)
 
 	if err := rootCmd.Execute(); err != nil {
 		// Cobra already prints usage on flag errors; surface RunE errors here.

--- a/internal/cli/sink.go
+++ b/internal/cli/sink.go
@@ -19,8 +19,8 @@ import (
 	"github.com/mvanhorn/agentcookie/internal/cli/httpserver"
 	"github.com/mvanhorn/agentcookie/internal/config"
 	"github.com/mvanhorn/agentcookie/internal/keystore"
-	"github.com/mvanhorn/agentcookie/internal/secretsbus"
 	"github.com/mvanhorn/agentcookie/internal/protocol"
+	"github.com/mvanhorn/agentcookie/internal/secretsbus"
 	"github.com/mvanhorn/agentcookie/internal/sinkpush"
 	"github.com/mvanhorn/agentcookie/internal/state"
 	"github.com/mvanhorn/agentcookie/internal/transport"
@@ -185,7 +185,7 @@ func runSink(cmd *cobra.Command, args []string) error {
 			sinkState.TotalWrites++
 			sinkState.TotalDropped += dropped
 			_ = stateWriter.Save(sinkState)
-			_, _ = fmt.Fprintf(w, "dry-run ok: accepted %d cookies; dropped %d non-allowlisted\n", len(cookies), dropped)
+			_, _ = fmt.Fprintf(w, "dry-run ok: accepted %d cookies; dropped %d blocklisted cookies\n", len(cookies), dropped)
 			return
 		}
 
@@ -214,7 +214,7 @@ func runSink(cmd *cobra.Command, args []string) error {
 			http.Error(w, fmt.Sprintf("apply envelope: %v", writeErr), http.StatusInternalServerError)
 			return
 		}
-		fmt.Fprintf(os.Stderr, "agentcookie sink: wrote %d cookies (+ %d sidecar) + %d localStorage origins + %d indexedDB origins (mode=%s, dropped %d non-allowlisted cookies)\n", result.Cookies, result.SidecarCookies, result.LocalStorage, result.IndexedDB, writeMode, dropped)
+		fmt.Fprintf(os.Stderr, "agentcookie sink: wrote %d cookies (+ %d sidecar) + %d localStorage origins + %d indexedDB origins (mode=%s, dropped %d blocklisted cookies)\n", result.Cookies, result.SidecarCookies, result.LocalStorage, result.IndexedDB, writeMode, dropped)
 		sinkState.LastWrite = time.Now().UTC()
 		// In skip_chrome_sqlite mode, result.Cookies is zero (we did not
 		// write Chrome SQLite); report the sidecar count so sink-state
@@ -278,7 +278,7 @@ func runSink(cmd *cobra.Command, args []string) error {
 		}
 
 		_ = stateWriter.Save(sinkState)
-		_, _ = fmt.Fprintf(w, "ok: wrote %d cookies (%d sidecar), %d localStorage origins, %d indexedDB origins; dropped %d non-allowlisted cookies\n", result.Cookies, result.SidecarCookies, result.LocalStorage, result.IndexedDB, dropped)
+		_, _ = fmt.Fprintf(w, "ok: wrote %d cookies (%d sidecar), %d localStorage origins, %d indexedDB origins; dropped %d blocklisted cookies\n", result.Cookies, result.SidecarCookies, result.LocalStorage, result.IndexedDB, dropped)
 	})
 
 	srv := httpserver.Configure(&http.Server{Addr: cfg.Listen.Addr, Handler: mux}, httpserver.SinkSync)

--- a/internal/cli/source.go
+++ b/internal/cli/source.go
@@ -44,7 +44,7 @@ type dbscSummary struct {
 
 var sourceCmd = &cobra.Command{
 	Use:   "source",
-	Short: "Read allowlisted cookies from local Chrome and push to the configured sink",
+	Short: "Read local Chrome cookies, apply the blocklist, and push to the configured sink",
 	Long: `Two modes:
 
   agentcookie source --once   one read+push cycle, then exit. Useful for cron

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -14,7 +14,7 @@ import (
 
 var statusCmd = &cobra.Command{
 	Use:   "status",
-	Short: "Print local config, allowlist, live daemon state, and any load errors",
+	Short: "Print local config, blocklist, live daemon state, and any load errors",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		home, _ := os.UserHomeDir()
 		st := struct {
@@ -22,7 +22,7 @@ var statusCmd = &cobra.Command{
 			ConfigDir    string               `json:"config_dir"`
 			SourceConfig *config.SourceConfig `json:"source_config,omitempty"`
 			SinkConfig   *config.SinkConfig   `json:"sink_config,omitempty"`
-			Allowlist    *config.Allowlist    `json:"allowlist,omitempty"`
+			Blocklist    *config.Blocklist    `json:"blocklist,omitempty"`
 			SourceState  *state.SourceState   `json:"source_state,omitempty"`
 			SinkState    *state.SinkState     `json:"sink_state,omitempty"`
 			Errors       []string             `json:"errors,omitempty"`
@@ -41,10 +41,10 @@ var statusCmd = &cobra.Command{
 		} else {
 			st.Errors = append(st.Errors, "sink.yaml: "+err.Error())
 		}
-		if a, err := config.LoadAllowlist(common.ConfigDir); err == nil {
-			st.Allowlist = a
+		if bl, err := config.LoadBlocklist(common.ConfigDir); err == nil {
+			st.Blocklist = bl
 		} else {
-			st.Errors = append(st.Errors, "allowlist.yaml: "+err.Error())
+			st.Errors = append(st.Errors, "blocklist.yaml: "+err.Error())
 		}
 		if ss, err := state.LoadSource(state.SourcePath(home)); err == nil && ss != nil {
 			st.SourceState = ss
@@ -75,9 +75,9 @@ var statusCmd = &cobra.Command{
 		} else {
 			fmt.Println("  sink: not configured")
 		}
-		if st.Allowlist != nil {
-			fmt.Printf("  allowlist v%d: %d domains\n", st.Allowlist.Version, len(st.Allowlist.Domains))
-			for _, d := range st.Allowlist.Domains {
+		if st.Blocklist != nil {
+			fmt.Printf("  blocklist v%d: %d patterns\n", st.Blocklist.Version, len(st.Blocklist.Domains))
+			for _, d := range st.Blocklist.Domains {
 				if d.Description != "" {
 					fmt.Printf("    - %s  (%s)\n", d.Pattern, d.Description)
 				} else {
@@ -85,7 +85,7 @@ var statusCmd = &cobra.Command{
 				}
 			}
 		} else {
-			fmt.Println("  allowlist: not configured")
+			fmt.Println("  blocklist: not configured")
 		}
 		if st.SourceState != nil {
 			ago := "never"

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -96,7 +96,7 @@ func init() {
 	wizardInstallCmd.Flags().StringVar(&wizardCode, "code", "", "[sink] pairing code (from source's wizard output)")
 	wizardInstallCmd.Flags().StringVar(&wizardPairURL, "pair-url", "", "[sink] source's pairing URL")
 	wizardInstallCmd.Flags().BoolVar(&wizardRepair, "repair", false, "force a fresh pairing handshake even if a key already exists")
-	wizardInstallCmd.Flags().BoolVar(&wizardForce, "force", false, "overwrite existing source.yaml / sink.yaml / allowlist.yaml")
+	wizardInstallCmd.Flags().BoolVar(&wizardForce, "force", false, "overwrite existing source.yaml / sink.yaml / blocklist.yaml")
 	wizardInstallCmd.Flags().BoolVar(&wizardSkipDaemon, "skip-daemon", false, "skip installing the LaunchAgent (configs + pairing only)")
 	wizardInstallCmd.Flags().BoolVar(&wizardSkipExitNode, "skip-exit-node-hint", false, "do not detect Tailscale or print the sudo commands that route the sink's outbound traffic through the source machine")
 	wizardInstallCmd.Flags().BoolVar(&wizardSkipKeychainPrompt, "skip-keychain-prompt", false, "[sink] do not trigger the Chrome Safe Storage Keychain prompt during install; the sink daemon will prompt on first sync instead")
@@ -146,7 +146,7 @@ func wizardInstallSource(ctx context.Context, binPath, logDir string) error {
 		return err
 	}
 
-	// Step 1: drop source.yaml + allowlist.yaml if missing or force.
+	// Step 1: drop source.yaml + blocklist.yaml if missing or force.
 	// v0.12.0-beta.2: if source.yaml already exists with a peer.hostname
 	// that differs from --peer, fail loud rather than silently keeping the
 	// stale value (per friction log #14, 2026-05-19 dry-run). A future
@@ -907,25 +907,38 @@ func validateListenAddr(addr string) error {
 
 func starterBlocklistYAML() string {
 	return `# blocklist.yaml: domains to KEEP on this machine (NOT synced to the peer).
-# Empty file = sync everything. Uncomment any pattern below to opt out.
+# Empty file = sync everything. Prefer agentcookie accounts off <domain>
+# for normal site toggles; it writes exact + subdomain-safe patterns.
 version: 1
 domains:
   # Banking / brokerage / personal finance:
-  # - pattern: "%chase.com"
-  # - pattern: "%vanguard.com"
-  # - pattern: "%fidelity.com"
-  # - pattern: "%schwab.com"
-  # - pattern: "%bankofamerica.com"
+  # - pattern: "chase.com"
+  # - pattern: "%.chase.com"
+  # - pattern: "vanguard.com"
+  # - pattern: "%.vanguard.com"
+  # - pattern: "fidelity.com"
+  # - pattern: "%.fidelity.com"
+  # - pattern: "schwab.com"
+  # - pattern: "%.schwab.com"
+  # - pattern: "bankofamerica.com"
+  # - pattern: "%.bankofamerica.com"
   # Password managers (probably never want these on a second machine):
-  # - pattern: "%1password.com"
-  # - pattern: "%bitwarden.com"
-  # - pattern: "%lastpass.com"
+  # - pattern: "1password.com"
+  # - pattern: "%.1password.com"
+  # - pattern: "bitwarden.com"
+  # - pattern: "%.bitwarden.com"
+  # - pattern: "lastpass.com"
+  # - pattern: "%.lastpass.com"
   # Tax / IRS:
-  # - pattern: "%irs.gov"
-  # - pattern: "%turbotax.intuit.com"
+  # - pattern: "irs.gov"
+  # - pattern: "%.irs.gov"
+  # - pattern: "turbotax.intuit.com"
+  # - pattern: "%.turbotax.intuit.com"
   # Health / insurance:
-  # - pattern: "%kaiserpermanente.org"
-  # - pattern: "%bcbs.com"
+  # - pattern: "kaiserpermanente.org"
+  # - pattern: "%.kaiserpermanente.org"
+  # - pattern: "bcbs.com"
+  # - pattern: "%.bcbs.com"
 `
 }
 

--- a/internal/config/allowlist.go
+++ b/internal/config/allowlist.go
@@ -7,7 +7,7 @@ import (
 )
 
 // BlocklistEntry is one explicitly opted-OUT cookie domain. Pattern follows
-// SQLite LIKE syntax (use '%' as wildcard, e.g. "%chase.com"). Cookies whose
+// SQLite LIKE syntax (use '%' as wildcard, e.g. "%.chase.com"). Cookies whose
 // host_key matches any pattern are NOT synced.
 type BlocklistEntry struct {
 	Pattern     string `yaml:"pattern" json:"pattern"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,5 +1,5 @@
 // Package config loads agentcookie's on-disk configuration: source.yaml,
-// sink.yaml, and allowlist.yaml. Each file is independently optional so
+// sink.yaml, and blocklist.yaml. Each file is independently optional so
 // `agentcookie status` can report partial state.
 package config
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -261,9 +261,9 @@ func TestLoadBlocklistHappyPath(t *testing.T) {
 	writeFile(t, dir, "blocklist.yaml", `
 version: 1
 domains:
-  - pattern: "%chase.com"
+  - pattern: "chase.com"
     description: Chase bank
-  - pattern: "%1password.com"
+  - pattern: "%.chase.com"
 `)
 	bl, err := LoadBlocklist(dir)
 	if err != nil {
@@ -272,7 +272,7 @@ domains:
 	if len(bl.Domains) != 2 {
 		t.Errorf("expected 2 domains, got %d", len(bl.Domains))
 	}
-	if bl.Domains[0].Pattern != "%chase.com" {
+	if bl.Domains[0].Pattern != "chase.com" {
 		t.Errorf("first pattern wrong: %q", bl.Domains[0].Pattern)
 	}
 }
@@ -318,7 +318,7 @@ func TestLoadBlocklistMigratesLegacyAllowlist(t *testing.T) {
 	writeFile(t, dir, "allowlist.yaml", `
 version: 1
 domains:
-  - pattern: "%instacart.com"
+  - pattern: "%.instacart.com"
 `)
 	bl, err := LoadBlocklist(dir)
 	if err != nil {


### PR DESCRIPTION
## Summary
- add `agentcookie accounts off <domain>`, `accounts on <domain>`, and `accounts list`
- write safe exact + subdomain blocklist patterns like `x.com` and `%.x.com`
- update docs/examples/status wording around blocklist semantics

## Safety notes
- `blocklist.yaml` writes now use temp-file + chmod + fsync + rename
- `accounts on` also removes older broad `%domain` patterns for the requested domain
- `accounts list` groups exact+`%.` pairs back into disabled domains and reports custom patterns separately

## Tests
- `git diff --check HEAD~1..HEAD`
- `go test ./...`
- manual smoke: `go run ./cmd/agentcookie --config-dir <tmp> accounts off/list/status --json/on/list x.com`