### PR TITLE
fix(cli): load blocklist fresh and fail closed at sync boundaries

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -56,6 +56,8 @@ domains:
 
 Patterns use SQLite LIKE semantics (`%` wildcard). Matching is case-insensitive and matches against Chrome's `host_key` column, which includes a leading dot for subdomain cookies. Prefer `agentcookie accounts off <domain>` for normal site toggles; it writes the exact host plus a subdomain-safe `%.` pattern.
 
+A missing `blocklist.yaml` still means sync-all; a present but unparseable blocklist intentionally halts sync instead of falling back to sync-all.
+
 ## Versioning
 
 - v1 is the current wire format. Source and sink must both speak it.

--- a/internal/cli/blocklist.go
+++ b/internal/cli/blocklist.go
@@ -1,0 +1,10 @@
+package cli
+
+import "github.com/mvanhorn/agentcookie/internal/config"
+
+// loadFreshBlocklist loads the current blocklist for one sync boundary.
+// A missing blocklist.yaml preserves v0.3 sync-all semantics; any returned
+// error must be treated by callers as fail-closed, not as an empty blocklist.
+func loadFreshBlocklist() (*config.Blocklist, error) {
+	return config.LoadBlocklist(common.ConfigDir)
+}

--- a/internal/cli/blocklist_test.go
+++ b/internal/cli/blocklist_test.go
@@ -1,0 +1,118 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadFreshBlocklistMissingReturnsEmpty(t *testing.T) {
+	withConfigDir(t, t.TempDir())
+
+	bl, err := loadFreshBlocklist()
+	if err != nil {
+		t.Fatalf("loadFreshBlocklist missing file: %v", err)
+	}
+	if bl == nil {
+		t.Fatal("loadFreshBlocklist returned nil blocklist for missing file")
+	}
+	if bl.Version != 1 {
+		t.Errorf("Version = %d, want 1", bl.Version)
+	}
+	if len(bl.Domains) != 0 {
+		t.Errorf("missing blocklist should be sync-all empty, got %d domains", len(bl.Domains))
+	}
+}
+
+func TestLoadFreshBlocklistWellFormed(t *testing.T) {
+	dir := t.TempDir()
+	withConfigDir(t, dir)
+	writeCLIFile(t, filepath.Join(dir, "blocklist.yaml"), `
+version: 1
+domains:
+  - pattern: "chase.com"
+  - pattern: "%.chase.com"
+`)
+
+	bl, err := loadFreshBlocklist()
+	if err != nil {
+		t.Fatalf("loadFreshBlocklist valid file: %v", err)
+	}
+	if bl == nil {
+		t.Fatal("loadFreshBlocklist returned nil blocklist for valid file")
+	}
+	if len(bl.Domains) != 2 {
+		t.Fatalf("len(Domains) = %d, want 2", len(bl.Domains))
+	}
+	if bl.Domains[0].Pattern != "chase.com" || bl.Domains[1].Pattern != "%.chase.com" {
+		t.Errorf("patterns = %#v", bl.Domains)
+	}
+}
+
+func TestLoadFreshBlocklistRejectsUnknownTopLevelKey(t *testing.T) {
+	dir := t.TempDir()
+	withConfigDir(t, dir)
+	writeCLIFile(t, filepath.Join(dir, "blocklist.yaml"), `
+version: 1
+domains: []
+unexpected: true
+`)
+
+	bl, err := loadFreshBlocklist()
+	if err == nil {
+		t.Fatalf("loadFreshBlocklist should reject unknown top-level key, got blocklist %+v", bl)
+	}
+	if !strings.Contains(err.Error(), "field unexpected not found") {
+		t.Errorf("error should mention unknown key, got %v", err)
+	}
+}
+
+func TestLoadFreshBlocklistRejectsTruncatedFile(t *testing.T) {
+	dir := t.TempDir()
+	withConfigDir(t, dir)
+	writeCLIFile(t, filepath.Join(dir, "blocklist.yaml"), `
+version: 1
+domains:
+  - pattern: "%.chas
+`)
+
+	bl, err := loadFreshBlocklist()
+	if err == nil {
+		t.Fatalf("loadFreshBlocklist should reject truncated YAML, got blocklist %+v", bl)
+	}
+}
+
+func TestLoadFreshBlocklistRejectsUnsupportedVersion(t *testing.T) {
+	dir := t.TempDir()
+	withConfigDir(t, dir)
+	writeCLIFile(t, filepath.Join(dir, "blocklist.yaml"), `
+version: 2
+domains: []
+`)
+
+	bl, err := loadFreshBlocklist()
+	if err == nil {
+		t.Fatalf("loadFreshBlocklist should reject unsupported version, got blocklist %+v", bl)
+	}
+	if !strings.Contains(err.Error(), "unsupported blocklist version 2") {
+		t.Errorf("error should mention unsupported version, got %v", err)
+	}
+}
+
+func withConfigDir(t *testing.T, dir string) {
+	t.Helper()
+	oldDir := common.ConfigDir
+	common.ConfigDir = dir
+	t.Cleanup(func() { common.ConfigDir = oldDir })
+}
+
+func writeCLIFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/internal/cli/cookies.go
+++ b/internal/cli/cookies.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/mvanhorn/agentcookie/internal/config"
 	"github.com/mvanhorn/agentcookie/internal/protocol"
 	"github.com/mvanhorn/agentcookie/pkg/sidecar"
 )
@@ -40,7 +39,10 @@ with --json.
 		}
 		// Enforce the same blocklist the sink applies, so a blocked domain
 		// never leaks out through this door.
-		bl, _ := config.LoadBlocklist(common.ConfigDir)
+		bl, err := loadFreshBlocklist()
+		if err != nil {
+			return fmt.Errorf("cookies: load blocklist: %w", err)
+		}
 		matcher := protocol.NewBlocklistMatcher(bl)
 
 		cookies, err := collectDomainCookies(path, cookiesDomain, matcher)

--- a/internal/cli/cookies_test.go
+++ b/internal/cli/cookies_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"database/sql"
 	"encoding/json"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -39,6 +41,15 @@ func TestHostMatchesDomain(t *testing.T) {
 func makeSidecar(t *testing.T, rows [][3]string) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "cookies-plain.db")
+	makeSidecarAt(t, path, rows)
+	return path
+}
+
+func makeSidecarAt(t *testing.T, path string, rows [][3]string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir sidecar parent: %v", err)
+	}
 	db, err := sql.Open("sqlite3", path)
 	if err != nil {
 		t.Fatalf("open sidecar: %v", err)
@@ -56,7 +67,6 @@ func makeSidecar(t *testing.T, rows [][3]string) string {
 			t.Fatalf("insert: %v", err)
 		}
 	}
-	return path
 }
 
 func names(cookies []sidecar.Cookie) map[string]bool {
@@ -123,6 +133,71 @@ func TestCollectDomainCookies_MissingFile(t *testing.T) {
 	}
 }
 
+func TestCookiesCommandMalformedBlocklistReturnsError(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	configDir := t.TempDir()
+	writeCLIFile(t, filepath.Join(configDir, "blocklist.yaml"), `
+version: 1
+domains: []
+unexpected: true
+`)
+
+	out, err := runCookiesCommandForTest(t, configDir, ".amazon.com", false)
+	if err == nil {
+		t.Fatal("cookies command should fail on malformed blocklist")
+	}
+	if !strings.Contains(err.Error(), "load blocklist") {
+		t.Errorf("error should name blocklist load, got %v", err)
+	}
+	if out != "" {
+		t.Errorf("malformed blocklist should not emit cookies, got %q", out)
+	}
+}
+
+func TestCookiesCommandWellFormedBlocklist(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	sidecarPath := filepath.Join(home, ".agentcookie", "cookies-plain.db")
+	makeSidecarAt(t, sidecarPath, [][3]string{
+		{"amazon.com", "session-token", "tok"},
+		{"www.amazon.com", "ubid", "ub"},
+	})
+	configDir := t.TempDir()
+	writeCLIFile(t, filepath.Join(configDir, "blocklist.yaml"), `
+version: 1
+domains:
+  - pattern: "amazon.com"
+  - pattern: "%.amazon.com"
+`)
+
+	out, err := runCookiesCommandForTest(t, configDir, ".amazon.com", false)
+	if err != nil {
+		t.Fatalf("cookies command: %v", err)
+	}
+	if got := strings.TrimSpace(out); got != "" {
+		t.Errorf("blocklisted domain should emit no cookies, got %q", out)
+	}
+}
+
+func TestCookiesCommandMissingBlocklistSyncAll(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	sidecarPath := filepath.Join(home, ".agentcookie", "cookies-plain.db")
+	makeSidecarAt(t, sidecarPath, [][3]string{
+		{"amazon.com", "session-token", "tok"},
+	})
+	configDir := t.TempDir()
+
+	out, err := runCookiesCommandForTest(t, configDir, ".amazon.com", false)
+	if err != nil {
+		t.Fatalf("cookies command missing blocklist: %v", err)
+	}
+	if strings.TrimSpace(out) != "session-token=tok" {
+		t.Errorf("missing blocklist output = %q, want session-token=tok", out)
+	}
+}
+
 func TestEmitCookies_Header(t *testing.T) {
 	var buf bytes.Buffer
 	cookies := []sidecar.Cookie{
@@ -160,4 +235,23 @@ func TestEmitCookies_EmptyJSON(t *testing.T) {
 	if got := buf.String(); got != "[]\n" {
 		t.Errorf("empty JSON = %q, want %q", got, "[]\n")
 	}
+}
+
+func runCookiesCommandForTest(t *testing.T, configDir, domain string, asJSON bool) (string, error) {
+	t.Helper()
+	oldDir := common.ConfigDir
+	oldJSON := common.JSON
+	oldDomain := cookiesDomain
+	common.ConfigDir = configDir
+	common.JSON = asJSON
+	cookiesDomain = domain
+	t.Cleanup(func() {
+		common.ConfigDir = oldDir
+		common.JSON = oldJSON
+		cookiesDomain = oldDomain
+	})
+
+	out := &bytes.Buffer{}
+	err := cookiesCmd.RunE(commandWithOutput(out), nil)
+	return out.String(), err
 }

--- a/internal/cli/sink.go
+++ b/internal/cli/sink.go
@@ -94,16 +94,7 @@ func runSink(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Sink-side blocklist (defense in depth). Empty or missing blocklist =
-	// sync everything the source pushed. Patterns that match host_keys are
-	// dropped on the sink side regardless of what the source sent.
-	bl, _ := config.LoadBlocklist(common.ConfigDir)
-	blockMatcher := protocol.NewBlocklistMatcher(bl)
-	if blockMatcher.PatternCount() == 0 {
-		fmt.Fprintln(os.Stderr, "agentcookie sink: blocklist empty; sync-all mode")
-	} else {
-		fmt.Fprintf(os.Stderr, "agentcookie sink: blocklist has %d opt-out patterns\n", blockMatcher.PatternCount())
-	}
+	logSinkStartupBlocklistStatus()
 
 	// Persistent replay-defense state. Survives sink restart so a
 	// captured /sync envelope cannot be replayed after a reboot. A
@@ -124,6 +115,39 @@ func runSink(cmd *cobra.Command, args []string) error {
 		ListenAddr: cfg.Listen.Addr,
 	}
 
+	mux := newSinkMux(cfg, transportSecret, key, seqTracker, stateWriter, sinkState)
+
+	srv := httpserver.Configure(&http.Server{Addr: cfg.Listen.Addr, Handler: mux}, httpserver.SinkSync)
+	if sinkDryRun {
+		fmt.Fprintf(os.Stderr, "agentcookie sink: listening on http://%s (dry-run; no Chrome state will be modified)\n", cfg.Listen.Addr)
+	} else {
+		fmt.Fprintf(os.Stderr, "agentcookie sink: listening on http://%s (db=%s)\n", cfg.Listen.Addr, cfg.Chrome.DBPath)
+	}
+	return srv.ListenAndServe()
+}
+
+func logSinkStartupBlocklistStatus() {
+	bl, err := loadFreshBlocklist()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "agentcookie sink: blocklist load failed; /sync will fail closed until fixed: %v\n", err)
+		return
+	}
+	blockMatcher := protocol.NewBlocklistMatcher(bl)
+	if blockMatcher.PatternCount() == 0 {
+		fmt.Fprintln(os.Stderr, "agentcookie sink: blocklist empty; sync-all mode")
+	} else {
+		fmt.Fprintf(os.Stderr, "agentcookie sink: blocklist has %d opt-out patterns\n", blockMatcher.PatternCount())
+	}
+}
+
+func newSinkMux(
+	cfg *config.SinkConfig,
+	transportSecret string,
+	key []byte,
+	seqTracker *protocol.SequenceTracker,
+	stateWriter *state.Writer,
+	sinkState *state.SinkState,
+) *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		_, _ = fmt.Fprintln(w, "ok")
@@ -153,6 +177,16 @@ func runSink(cmd *cobra.Command, args []string) error {
 			http.Error(w, fmt.Sprintf("protocol version mismatch: got %d, sink speaks %d-%d", envelope.ProtocolVersion, protocol.MinVersion, protocol.Version), http.StatusBadRequest)
 			return
 		}
+
+		bl, err := loadFreshBlocklist()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "agentcookie sink: blocklist load failed: %v\n", err)
+			recordSinkReject(sinkState, stateWriter, err)
+			http.Error(w, "load blocklist: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		blockMatcher := protocol.NewBlocklistMatcher(bl)
+
 		if !seqTracker.Accept(envelope.SourceHostname, envelope.Sequence) {
 			http.Error(w, fmt.Sprintf("sequence %d not greater than last seen for %q (replay defense)", envelope.Sequence, envelope.SourceHostname), http.StatusConflict)
 			return
@@ -207,10 +241,7 @@ func runSink(cmd *cobra.Command, args []string) error {
 		}
 		if writeErr != nil {
 			fmt.Fprintf(os.Stderr, "agentcookie sink: write failed (cookies=%d ls=%d idb=%d mode=%s): %v\n", result.Cookies, result.LocalStorage, result.IndexedDB, writeMode, writeErr)
-			sinkState.LastError = writeErr.Error()
-			sinkState.LastErrorAt = time.Now().UTC()
-			sinkState.TotalRejects++
-			_ = stateWriter.Save(sinkState)
+			recordSinkReject(sinkState, stateWriter, writeErr)
 			http.Error(w, fmt.Sprintf("apply envelope: %v", writeErr), http.StatusInternalServerError)
 			return
 		}
@@ -280,14 +311,19 @@ func runSink(cmd *cobra.Command, args []string) error {
 		_ = stateWriter.Save(sinkState)
 		_, _ = fmt.Fprintf(w, "ok: wrote %d cookies (%d sidecar), %d localStorage origins, %d indexedDB origins; dropped %d blocklisted cookies\n", result.Cookies, result.SidecarCookies, result.LocalStorage, result.IndexedDB, dropped)
 	})
+	return mux
+}
 
-	srv := httpserver.Configure(&http.Server{Addr: cfg.Listen.Addr, Handler: mux}, httpserver.SinkSync)
-	if sinkDryRun {
-		fmt.Fprintf(os.Stderr, "agentcookie sink: listening on http://%s (dry-run; no Chrome state will be modified)\n", cfg.Listen.Addr)
-	} else {
-		fmt.Fprintf(os.Stderr, "agentcookie sink: listening on http://%s (db=%s)\n", cfg.Listen.Addr, cfg.Chrome.DBPath)
+func recordSinkReject(sinkState *state.SinkState, stateWriter *state.Writer, err error) {
+	if sinkState == nil {
+		return
 	}
-	return srv.ListenAndServe()
+	sinkState.LastError = err.Error()
+	sinkState.LastErrorAt = time.Now().UTC()
+	sinkState.TotalRejects++
+	if stateWriter != nil {
+		_ = stateWriter.Save(sinkState)
+	}
 }
 
 // toStateAdapterResults converts sinkpush.Result slices to the state

--- a/internal/cli/sink_test.go
+++ b/internal/cli/sink_test.go
@@ -1,14 +1,25 @@
 package cli
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
+	"sort"
 	"strings"
 	"testing"
 
 	"github.com/mvanhorn/agentcookie/internal/chrome"
+	"github.com/mvanhorn/agentcookie/internal/config"
+	"github.com/mvanhorn/agentcookie/internal/protocol"
+	"github.com/mvanhorn/agentcookie/internal/state"
+	"github.com/mvanhorn/agentcookie/internal/transport"
+	"github.com/mvanhorn/agentcookie/pkg/sidecar"
 )
 
 // TestValidateListenAddr_PolicyMatrix exercises the v0.12 S1 binding
@@ -192,6 +203,131 @@ func TestApplySidecarOnlyToSink_EmptyCookies(t *testing.T) {
 	}
 }
 
+func TestSinkSyncMalformedBlocklistReturns500AndWritesNothing(t *testing.T) {
+	fx := newSinkHandlerFixture(t, false)
+	writeCLIFile(t, filepath.Join(fx.configDir, "blocklist.yaml"), `
+version: 1
+domains: []
+unexpected: true
+`)
+
+	rec := fx.postSync(1, []chrome.Cookie{
+		{HostKey: ".blocked.com", Name: "blocked", Value: "b", Path: "/"},
+		{HostKey: ".allowed.com", Name: "allowed", Value: "a", Path: "/"},
+	})
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500; body=%q", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "load blocklist") {
+		t.Errorf("response should name blocklist load failure, got %q", rec.Body.String())
+	}
+	if _, err := os.Stat(fx.sidecarPath()); !os.IsNotExist(err) {
+		t.Fatalf("sidecar should be untouched on malformed blocklist, stat err=%v", err)
+	}
+	if fx.sinkState.TotalRejects != 1 {
+		t.Errorf("TotalRejects = %d, want 1", fx.sinkState.TotalRejects)
+	}
+	if got := fx.seqTracker.Last("source-test"); got != 0 {
+		t.Errorf("malformed blocklist should not accept sequence, got %d", got)
+	}
+}
+
+func TestSinkSyncWellFormedBlocklistFiltersBeforeWrite(t *testing.T) {
+	fx := newSinkHandlerFixture(t, false)
+	writeCLIFile(t, filepath.Join(fx.configDir, "blocklist.yaml"), `
+version: 1
+domains:
+  - pattern: "%.blocked.com"
+`)
+
+	rec := fx.postSync(1, []chrome.Cookie{
+		{HostKey: ".blocked.com", Name: "blocked", Value: "b", Path: "/"},
+		{HostKey: ".allowed.com", Name: "allowed", Value: "a", Path: "/"},
+	})
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "dropped 1 blocklisted cookies") {
+		t.Errorf("response should report dropped cookie, got %q", rec.Body.String())
+	}
+	if got := fx.sidecarHosts(); !reflect.DeepEqual(got, []string{".allowed.com"}) {
+		t.Fatalf("sidecar hosts = %v, want only allowed", got)
+	}
+}
+
+func TestSinkSyncMissingBlocklistSyncsAll(t *testing.T) {
+	fx := newSinkHandlerFixture(t, false)
+
+	rec := fx.postSync(1, []chrome.Cookie{
+		{HostKey: ".one.com", Name: "one", Value: "1", Path: "/"},
+		{HostKey: ".two.com", Name: "two", Value: "2", Path: "/"},
+	})
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", rec.Code, rec.Body.String())
+	}
+	if got := fx.sidecarHosts(); !reflect.DeepEqual(got, []string{".one.com", ".two.com"}) {
+		t.Fatalf("sidecar hosts = %v, want sync-all", got)
+	}
+}
+
+func TestSinkSyncReloadsBlocklistBetweenRequests(t *testing.T) {
+	fx := newSinkHandlerFixture(t, false)
+	cookies := []chrome.Cookie{
+		{HostKey: ".blocked.com", Name: "blocked", Value: "b", Path: "/"},
+		{HostKey: ".allowed.com", Name: "allowed", Value: "a", Path: "/"},
+	}
+
+	rec := fx.postSync(1, cookies)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("first status = %d, want 200; body=%q", rec.Code, rec.Body.String())
+	}
+	if got := fx.sidecarHosts(); !reflect.DeepEqual(got, []string{".allowed.com", ".blocked.com"}) {
+		t.Fatalf("first sidecar hosts = %v", got)
+	}
+
+	writeCLIFile(t, filepath.Join(fx.configDir, "blocklist.yaml"), `
+version: 1
+domains:
+  - pattern: "%.blocked.com"
+`)
+	rec = fx.postSync(2, cookies)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("second status = %d, want 200; body=%q", rec.Code, rec.Body.String())
+	}
+	if got := fx.sidecarHosts(); !reflect.DeepEqual(got, []string{".allowed.com"}) {
+		t.Fatalf("second sidecar hosts = %v, want newly blocked host dropped", got)
+	}
+}
+
+func TestSinkSyncDryRunMalformedBlocklistRefuses(t *testing.T) {
+	fx := newSinkHandlerFixture(t, true)
+	writeCLIFile(t, filepath.Join(fx.configDir, "blocklist.yaml"), `
+version: 1
+domains:
+  - pattern: "%.blocked.com
+`)
+
+	rec := fx.postSync(1, []chrome.Cookie{
+		{HostKey: ".allowed.com", Name: "allowed", Value: "a", Path: "/"},
+	})
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500; body=%q", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "accepted") {
+		t.Errorf("dry-run malformed blocklist should not report accepted cookies, got %q", rec.Body.String())
+	}
+	if fx.sinkState.TotalWrites != 0 {
+		t.Errorf("TotalWrites = %d, want 0", fx.sinkState.TotalWrites)
+	}
+	if _, err := os.Stat(fx.sidecarPath()); !os.IsNotExist(err) {
+		t.Fatalf("dry-run malformed blocklist should not create sidecar, stat err=%v", err)
+	}
+}
+
 // TestSetCDPInjectorForTesting confirms the test seam restores the
 // production injector. Used by other tests that need to stub
 // cdpInject.
@@ -256,4 +392,84 @@ func TestCDPInjector_FailureDoesNotPropagate(t *testing.T) {
 	if !strings.Contains(err.Error(), "simulated chromedp launch failure") {
 		t.Errorf("unexpected error: %v", err)
 	}
+}
+
+type sinkHandlerFixture struct {
+	configDir  string
+	home       string
+	mux        *http.ServeMux
+	secret     string
+	seqTracker *protocol.SequenceTracker
+	sinkState  *state.SinkState
+}
+
+func newSinkHandlerFixture(t *testing.T, dryRun bool) *sinkHandlerFixture {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	configDir := t.TempDir()
+	withConfigDir(t, configDir)
+
+	oldDryRun := sinkDryRun
+	sinkDryRun = dryRun
+	t.Cleanup(func() { sinkDryRun = oldDryRun })
+
+	cfg := &config.SinkConfig{
+		Listen:           config.ListenRef{Addr: "127.0.0.1:9999"},
+		SkipChromeSQLite: true,
+	}
+	secret := "sink-handler-test-secret"
+	seqTracker := protocol.NewSequenceTracker()
+	sinkState := &state.SinkState{Role: "sink", ListenAddr: cfg.Listen.Addr}
+	stateWriter := state.NewWriter(filepath.Join(t.TempDir(), "sink-state.json"))
+	mux := newSinkMux(cfg, secret, []byte("0123456789abcdef"), seqTracker, stateWriter, sinkState)
+
+	return &sinkHandlerFixture{
+		configDir:  configDir,
+		home:       home,
+		mux:        mux,
+		secret:     secret,
+		seqTracker: seqTracker,
+		sinkState:  sinkState,
+	}
+}
+
+func (f *sinkHandlerFixture) postSync(seq int64, cookies []chrome.Cookie) *httptest.ResponseRecorder {
+	envelope := protocol.SyncEnvelope{
+		ProtocolVersion: protocol.Version,
+		SourceHostname:  "source-test",
+		Sequence:        seq,
+		Cookies:         cookies,
+	}
+	payload, err := json.Marshal(envelope)
+	if err != nil {
+		panic(err)
+	}
+	sealed, err := transport.SealWithSecret(payload, f.secret)
+	if err != nil {
+		panic(err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/sync", bytes.NewReader(sealed))
+	rec := httptest.NewRecorder()
+	f.mux.ServeHTTP(rec, req)
+	return rec
+}
+
+func (f *sinkHandlerFixture) sidecarPath() string {
+	return filepath.Join(f.home, ".agentcookie", "cookies-plain.db")
+}
+
+func (f *sinkHandlerFixture) sidecarHosts() []string {
+	cookies, err := sidecar.ReadSidecar(f.sidecarPath())
+	if err != nil {
+		panic(err)
+	}
+	hosts := make([]string, 0, len(cookies))
+	for _, c := range cookies {
+		hosts = append(hosts, c.HostKey)
+	}
+	sort.Strings(hosts)
+	return hosts
 }

--- a/internal/cli/source.go
+++ b/internal/cli/source.go
@@ -80,8 +80,8 @@ func runSource(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	// v0.3: sync-all by default. Blocklist is optional; missing file is fine.
-	blocklist, err := config.LoadBlocklist(common.ConfigDir)
-	if err != nil {
+	// Fail fast on a broken file at startup, then reload again for each push.
+	if _, err := loadFreshBlocklist(); err != nil {
 		return err
 	}
 
@@ -108,21 +108,7 @@ func runSource(cmd *cobra.Command, args []string) error {
 	skipDBSC := sourceSkipDBSC || os.Getenv("AGENTCOOKIE_SKIP_DBSC_SUSPECT") == "1"
 
 	push := func(ctx context.Context) (int, error) {
-		n, dbsc, err := pushOnce(ctx, cfg, blocklist, key, secret, sourceDryRun, sourceVerbose, skipDBSC)
-		if err != nil {
-			srcState.TotalFailures++
-			srcState.LastError = err.Error()
-			srcState.LastErrorAt = time.Now().UTC()
-		} else {
-			srcState.TotalPushes++
-			srcState.LastPushCount = n
-			srcState.LastPush = time.Now().UTC()
-		}
-		srcState.LastDBSCWarned = dbsc.warned
-		srcState.LastDBSCSkipped = dbsc.skipped
-		srcState.LastDBSCSample = dbsc.sample
-		_ = stateWriter.Save(srcState)
-		return n, err
+		return pushWithFreshBlocklist(ctx, cfg, key, secret, sourceDryRun, sourceVerbose, skipDBSC, srcState, stateWriter)
 	}
 
 	if sourceOnce {
@@ -191,6 +177,55 @@ func runSource(cmd *cobra.Command, args []string) error {
 	}()
 
 	return w.Run(cmd.Context())
+}
+
+func pushWithFreshBlocklist(
+	ctx context.Context,
+	cfg *config.SourceConfig,
+	key []byte,
+	secret string,
+	dryRun bool,
+	verbose bool,
+	skipDBSC bool,
+	srcState *state.SourceState,
+	stateWriter *state.Writer,
+) (int, error) {
+	blocklist, err := loadFreshBlocklist()
+	var dbsc dbscSummary
+	if err != nil {
+		recordSourcePushResult(srcState, stateWriter, 0, dbsc, err)
+		return 0, err
+	}
+	n, dbsc, err := pushOnce(ctx, cfg, blocklist, key, secret, dryRun, verbose, skipDBSC)
+	recordSourcePushResult(srcState, stateWriter, n, dbsc, err)
+	return n, err
+}
+
+func recordSourcePushResult(
+	srcState *state.SourceState,
+	stateWriter *state.Writer,
+	n int,
+	dbsc dbscSummary,
+	err error,
+) {
+	if srcState == nil {
+		return
+	}
+	if err != nil {
+		srcState.TotalFailures++
+		srcState.LastError = err.Error()
+		srcState.LastErrorAt = time.Now().UTC()
+	} else {
+		srcState.TotalPushes++
+		srcState.LastPushCount = n
+		srcState.LastPush = time.Now().UTC()
+	}
+	srcState.LastDBSCWarned = dbsc.warned
+	srcState.LastDBSCSkipped = dbsc.skipped
+	srcState.LastDBSCSample = dbsc.sample
+	if stateWriter != nil {
+		_ = stateWriter.Save(srcState)
+	}
 }
 
 // pushOnce performs one read+filter+push cycle. Returns the number of cookies

--- a/internal/cli/source_test.go
+++ b/internal/cli/source_test.go
@@ -1,0 +1,339 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"sync"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/mvanhorn/agentcookie/internal/chrome"
+	"github.com/mvanhorn/agentcookie/internal/config"
+	"github.com/mvanhorn/agentcookie/internal/protocol"
+	"github.com/mvanhorn/agentcookie/internal/state"
+	"github.com/mvanhorn/agentcookie/internal/transport"
+)
+
+func TestSourcePushReloadsBlocklistBetweenPushes(t *testing.T) {
+	fx := newSourcePushFixture(t, []chrome.Cookie{
+		{HostKey: ".blocked.com", Name: "blocked", Value: "b", Path: "/"},
+		{HostKey: ".allowed.com", Name: "allowed", Value: "a", Path: "/"},
+	})
+	writeCLIFile(t, filepath.Join(fx.configDir, "blocklist.yaml"), `
+version: 1
+domains: []
+`)
+
+	if _, err := fx.push(); err != nil {
+		t.Fatalf("first push: %v", err)
+	}
+	if got := fx.hostsAt(0); !reflect.DeepEqual(got, []string{".allowed.com", ".blocked.com"}) {
+		t.Fatalf("first push hosts = %v", got)
+	}
+
+	writeCLIFile(t, filepath.Join(fx.configDir, "blocklist.yaml"), `
+version: 1
+domains:
+  - pattern: "%.blocked.com"
+`)
+	if _, err := fx.push(); err != nil {
+		t.Fatalf("second push: %v", err)
+	}
+	if got := fx.hostsAt(1); !reflect.DeepEqual(got, []string{".allowed.com"}) {
+		t.Fatalf("second push hosts = %v, want only allowed host after reload", got)
+	}
+}
+
+func TestSourcePushReloadsAccountsOffStyleBlocklist(t *testing.T) {
+	fx := newSourcePushFixture(t, []chrome.Cookie{
+		{HostKey: "example.com", Name: "apex", Value: "a", Path: "/"},
+		{HostKey: "www.example.com", Name: "sub", Value: "s", Path: "/"},
+		{HostKey: "allowed.com", Name: "allowed", Value: "ok", Path: "/"},
+	})
+
+	if _, err := fx.push(); err != nil {
+		t.Fatalf("first push: %v", err)
+	}
+	if got := fx.hostsAt(0); !reflect.DeepEqual(got, []string{"allowed.com", "example.com", "www.example.com"}) {
+		t.Fatalf("first push hosts = %v", got)
+	}
+
+	writeCLIFile(t, filepath.Join(fx.configDir, "blocklist.yaml"), `
+version: 1
+domains:
+  - pattern: "example.com"
+  - pattern: "%.example.com"
+`)
+	if _, err := fx.push(); err != nil {
+		t.Fatalf("second push: %v", err)
+	}
+	if got := fx.hostsAt(1); !reflect.DeepEqual(got, []string{"allowed.com"}) {
+		t.Fatalf("second push hosts = %v, want exact and subdomain dropped", got)
+	}
+}
+
+func TestSourcePushMalformedBlocklistSkipsPushAndRecordsFailure(t *testing.T) {
+	fx := newSourcePushFixture(t, []chrome.Cookie{
+		{HostKey: ".blocked.com", Name: "blocked", Value: "b", Path: "/"},
+		{HostKey: ".allowed.com", Name: "allowed", Value: "a", Path: "/"},
+	})
+	writeCLIFile(t, filepath.Join(fx.configDir, "blocklist.yaml"), `
+version: 1
+domains: []
+`)
+
+	if _, err := fx.push(); err != nil {
+		t.Fatalf("first push: %v", err)
+	}
+	writeCLIFile(t, filepath.Join(fx.configDir, "blocklist.yaml"), `
+version: 1
+domains: []
+unexpected: true
+`)
+
+	n, err := fx.push()
+	if err == nil {
+		t.Fatal("malformed blocklist should fail closed")
+	}
+	if n != 0 {
+		t.Errorf("malformed blocklist push count = %d, want 0", n)
+	}
+	if got := fx.batchCount(); got != 1 {
+		t.Fatalf("malformed blocklist should not send a second request, got %d batches", got)
+	}
+	if fx.srcState.TotalFailures != 1 {
+		t.Errorf("TotalFailures = %d, want 1", fx.srcState.TotalFailures)
+	}
+	if fx.srcState.LastError == "" {
+		t.Fatal("LastError should be set")
+	}
+	if fx.srcState.LastErrorAt.IsZero() {
+		t.Fatal("LastErrorAt should be set")
+	}
+}
+
+func TestSourcePushDeletedBlocklistFallsBackToSyncAll(t *testing.T) {
+	fx := newSourcePushFixture(t, []chrome.Cookie{
+		{HostKey: ".blocked.com", Name: "blocked", Value: "b", Path: "/"},
+		{HostKey: ".allowed.com", Name: "allowed", Value: "a", Path: "/"},
+	})
+	blocklistPath := filepath.Join(fx.configDir, "blocklist.yaml")
+	writeCLIFile(t, blocklistPath, `
+version: 1
+domains:
+  - pattern: "%.blocked.com"
+`)
+
+	if _, err := fx.push(); err != nil {
+		t.Fatalf("first push: %v", err)
+	}
+	if got := fx.hostsAt(0); !reflect.DeepEqual(got, []string{".allowed.com"}) {
+		t.Fatalf("first push hosts = %v", got)
+	}
+
+	if err := os.Remove(blocklistPath); err != nil {
+		t.Fatalf("remove blocklist: %v", err)
+	}
+	if _, err := fx.push(); err != nil {
+		t.Fatalf("second push after delete: %v", err)
+	}
+	if got := fx.hostsAt(1); !reflect.DeepEqual(got, []string{".allowed.com", ".blocked.com"}) {
+		t.Fatalf("deleted blocklist hosts = %v, want sync-all", got)
+	}
+}
+
+func TestSourcePushStableBlocklistFiltersConsistently(t *testing.T) {
+	fx := newSourcePushFixture(t, []chrome.Cookie{
+		{HostKey: ".blocked.com", Name: "blocked", Value: "b", Path: "/"},
+		{HostKey: ".allowed.com", Name: "allowed", Value: "a", Path: "/"},
+	})
+	writeCLIFile(t, filepath.Join(fx.configDir, "blocklist.yaml"), `
+version: 1
+domains:
+  - pattern: "%.blocked.com"
+`)
+
+	if _, err := fx.push(); err != nil {
+		t.Fatalf("first push: %v", err)
+	}
+	if _, err := fx.push(); err != nil {
+		t.Fatalf("second push: %v", err)
+	}
+	want := []string{".allowed.com"}
+	if got := fx.hostsAt(0); !reflect.DeepEqual(got, want) {
+		t.Fatalf("first push hosts = %v, want %v", got, want)
+	}
+	if got := fx.hostsAt(1); !reflect.DeepEqual(got, want) {
+		t.Fatalf("second push hosts = %v, want %v", got, want)
+	}
+}
+
+type sourcePushFixture struct {
+	configDir string
+	cfg       *config.SourceConfig
+	key       []byte
+	secret    string
+	capture   *sourceCapture
+	srcState  *state.SourceState
+}
+
+func newSourcePushFixture(t *testing.T, cookies []chrome.Cookie) *sourcePushFixture {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	configDir := t.TempDir()
+	withConfigDir(t, configDir)
+
+	key := []byte("0123456789abcdef")
+	dbPath := filepath.Join(t.TempDir(), "Cookies")
+	seedSourceCookiesDB(t, dbPath, cookies, key)
+
+	secret := "source-push-test-secret"
+	capture := newSourceCapture(t, secret)
+	oldTransport := http.DefaultTransport
+	http.DefaultTransport = capture
+	t.Cleanup(func() { http.DefaultTransport = oldTransport })
+
+	cfg := &config.SourceConfig{
+		Sink:   config.SinkRef{URL: "http://agentcookie-sink.test/sync"},
+		Chrome: config.ChromeRef{DBPath: dbPath},
+	}
+	return &sourcePushFixture{
+		configDir: configDir,
+		cfg:       cfg,
+		key:       key,
+		secret:    secret,
+		capture:   capture,
+		srcState:  &state.SourceState{Role: "source", SinkURL: "http://agentcookie-sink.test/sync"},
+	}
+}
+
+func (f *sourcePushFixture) push() (int, error) {
+	return pushWithFreshBlocklist(context.Background(), f.cfg, f.key, f.secret, false, false, false, f.srcState, nil)
+}
+
+func (f *sourcePushFixture) batchCount() int {
+	return f.capture.batchCount()
+}
+
+func (f *sourcePushFixture) hostsAt(i int) []string {
+	return hostsFromChromeCookies(f.capture.batchAt(i))
+}
+
+type sourceCapture struct {
+	secret  string
+	mu      sync.Mutex
+	batches [][]chrome.Cookie
+}
+
+func newSourceCapture(t *testing.T, secret string) *sourceCapture {
+	t.Helper()
+	return &sourceCapture{secret: secret}
+}
+
+func (c *sourceCapture) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Method != http.MethodPost {
+		return nil, fmt.Errorf("unexpected method %s", req.Method)
+	}
+	sealed, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read body: %w", err)
+	}
+	plaintext, err := transport.OpenWithSecret(sealed, c.secret)
+	if err != nil {
+		return nil, fmt.Errorf("open payload: %w", err)
+	}
+	var envelope protocol.SyncEnvelope
+	if err := json.Unmarshal(plaintext, &envelope); err != nil {
+		return nil, fmt.Errorf("unmarshal envelope: %w", err)
+	}
+	c.mu.Lock()
+	c.batches = append(c.batches, append([]chrome.Cookie(nil), envelope.Cookies...))
+	c.mu.Unlock()
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Status:     "200 OK",
+		Header:     make(http.Header),
+		Body:       io.NopCloser(bytes.NewBufferString("ok\n")),
+		Request:    req,
+	}, nil
+}
+
+func (c *sourceCapture) batchCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.batches)
+}
+
+func (c *sourceCapture) batchAt(i int) []chrome.Cookie {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]chrome.Cookie(nil), c.batches[i]...)
+}
+
+func seedSourceCookiesDB(t *testing.T, path string, cookies []chrome.Cookie, key []byte) {
+	t.Helper()
+	db, err := sql.Open("sqlite3", "file:"+path)
+	if err != nil {
+		t.Fatalf("open seed db: %v", err)
+	}
+	if _, err := db.Exec(sourceCookieSchema); err != nil {
+		_ = db.Close()
+		t.Fatalf("seed schema: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close seed db: %v", err)
+	}
+	if _, err := chrome.WriteCookies(path, cookies, key); err != nil {
+		t.Fatalf("seed cookies: %v", err)
+	}
+}
+
+func hostsFromChromeCookies(cookies []chrome.Cookie) []string {
+	hosts := make([]string, 0, len(cookies))
+	for _, c := range cookies {
+		hosts = append(hosts, c.HostKey)
+	}
+	sort.Strings(hosts)
+	return hosts
+}
+
+const sourceCookieSchema = `
+CREATE TABLE IF NOT EXISTS cookies(
+	creation_utc INTEGER NOT NULL,
+	host_key TEXT NOT NULL,
+	top_frame_site_key TEXT NOT NULL,
+	name TEXT NOT NULL,
+	value TEXT NOT NULL,
+	encrypted_value BLOB NOT NULL,
+	path TEXT NOT NULL,
+	expires_utc INTEGER NOT NULL,
+	is_secure INTEGER NOT NULL,
+	is_httponly INTEGER NOT NULL,
+	last_access_utc INTEGER NOT NULL,
+	has_expires INTEGER NOT NULL,
+	is_persistent INTEGER NOT NULL,
+	priority INTEGER NOT NULL,
+	samesite INTEGER NOT NULL,
+	source_scheme INTEGER NOT NULL,
+	source_port INTEGER NOT NULL,
+	last_update_utc INTEGER NOT NULL,
+	source_type INTEGER NOT NULL,
+	has_cross_site_ancestor INTEGER NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS cookies_unique_index ON cookies(
+	host_key, top_frame_site_key, has_cross_site_ancestor, name, path, source_scheme, source_port
+);
+`


### PR DESCRIPTION
Fixes two issues from the #77 review: a malformed `blocklist.yaml` could silently fall open to sync-all, and `accounts off/on` had no effect on a running daemon until restart.

Both share one root cause: the blocklist was loaded once at startup and its load errors were handled inconsistently. This loads the blocklist fresh at each sync boundary and fails closed on any load error.

- Source `--watch` reloads per push; a load error records a source-state failure and skips the push (no unfiltered sync). Startup keeps its fail-fast load.
- Sink `/sync` loads per request; a malformed blocklist returns HTTP 500 and writes nothing instead of degrading to sync-all. Startup load is now informational only.
- `cookies` propagates the load error instead of treating a broken file as empty.
- A missing `blocklist.yaml` still means sync-all (unchanged).

Behavior change: an unparseable blocklist now halts sync instead of leaking opted-out cookies. The error is surfaced at each boundary (source-state, sink 500 + stderr, `cookies` exit).

`go build`, `go vet`, `go test ./...` all pass.

Closes #78
Closes #79
