### PR TITLE
ci: port PP/last30days automations (Greptile config, govulncheck, golangci-lint, PR hygiene)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## Summary
+
+<!-- What does this change do, and why? One or two sentences. -->
+
+## Verified
+
+<!-- How did you confirm it works? e.g. go build ./..., go vet ./..., go test ./... -->
+- [ ] `go build ./...`
+- [ ] `go vet ./...`
+- [ ] `go test ./...`
+
+## Notes
+
+<!-- Behavior changes, follow-ups, or anything a reviewer should know.
+     Call out explicitly if this changes on-disk config, the wire format,
+     or the blocklist/sync filtering behavior. -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version-file: go.mod
           cache: true
       - name: go vet
         run: go vet ./...

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,34 @@
+name: govulncheck
+
+# Reachable-vulnerability scan of the module. Runs on every PR and can be
+# triggered manually. Uses govulncheck's default package-reachability mode,
+# which fails only on vulnerabilities actually reachable from the code (low
+# false-positive rate). Do not switch to -scan=module unless the repo wants
+# dependency-presence hygiene rather than reachable-vulnerability blocking.
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  govulncheck:
+    name: govulncheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
+
+      - name: Run govulncheck
+        run: govulncheck ./...

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,29 @@
+name: lint
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  go-lint:
+    name: go-lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.11.4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,6 +24,6 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - uses: golangci/golangci-lint-action@v9
+      - uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9
         with:
           version: v2.11.4

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,38 @@
+name: pr-title
+
+# Enforce Conventional Commit style on PR titles (the title becomes the squash
+# commit subject). Scope is optional -- agentcookie's history mixes scoped
+# (fix(cli): ...) and unscoped (docs: ...) titles.
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  pr-title:
+    name: pr-title
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        with:
+          types: |
+            feat
+            fix
+            docs
+            chore
+            refactor
+            test
+            ci
+            perf
+            build
+            style
+            revert
+          requireScope: false
+          subjectPattern: ^.+$
+          subjectPatternError: "PR title must have a description after the colon"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   pull-requests: read
 
@@ -17,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: amannn/action-semantic-pull-request@v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         with:
           types: |
             feat

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,50 @@
+version: "2"
+
+formatters:
+  enable:
+    - gofmt
+
+linters:
+  enable:
+    - govet
+    - errcheck
+    - staticcheck
+    - unused
+    # Catches accumulated "Go has a newer way to do this" patterns:
+    # interface{} -> any, ad-hoc loops -> slices.Contains, range-over-int,
+    # min/max builtins, strings.Builder, CutPrefix/CutSuffix, etc.
+    - modernize
+  settings:
+    errcheck:
+      exclude-functions:
+        # CLI output -- failure means stdout is broken, nothing to recover.
+        - (io.Writer).Write
+        # Idiomatic deferred rollback in error paths (not covered by the
+        # std-error-handling preset below, which handles Close/Flush/Remove).
+        - (*database/sql.Tx).Rollback
+  exclusions:
+    # std-error-handling excludes the idiomatic unchecked Close/Flush/Remove/
+    # print/Setenv errors across all types -- the standard Go convention where
+    # the error has nowhere meaningful to go (deferred cleanup, CLI output).
+    presets:
+      - std-error-handling
+    rules:
+      # Test files get a lighter touch: unchecked errors and ineffectual
+      # assignments in setup/cleanup helpers are noise, not bugs.
+      - path: '_test\.go'
+        linters:
+          - errcheck
+          - ineffassign
+      # staticcheck cannot see that t.Fatal terminates the test, so it reports
+      # false-positive nil-deref warnings after a `if x == nil { t.Fatal }`
+      # guard. SA4006 likewise flags intentional size sanity checks in tests.
+      - path: '_test\.go'
+        text: 'SA5011'
+      - path: '_test\.go'
+        text: 'SA4006'
+      # omitempty on a nested struct field has no effect, but switching to
+      # omitzero would change config/wire serialization (config.go is the
+      # on-disk and wire format). Out of scope for a lint-gate change.
+      - text: 'omitzero'
+        linters:
+          - modernize

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
   enable:
     - govet
     - errcheck
+    - ineffassign
     - staticcheck
     - unused
     # Catches accumulated "Go has a newer way to do this" patterns:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mvanhorn/agentcookie
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/chromedp/cdproto v0.0.0-20260321001828-e3e3800016bc

--- a/greptile.json
+++ b/greptile.json
@@ -1,0 +1,32 @@
+{
+  "statusCheck": true,
+  "triggerOnUpdates": true,
+  "customContext": {
+    "rules": [
+      {
+        "scope": [".github/workflows/**"],
+        "rule": "P0. A workflow that combines a pull_request_target trigger with a checkout step whose ref points at PR-head code (github.event.pull_request.head.sha, github.event.pull_request.head.ref, or refs/pull/<n>/merge) runs untrusted head code with base-context secrets and OIDC tokens, which attackers exfiltrate from runner memory. agentcookie's workflows run on pull_request (not pull_request_target) and do not check out untrusted refs. Flag any new pull_request_target workflow that overrides the checkout ref; recommend switching to pull_request or removing the ref override so checkout defaults to the base commit."
+      },
+      {
+        "scope": [".github/workflows/**"],
+        "rule": "P0. id-token: write mints OIDC tokens used to publish to npm, Sigstore, AWS, etc. agentcookie has no workflow that needs OIDC (releases use goreleaser). Any new workflow granting id-token: write is an OIDC-theft attack shape. Flag and recommend removing the permission unless a publishing workflow is genuinely being introduced with reviewer sign-off."
+      },
+      {
+        "scope": [".github/workflows/**"],
+        "rule": "P0. Setting GOPROXY, GOFLAGS, GONOSUMCHECK, GOSUMDB, or GONOSUMDB inside a workflow env block (workflow, job, or step level) lets PR authors redirect Go module resolution to an attacker proxy or suppress checksum verification. agentcookie does not use any of these overrides; new ones are forward-looking attack vectors. Flag any addition and recommend configuring private proxies at the org/runner level under operator review instead."
+      },
+      {
+        "scope": ["internal/**/*.go", "cmd/**/*.go", "pkg/**/*.go"],
+        "rule": "agentcookie legitimately reads the local Chrome cookie store and the macOS Keychain (Safe Storage password) as its core function. Judge whether a credential-path read is part of that established surface. Flag P0 when NEW reads of unrelated credential paths or secret env vars are added outside the existing Chrome/Keychain code: literal strings or os.Getenv for ~/.aws, ~/.ssh, ~/.kube, ~/.claude, ~/.vscode, or env vars AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN, GITHUB_TOKEN, NPM_TOKEN, ACTIONS_ID_TOKEN_REQUEST_URL. agentcookie has no reason to read these."
+      },
+      {
+        "scope": ["internal/**/*.go", "cmd/**/*.go", "pkg/**/*.go"],
+        "rule": "agentcookie is peer-to-peer over Tailscale with no cloud middleman: cookies flow only from the source to the configured sink. Flag any newly introduced outbound network sink (HTTP client to an external host, new URL/endpoint, DNS exfil shape) that is not part of the existing source-to-sink transport. Cookie or auth-state material must never leave the machine to an endpoint other than the configured peer."
+      },
+      {
+        "scope": ["internal/cli/**/*.go"],
+        "rule": "The blocklist is the safety mechanism that keeps opted-out domains (banking, password managers) off the sync. Every sync boundary (source push, sink /sync handler, cookies command) must load the blocklist fresh and FAIL CLOSED on a load error (refuse to sync), never degrade to sync-all. A missing blocklist file is sync-all and is fine. Flag any sync/filter path that loads the blocklist with the error discarded (e.g. `bl, _ := config.LoadBlocklist(...)`) or that proceeds to sync when the load failed."
+      }
+    ]
+  }
+}

--- a/internal/chrome/keychain.go
+++ b/internal/chrome/keychain.go
@@ -155,7 +155,7 @@ func isUnsignedCodesignOutput(out string) bool {
 // codesign's verbose output. Returns "" for a missing line or the literal
 // "not set" sentinel codesign emits for ad-hoc signatures.
 func parseTeamIdentifier(codesignOutput string) string {
-	for _, line := range strings.Split(codesignOutput, "\n") {
+	for line := range strings.SplitSeq(codesignOutput, "\n") {
 		line = strings.TrimSpace(line)
 		const prefix = "TeamIdentifier="
 		if !strings.HasPrefix(line, prefix) {
@@ -290,7 +290,7 @@ func CountSafeStorageItems() (int, error) {
 		return 0, fmt.Errorf("dump keychain: %w", err)
 	}
 	n := 0
-	for _, line := range strings.Split(out, "\n") {
+	for line := range strings.SplitSeq(out, "\n") {
 		if strings.Contains(line, safeStorageItemMarker) {
 			n++
 		}

--- a/internal/chrome/launchagent_helper.go
+++ b/internal/chrome/launchagent_helper.go
@@ -185,11 +185,11 @@ func agentStateAndExit(label string) (string, int, bool) {
 }
 
 func scanField(text, key string) string {
-	idx := strings.Index(text, key)
-	if idx < 0 {
+	_, after, ok := strings.Cut(text, key)
+	if !ok {
 		return ""
 	}
-	tail := text[idx+len(key):]
+	tail := after
 	end := strings.IndexByte(tail, '\n')
 	if end < 0 {
 		end = len(tail)

--- a/internal/chrome/write.go
+++ b/internal/chrome/write.go
@@ -138,10 +138,10 @@ func readTableColumns(db *sql.DB, table string) (map[string]bool, error) {
 	cols := map[string]bool{}
 	for rows.Next() {
 		var (
-			cid          int
-			name, ctype  string
-			notNull, pk  int
-			dfltValue    sql.NullString
+			cid         int
+			name, ctype string
+			notNull, pk int
+			dfltValue   sql.NullString
 		)
 		if err := rows.Scan(&cid, &name, &ctype, &notNull, &dfltValue, &pk); err != nil {
 			return nil, err

--- a/internal/chrome/write_test.go
+++ b/internal/chrome/write_test.go
@@ -178,7 +178,7 @@ func TestWriteCookies_MetaVersionIdempotent(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "Cookies")
 	seedEmptyCookiesDB(t, path)
 
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		if _, err := WriteCookies(path, []Cookie{{HostKey: ".a.com", Name: "n", Value: "v", Path: "/"}}, testKey); err != nil {
 			t.Fatalf("WriteCookies pass %d: %v", i, err)
 		}

--- a/internal/chromectl/chromectl.go
+++ b/internal/chromectl/chromectl.go
@@ -4,16 +4,16 @@
 // LevelDB). One package, one ceremony, used by every writer.
 //
 // The ceremony:
-//   1. Caller asks for Chrome to be quit
-//   2. osascript "tell application Google Chrome to quit" sends an
-//      AppleEvent that lets Chrome save session state and persist
-//      preferences before exiting
-//   3. Caller polls until the process is gone
-//   4. Caller does its file writes
-//   5. Caller asks Chrome to relaunch via open(1)
-//   6. Caller polls until Chrome's user-data-dir is in a stable state
-//      (its Local State file is being written, indicating Chrome boot
-//      finished initial setup)
+//  1. Caller asks for Chrome to be quit
+//  2. osascript "tell application Google Chrome to quit" sends an
+//     AppleEvent that lets Chrome save session state and persist
+//     preferences before exiting
+//  3. Caller polls until the process is gone
+//  4. Caller does its file writes
+//  5. Caller asks Chrome to relaunch via open(1)
+//  6. Caller polls until Chrome's user-data-dir is in a stable state
+//     (its Local State file is being written, indicating Chrome boot
+//     finished initial setup)
 //
 // Both polling steps are deadline-bounded so a stuck Chrome process
 // surfaces as a typed error rather than a hang.

--- a/internal/cli/accounts.go
+++ b/internal/cli/accounts.go
@@ -157,8 +157,8 @@ func accountListResult(bl *config.Blocklist) accountsListResult {
 	consumed := make(map[string]bool, len(patterns))
 	domains := make([]string, 0)
 	for pattern := range patterns {
-		if strings.HasPrefix(pattern, "%.") {
-			domain := strings.TrimPrefix(pattern, "%.")
+		if after, ok := strings.CutPrefix(pattern, "%."); ok {
+			domain := after
 			if patterns[domain] {
 				domains = append(domains, domain)
 				consumed[pattern] = true
@@ -295,7 +295,7 @@ func normalizeAccountDomain(raw string) (string, error) {
 	if domain == "" || strings.Contains(domain, "..") || !accountDomainPattern.MatchString(domain) {
 		return "", fmt.Errorf("accounts: invalid domain %q", raw)
 	}
-	for _, label := range strings.Split(domain, ".") {
+	for label := range strings.SplitSeq(domain, ".") {
 		if label == "" || strings.HasPrefix(label, "-") || strings.HasSuffix(label, "-") {
 			return "", fmt.Errorf("accounts: invalid domain %q", raw)
 		}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -1112,11 +1113,8 @@ func countEnvKeys(data []byte) int {
 		if len(trim) == 0 || trim[0] == '#' {
 			continue
 		}
-		for _, b := range trim {
-			if b == '=' {
-				n++
-				break
-			}
+		if slices.Contains(trim, '=') {
+			n++
 		}
 	}
 	return n

--- a/internal/cli/httpserver/httpserver_test.go
+++ b/internal/cli/httpserver/httpserver_test.go
@@ -12,9 +12,9 @@ import (
 
 func TestDefaults_AllProfiles(t *testing.T) {
 	cases := []struct {
-		profile         Profile
-		wantServerSide  bool
-		wantClientSide  bool
+		profile           Profile
+		wantServerSide    bool
+		wantClientSide    bool
 		wantMaxBodyAtMost int64
 	}{
 		{SinkSync, true, false, 256 * 1024 * 1024},

--- a/internal/cli/secret.go
+++ b/internal/cli/secret.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"path/filepath"
 	"sort"
@@ -286,9 +287,7 @@ func runSecretImportFrom(cmd *cobra.Command, args []string) error {
 	if existing == nil {
 		existing = map[string]string{}
 	}
-	for k, v := range flat {
-		existing[k] = v
-	}
+	maps.Copy(existing, flat)
 	if err := os.MkdirAll(filepath.Dir(envPath), 0o700); err != nil {
 		return err
 	}
@@ -456,12 +455,12 @@ func validBusKey(k string) bool {
 		isDigit := r >= '0' && r <= '9'
 		isUnder := r == '_'
 		if i == 0 {
-			if !(isLetter || isUnder) {
+			if !isLetter && !isUnder {
 				return false
 			}
 			continue
 		}
-		if !(isLetter || isDigit || isUnder) {
+		if !isLetter && !isDigit && !isUnder {
 			return false
 		}
 	}
@@ -536,15 +535,15 @@ func parseEnvBytesShim(data []byte) (map[string]string, error) {
 		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
 			continue
 		}
-		eq := strings.IndexByte(line, '=')
-		if eq < 0 {
+		before, after, ok := strings.Cut(line, "=")
+		if !ok {
 			return nil, fmt.Errorf("line %d: missing '='", ln)
 		}
-		key := line[:eq]
+		key := before
 		if key != strings.TrimSpace(key) {
 			return nil, fmt.Errorf("line %d: whitespace around '='", ln)
 		}
-		val := line[eq+1:]
+		val := after
 		if len(val) >= 2 {
 			first, last := val[0], val[len(val)-1]
 			if (first == '"' && last == '"') || (first == '\'' && last == '\'') {
@@ -661,9 +660,7 @@ func manifestAliases(cliName string) map[string]string {
 	if !ok || rp.Manifest == nil {
 		return out
 	}
-	for declared, stored := range rp.Manifest.Aliases {
-		out[declared] = stored
-	}
+	maps.Copy(out, rp.Manifest.Aliases)
 	return out
 }
 
@@ -675,9 +672,7 @@ func manifestAliases(cliName string) map[string]string {
 func effectiveAliases(cliName string) map[string]string {
 	merged := manifestAliases(cliName)
 	local, _ := readAliases(cliName)
-	for declared, stored := range local {
-		merged[declared] = stored
-	}
+	maps.Copy(merged, local)
 	return merged
 }
 

--- a/internal/cli/secret_revoke.go
+++ b/internal/cli/secret_revoke.go
@@ -81,7 +81,7 @@ To silence the auto-detect, drop a manifest with sync.default = false:
   default = false
   EOF
 
-Then re-run ` + "`agentcookie discover`" + ` to confirm.
+Then re-run `+"`agentcookie discover`"+` to confirm.
 `, name, rp.SourcePath, home, name, name, name, rp.ReadInPlacePath)
 		return nil
 

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -616,11 +616,11 @@ func (p *pairingInfoWriter) Write(data []byte) (int, error) {
 
 func extractCode(text string) string {
 	const tag = "pairing code:"
-	i := strings.Index(text, tag)
-	if i < 0 {
+	_, after, ok := strings.Cut(text, tag)
+	if !ok {
 		return ""
 	}
-	tail := text[i+len(tag):]
+	tail := after
 	fields := strings.Fields(tail)
 	if len(fields) == 0 {
 		return ""
@@ -704,6 +704,8 @@ peer:
 // keychain step), so resolveSinkHeadlessMode no longer consults this.
 // Retained as a small TTY probe for callers and tests. When in doubt
 // (e.g. tests), returns false.
+//
+//nolint:unused // intentionally retained TTY probe for callers/tests
 func isHeadlessInstall() bool {
 	stat, err := os.Stdin.Stat()
 	if err != nil {

--- a/internal/cli/wizard_keychain.go
+++ b/internal/cli/wizard_keychain.go
@@ -237,7 +237,7 @@ func convergeSafeStorageToOneItem(loginPassword string) (removed int, err error)
 	}
 
 	// Delete every matching item, then re-add exactly one with the SAME value.
-	for i := 0; i < n; i++ {
+	for range n {
 		if _, derr := execSecurityFunc("delete-generic-password",
 			"-s", "Chrome Safe Storage", "-a", "Chrome"); derr != nil {
 			break // nothing left to delete
@@ -457,7 +457,6 @@ func buildStrategies(extraBinaries []string, enableSealing bool, anyApp bool) []
 	}...)
 
 	for _, bin := range extraBinaries {
-		bin := bin
 		out = append(out, kcStrategy{
 			name: "trust-list:" + filepath.Base(bin),
 			apply: func() (string, error) {

--- a/internal/cli/wizard_keychain_test.go
+++ b/internal/cli/wizard_keychain_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -236,12 +237,7 @@ func TestAnyApp_DefaultUnchanged(t *testing.T) {
 }
 
 func contains(args []string, want string) bool {
-	for _, a := range args {
-		if a == want {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(args, want)
 }
 
 func containsPair(args []string, flag, val string) bool {

--- a/internal/cli/wizard_verify_adapters.go
+++ b/internal/cli/wizard_verify_adapters.go
@@ -110,8 +110,8 @@ func formatAdapterRow(r state.AdapterResult) (status, detail string) {
 // the table.
 func emitVerifyJSON(results []state.AdapterResult, statusCode string) error {
 	envelope := struct {
-		Status  string                 `json:"status"`
-		Results []state.AdapterResult  `json:"results,omitempty"`
+		Status  string                `json:"status"`
+		Results []state.AdapterResult `json:"results,omitempty"`
 	}{
 		Status:  statusCode,
 		Results: results,

--- a/internal/launchd/plist.go
+++ b/internal/launchd/plist.go
@@ -24,10 +24,10 @@ const (
 
 // Spec is the input to plist generation. All paths must be absolute.
 type Spec struct {
-	Role        Role
-	BinaryPath  string
-	LogDir      string
-	ExtraArgs   []string
+	Role       Role
+	BinaryPath string
+	LogDir     string
+	ExtraArgs  []string
 }
 
 // Label returns the launchd Label corresponding to the spec's role. Labels

--- a/internal/pairing/pairing_test.go
+++ b/internal/pairing/pairing_test.go
@@ -114,14 +114,12 @@ func TestRunSourceRejectsBadCode(t *testing.T) {
 	defer cancel()
 
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		// Source-side error not checked: we cancel the ctx below, which
 		// returns context.Canceled. The signal we care about is that the
 		// sink call returns the right rejection.
 		_, _, _ = RunSource(ctx, addr, "laptop.test", io.Discard)
-	}()
+	})
 
 	waitForListen(t, addr)
 

--- a/internal/pairing/ratelimit_test.go
+++ b/internal/pairing/ratelimit_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestRateLimiter_BucketCap(t *testing.T) {
 	l := newRateLimiter()
-	for i := 0; i < AttemptLimit; i++ {
+	for i := range AttemptLimit {
 		if !l.allow("1.2.3.4") {
 			t.Fatalf("attempt %d should be allowed", i+1)
 		}
@@ -20,7 +20,7 @@ func TestRateLimiter_BucketCap(t *testing.T) {
 
 func TestRateLimiter_PerIPIsolation(t *testing.T) {
 	l := newRateLimiter()
-	for i := 0; i < AttemptLimit; i++ {
+	for i := range AttemptLimit {
 		if !l.allow("1.2.3.4") {
 			t.Fatalf("a attempt %d should be allowed", i+1)
 		}
@@ -37,7 +37,7 @@ func TestRateLimiter_Refills(t *testing.T) {
 	l := newRateLimiter()
 	l.now = func() time.Time { return now }
 
-	for i := 0; i < AttemptLimit; i++ {
+	for range AttemptLimit {
 		_ = l.allow("1.2.3.4")
 	}
 	if l.allow("1.2.3.4") {

--- a/internal/protocol/jsonshim_test.go
+++ b/internal/protocol/jsonshim_test.go
@@ -4,5 +4,5 @@ import "encoding/json"
 
 // Test-only shims so the test file can avoid pulling encoding/json into the
 // production envelope.go.
-func jsonMarshal(v any) ([]byte, error)    { return json.Marshal(v) }
-func jsonUnmarshal(b []byte, v any) error  { return json.Unmarshal(b, v) }
+func jsonMarshal(v any) ([]byte, error)   { return json.Marshal(v) }
+func jsonUnmarshal(b []byte, v any) error { return json.Unmarshal(b, v) }

--- a/internal/protocol/protocol_test.go
+++ b/internal/protocol/protocol_test.go
@@ -48,15 +48,15 @@ func TestBlocklistMatcher_DropsMatchingHosts(t *testing.T) {
 	}
 	m := NewBlocklistMatcher(bl)
 	cases := map[string]bool{
-		"www.chase.com":          true,
-		"chase.com":              true,
-		".chase.com":              true,
-		"foo.vanguard.com":       true,
-		"passwords.example.com":  true,
-		"CHASE.COM":              true, // case-insensitive
-		"safe.example.com":       false,
-		"github.com":             false,
-		"":                       false,
+		"www.chase.com":         true,
+		"chase.com":             true,
+		".chase.com":            true,
+		"foo.vanguard.com":      true,
+		"passwords.example.com": true,
+		"CHASE.COM":             true, // case-insensitive
+		"safe.example.com":      false,
+		"github.com":            false,
+		"":                      false,
 	}
 	for host, wantBlocked := range cases {
 		got := m.MatchesHost(host)

--- a/internal/protocol/sequence_store.go
+++ b/internal/protocol/sequence_store.go
@@ -3,6 +3,7 @@ package protocol
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 )
@@ -114,9 +115,7 @@ type MemorySequenceStore struct {
 // given state. Pass nil for an empty store.
 func NewMemorySequenceStore(seed map[string]int64) *MemorySequenceStore {
 	st := map[string]int64{}
-	for k, v := range seed {
-		st[k] = v
-	}
+	maps.Copy(st, seed)
 	return &MemorySequenceStore{State: st}
 }
 
@@ -125,9 +124,7 @@ func (m *MemorySequenceStore) Load() (map[string]int64, error) {
 		return nil, m.FailLoad
 	}
 	out := map[string]int64{}
-	for k, v := range m.State {
-		out[k] = v
-	}
+	maps.Copy(out, m.State)
 	return out, nil
 }
 
@@ -137,9 +134,7 @@ func (m *MemorySequenceStore) Save(state map[string]int64) error {
 	}
 	m.SaveCount++
 	cp := map[string]int64{}
-	for k, v := range state {
-		cp[k] = v
-	}
+	maps.Copy(cp, state)
 	m.State = cp
 	return nil
 }

--- a/internal/secretsbus/discover_merge.go
+++ b/internal/secretsbus/discover_merge.go
@@ -2,6 +2,7 @@ package secretsbus
 
 import (
 	"fmt"
+	"maps"
 	"os"
 )
 
@@ -64,9 +65,7 @@ func LoadPayloadWithDiscovery(homeDir string) (*Payload, []error) {
 			for _, e := range carryErrs {
 				errs = append(errs, fmt.Errorf("discovered project %q: %w", slug, e))
 			}
-			for k, v := range carried {
-				filtered[k] = v
-			}
+			maps.Copy(filtered, carried)
 		}
 
 		if len(filtered) == 0 {

--- a/internal/secretsbus/discovery.go
+++ b/internal/secretsbus/discovery.go
@@ -27,12 +27,12 @@ const (
 // RegisteredProject is one row in the discovery registry. The Manifest
 // pointer may be in-memory (PP-derived) or parsed from disk (explicit).
 type RegisteredProject struct {
-	Name              string
-	Kind              SourceKind
-	SourcePath        string // where the manifest came from (file path)
-	ReadInPlacePath   string // expanded [secrets.file].path; empty for legacy-v1
-	Manifest          *ManifestV2
-	SkippedReason     string // populated only on SkippedEntry list
+	Name            string
+	Kind            SourceKind
+	SourcePath      string // where the manifest came from (file path)
+	ReadInPlacePath string // expanded [secrets.file].path; empty for legacy-v1
+	Manifest        *ManifestV2
+	SkippedReason   string // populated only on SkippedEntry list
 }
 
 // Registry holds the discovered projects keyed by slug, plus per-path
@@ -45,10 +45,10 @@ type Registry struct {
 // DiscoveryConfig customizes discovery for tests. Production callers pass
 // homeDir and accept defaults for the rest.
 type DiscoveryConfig struct {
-	HomeDir         string
-	ExtraPaths      []string // user-added paths via `agentcookie discover --add-path`
-	PPLibraryPath   string   // default ~/printing-press/library; settable for tests
-	SystemPath      string   // default /usr/local/share/agentcookie/manifests; settable for tests
+	HomeDir       string
+	ExtraPaths    []string // user-added paths via `agentcookie discover --add-path`
+	PPLibraryPath string   // default ~/printing-press/library; settable for tests
+	SystemPath    string   // default /usr/local/share/agentcookie/manifests; settable for tests
 }
 
 // Discover walks the well-known paths in priority order, parses every
@@ -228,10 +228,11 @@ func tryRegisterPP(reg *Registry, errs *[]error, ppJSONPath, homeDir string) {
 	}
 	finalName := m.Name
 	if existing, ok := reg.Projects[m.Name]; ok {
-		if existing.Kind == SourceKindExplicitManifest {
+		switch existing.Kind {
+		case SourceKindExplicitManifest:
 			// Explicit wins per 4.2; derived gets -pp suffix.
 			finalName = m.Name + "-pp"
-		} else if existing.Kind == SourceKindPPCLIDerived {
+		case SourceKindPPCLIDerived:
 			// Two derived collisions per 4.3: first-by-sort already won,
 			// this one gets a hash suffix.
 			sum := sha256.Sum256([]byte(ppJSONPath))

--- a/internal/secretsbus/discovery_test.go
+++ b/internal/secretsbus/discovery_test.go
@@ -191,8 +191,7 @@ func TestDiscoveryWatcher_DetectsNewManifest(t *testing.T) {
 	w := NewDiscoveryWatcher(cfg, 50*time.Millisecond, func(_ context.Context, d RegistryDelta, _ *Registry) {
 		deltas <- d
 	})
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	go w.Run(ctx)
 	time.Sleep(150 * time.Millisecond) // let initial snapshot fire
 

--- a/internal/secretsbus/manifest_v2.go
+++ b/internal/secretsbus/manifest_v2.go
@@ -175,7 +175,7 @@ func parseManifestV2Bytes(data []byte, sourcePath string) (*ManifestV2, []ParseW
 	}
 
 	// Second pass: map decode to detect explicit-vs-omitted sync.default.
-	var raw map[string]interface{}
+	var raw map[string]any
 	if _, err := toml.Decode(string(data), &raw); err != nil {
 		return nil, nil, fmt.Errorf("toml map parse: %w", err)
 	}
@@ -185,7 +185,7 @@ func parseManifestV2Bytes(data []byte, sourcePath string) (*ManifestV2, []ParseW
 	}
 
 	// Apply sync defaults. sync.default omitted -> true per spec section 6.
-	if syncRaw, ok := raw["sync"].(map[string]interface{}); ok {
+	if syncRaw, ok := raw["sync"].(map[string]any); ok {
 		if _, ok := syncRaw["default"]; !ok {
 			m.Sync.Default = true
 		}

--- a/internal/secretsbus/pp_cli_adapter.go
+++ b/internal/secretsbus/pp_cli_adapter.go
@@ -11,13 +11,13 @@ import (
 // the fields we read, so unknown fields in the JSON are silently ignored by
 // encoding/json.
 type ppCLIMetadata struct {
-	SchemaVersion       int                       `json:"schema_version"`
-	APIName             string                    `json:"api_name"`
-	DisplayName         string                    `json:"display_name"`
-	CLIName             string                    `json:"cli_name"`
-	Description         string                    `json:"description"`
-	AuthEnvVars         []string                  `json:"auth_env_vars"`
-	AuthEnvVarSpecs     []ppCLIAuthEnvVarSpec     `json:"auth_env_var_specs"`
+	SchemaVersion   int                   `json:"schema_version"`
+	APIName         string                `json:"api_name"`
+	DisplayName     string                `json:"display_name"`
+	CLIName         string                `json:"cli_name"`
+	Description     string                `json:"description"`
+	AuthEnvVars     []string              `json:"auth_env_vars"`
+	AuthEnvVarSpecs []ppCLIAuthEnvVarSpec `json:"auth_env_var_specs"`
 }
 
 type ppCLIAuthEnvVarSpec struct {

--- a/internal/secretsbus/secretsbus.go
+++ b/internal/secretsbus/secretsbus.go
@@ -51,6 +51,8 @@ type Manifest struct {
 
 // defaultSync returns the effective default. v1 spec: default is true when
 // the manifest omits [sync] entirely or omits sync.default.
+//
+//nolint:unused // intentionally retained; documents the v1 sync default semantics
 func (m *Manifest) defaultSync() bool {
 	// Burntsushi/toml zero-values Default to false; we need to distinguish
 	// "omitted" from "explicit false." We can't from the parsed struct
@@ -199,18 +201,18 @@ func parseEnvFile(path string) (map[string]string, error) {
 		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
 			continue
 		}
-		eq := strings.IndexByte(line, '=')
-		if eq < 0 {
+		before, after, ok := strings.Cut(line, "=")
+		if !ok {
 			return nil, fmt.Errorf("line %d: missing '=' (expected KEY=VALUE)", lineNum)
 		}
-		key := line[:eq]
+		key := before
 		if key != strings.TrimRight(key, " \t") || key != strings.TrimLeft(key, " \t") {
 			return nil, fmt.Errorf("line %d: whitespace around '=' is not allowed", lineNum)
 		}
 		if !validKeyName(key) {
 			return nil, fmt.Errorf("line %d: invalid key name %q", lineNum, key)
 		}
-		value := line[eq+1:]
+		value := after
 
 		if strings.HasSuffix(value, "\\") {
 			pending.WriteString(value[:len(value)-1])
@@ -253,12 +255,12 @@ func validKeyName(k string) bool {
 		isDigit := r >= '0' && r <= '9'
 		isUnder := r == '_'
 		if i == 0 {
-			if !(isLetter || isUnder) {
+			if !isLetter && !isUnder {
 				return false
 			}
 			continue
 		}
-		if !(isLetter || isDigit || isUnder) {
+		if !isLetter && !isDigit && !isUnder {
 			return false
 		}
 	}
@@ -283,12 +285,12 @@ func loadManifest(path string) (*Manifest, bool, error) {
 	}
 	// Two-pass: first decode into a generic map to detect whether
 	// sync.default was set explicitly; second pass into the typed struct.
-	var raw map[string]interface{}
+	var raw map[string]any
 	if err := toml.Unmarshal(data, &raw); err != nil {
 		return nil, false, fmt.Errorf("unmarshal: %w", err)
 	}
 	explicit := false
-	if syncRaw, ok := raw["sync"].(map[string]interface{}); ok {
+	if syncRaw, ok := raw["sync"].(map[string]any); ok {
 		if _, ok := syncRaw["default"]; ok {
 			explicit = true
 		}

--- a/internal/secretsbus/secretsbus_test.go
+++ b/internal/secretsbus/secretsbus_test.go
@@ -120,7 +120,7 @@ A = true
 func TestLoadPayload_OversizeFileSkipped(t *testing.T) {
 	home := t.TempDir()
 	cliDir := filepath.Join(SecretsRoot(home), "huge-cli")
-	huge := strings.Repeat("BIG_KEY=" + strings.Repeat("x", 100) + "\n", 3000)
+	huge := strings.Repeat("BIG_KEY="+strings.Repeat("x", 100)+"\n", 3000)
 	writeFile(t, filepath.Join(cliDir, "secrets.env"), huge)
 
 	p, errs := LoadPayload(home)
@@ -283,13 +283,13 @@ func TestValidCLIName(t *testing.T) {
 		{"foo123", true},
 		{"123foo", true},
 		{"", false},
-		{"Foo", false},      // uppercase
-		{"-foo", false},     // leading hyphen
-		{"foo-", false},     // trailing hyphen
-		{"foo.bar", false},  // dot
-		{"foo/bar", false},  // slash
-		{"foo_bar", false},  // underscore (per spec, only hyphen)
-		{"..", false},       // traversal
+		{"Foo", false},     // uppercase
+		{"-foo", false},    // leading hyphen
+		{"foo-", false},    // trailing hyphen
+		{"foo.bar", false}, // dot
+		{"foo/bar", false}, // slash
+		{"foo_bar", false}, // underscore (per spec, only hyphen)
+		{"..", false},      // traversal
 	}
 	for _, tc := range cases {
 		got := validCLIName(tc.in)

--- a/internal/secretsbus/writer.go
+++ b/internal/secretsbus/writer.go
@@ -2,6 +2,7 @@ package secretsbus
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"sort"
@@ -98,9 +99,7 @@ func WritePayload(homeDir string, payload map[string]map[string]string, sealingE
 		// Point path-reading CLIs at the carried files: a [[files]] item with an
 		// `env` set emits <ENV>=<abs materialized path> into secrets.env so
 		// `secret env` surfaces it (e.g. TESLA_CONFIG, TESLA_FLEET_KEY_FILE).
-		for envName, absPath := range matRes.EnvAdditions {
-			safe[envName] = absPath
-		}
+		maps.Copy(safe, matRes.EnvAdditions)
 
 		if len(safe) == 0 {
 			if matRes.FilesWritten > 0 {

--- a/internal/sinkpush/adapter_instacart.go
+++ b/internal/sinkpush/adapter_instacart.go
@@ -14,13 +14,13 @@ import (
 // InstacartAdapter pushes Instacart cookies into instacart-pp-cli's
 // session cache via the CLI's `auth paste` command. Strategy:
 //
-//   1. Filter cookies to instacart.com hosts (sink does this; adapter
-//      receives the filtered set).
-//   2. Format as a Cookie header value ("name=value; name=value; ...")
-//      mirroring the hack/dump-instacart reference flow that has been
-//      proven end-to-end on the Mac mini sink.
-//   3. exec `<cli> auth paste` with the header on stdin. instacart-pp-cli
-//      parses the header, writes its own session.json, and exits 0.
+//  1. Filter cookies to instacart.com hosts (sink does this; adapter
+//     receives the filtered set).
+//  2. Format as a Cookie header value ("name=value; name=value; ...")
+//     mirroring the hack/dump-instacart reference flow that has been
+//     proven end-to-end on the Mac mini sink.
+//  3. exec `<cli> auth paste` with the header on stdin. instacart-pp-cli
+//     parses the header, writes its own session.json, and exits 0.
 //
 // After Push completes, future invocations of instacart-pp-cli (over
 // SSH, via Hermes, anywhere) read from the freshly-written session.json

--- a/internal/sinkpush/adapter_pycookiecheat.go
+++ b/internal/sinkpush/adapter_pycookiecheat.go
@@ -19,8 +19,8 @@ import (
 // Discovered on 2026-05-17 from inspecting Matt's MBP after airbnb-pp-cli
 // and ebay-pp-cli auth flows ran successfully:
 //
-//   ~/.config/<cli>/config.toml   — TOML; access_token = '<cookie header>'
-//   ~/.config/<cli>/cookies.json  — JSON; {"cookies": "<cookie header>"}
+//	~/.config/<cli>/config.toml   — TOML; access_token = '<cookie header>'
+//	~/.config/<cli>/cookies.json  — JSON; {"cookies": "<cookie header>"}
 //
 // At least three PP CLIs share this exact format (airbnb-pp-cli,
 // ebay-pp-cli, pagliacci-pp-cli) -- they each shell out to

--- a/internal/sinkpush/init.go
+++ b/internal/sinkpush/init.go
@@ -5,11 +5,11 @@ package sinkpush
 // makes all five initial adapters available to RunAll.
 //
 // Adapters are registered in their plan-ordered sequence:
-//   1. instacart-pp-cli (U2; auth-paste strategy)
-//   2. airbnb-pp-cli (U3; pycookiecheat-style TOML+JSON)
-//   3. ebay-pp-cli (U3; same)
-//   4. pagliacci-pp-cli (U3; same; unverified end-to-end)
-//   5. table-reservation-goat-pp-cli (U4; single session.json)
+//  1. instacart-pp-cli (U2; auth-paste strategy)
+//  2. airbnb-pp-cli (U3; pycookiecheat-style TOML+JSON)
+//  3. ebay-pp-cli (U3; same)
+//  4. pagliacci-pp-cli (U3; same; unverified end-to-end)
+//  5. table-reservation-goat-pp-cli (U4; single session.json)
 //
 // Tests that need a clean registry call resetForTesting() first, then
 // Register their stubs. The built-ins re-register only on a fresh

--- a/internal/sinkpush/registry_test.go
+++ b/internal/sinkpush/registry_test.go
@@ -11,18 +11,18 @@ import (
 // stubAdapter is a configurable test double for Adapter. Each field
 // controls one observable behavior so tests can isolate concerns.
 type stubAdapter struct {
-	name        string
-	installed   bool
-	patterns    []string
-	pushErr     error
-	pushed      [][]chrome.Cookie // history of Push calls for assertions
-	binaryPath  string
+	name       string
+	installed  bool
+	patterns   []string
+	pushErr    error
+	pushed     [][]chrome.Cookie // history of Push calls for assertions
+	binaryPath string
 }
 
-func (s *stubAdapter) Name() string                   { return s.name }
-func (s *stubAdapter) CLIBinary() string              { return s.binaryPath }
-func (s *stubAdapter) IsInstalled() bool              { return s.installed }
-func (s *stubAdapter) CookieHostPatterns() []string   { return s.patterns }
+func (s *stubAdapter) Name() string                 { return s.name }
+func (s *stubAdapter) CLIBinary() string            { return s.binaryPath }
+func (s *stubAdapter) IsInstalled() bool            { return s.installed }
+func (s *stubAdapter) CookieHostPatterns() []string { return s.patterns }
 func (s *stubAdapter) Push(c []chrome.Cookie) error {
 	s.pushed = append(s.pushed, c)
 	return s.pushErr

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -76,7 +76,7 @@ func TestWriterIsConcurrencySafe(t *testing.T) {
 	w := NewWriter(path)
 
 	var wg sync.WaitGroup
-	for i := 0; i < 50; i++ {
+	for i := range 50 {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()

--- a/internal/tsclient/require_test.go
+++ b/internal/tsclient/require_test.go
@@ -157,18 +157,18 @@ func TestRequireTailnetIP_NilContext(t *testing.T) {
 
 func TestIsTailnetIP(t *testing.T) {
 	cases := map[string]bool{
-		"100.80.229.80":  true,
-		"100.64.0.0":     true,
+		"100.80.229.80":   true,
+		"100.64.0.0":      true,
 		"100.127.255.255": true,
-		"100.63.0.0":     false, // one below the block
-		"100.128.0.0":    false, // one above the block
-		"127.0.0.1":      false, // loopback, not tailnet
-		"0.0.0.0":        false, // any-interface bind, definitely not tailnet
-		"192.168.1.1":    false,
-		"":               false,
-		"not an ip":      false,
-		"::1":            false, // IPv6 loopback
-		"100::1":         false, // IPv6 unrelated
+		"100.63.0.0":      false, // one below the block
+		"100.128.0.0":     false, // one above the block
+		"127.0.0.1":       false, // loopback, not tailnet
+		"0.0.0.0":         false, // any-interface bind, definitely not tailnet
+		"192.168.1.1":     false,
+		"":                false,
+		"not an ip":       false,
+		"::1":             false, // IPv6 loopback
+		"100::1":          false, // IPv6 unrelated
 	}
 	for in, want := range cases {
 		t.Run(in, func(t *testing.T) {

--- a/internal/tsclient/tsclient.go
+++ b/internal/tsclient/tsclient.go
@@ -27,8 +27,8 @@ var ErrNotInstalled = errors.New("tsclient: Tailscale CLI not found")
 // Status is a thin JSON view over `tailscale status --json` containing only
 // the fields agentcookie cares about. The real JSON has many more fields.
 type Status struct {
-	Version string         `json:"Version"`
-	Self    *PeerStatus    `json:"Self"`
+	Version string                 `json:"Version"`
+	Self    *PeerStatus            `json:"Self"`
 	Peer    map[string]*PeerStatus `json:"Peer"`
 }
 

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -80,6 +80,11 @@ func (c Config) baselineTick() time.Duration {
 	return 30 * time.Second
 }
 
+// maxBackoff returns the effective backoff cap. NOTE: currently unwired -- the
+// run loop does not call this, so the documented cap is not enforced yet. Kept
+// (not deleted) to preserve that signal; wiring it in is tracked separately.
+//
+//nolint:unused // effective-cap helper not yet wired into the run loop
 func (c Config) maxBackoff() time.Duration {
 	if c.MaxBackoff > 0 {
 		return c.MaxBackoff

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -15,7 +14,6 @@ import (
 type fakePush struct {
 	count    atomic.Int64
 	pushed   atomic.Int64
-	mu       sync.Mutex
 	pushChan chan struct{}
 	failNext bool
 }
@@ -156,7 +154,7 @@ func TestWatcherDebouncesRapidWrites(t *testing.T) {
 	start := fp.count.Load()
 
 	// Hammer the file 10 times in 100ms.
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		_ = os.WriteFile(cookies, []byte{byte(i)}, 0o600)
 		time.Sleep(10 * time.Millisecond)
 	}
@@ -200,7 +198,7 @@ func TestWatcherIgnoresUnrelatedFiles(t *testing.T) {
 
 	// Touch an unrelated file in the same dir.
 	unrelated := filepath.Join(dir, "unrelated.txt")
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		_ = os.WriteFile(unrelated, []byte{byte(i)}, 0o600)
 		time.Sleep(10 * time.Millisecond)
 	}

--- a/pkg/agentcookiesecret/load.go
+++ b/pkg/agentcookiesecret/load.go
@@ -206,18 +206,18 @@ func parseEnvScanner(scanner *bufio.Scanner) (map[string]string, error) {
 		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
 			continue
 		}
-		eq := strings.IndexByte(line, '=')
-		if eq < 0 {
+		before, after, ok := strings.Cut(line, "=")
+		if !ok {
 			return nil, fmt.Errorf("line %d: missing '=' (expected KEY=VALUE)", lineNum)
 		}
-		key := line[:eq]
+		key := before
 		if key != strings.TrimRight(key, " \t") || key != strings.TrimLeft(key, " \t") {
 			return nil, fmt.Errorf("line %d: whitespace around '=' is not allowed", lineNum)
 		}
 		if !validKeyName(key) {
 			return nil, fmt.Errorf("line %d: invalid key name %q", lineNum, key)
 		}
-		value := line[eq+1:]
+		value := after
 
 		if strings.HasSuffix(value, "\\") {
 			pending.WriteString(value[:len(value)-1])
@@ -274,12 +274,12 @@ func validKeyName(k string) bool {
 		isDigit := r >= '0' && r <= '9'
 		isUnder := r == '_'
 		if i == 0 {
-			if !(isLetter || isUnder) {
+			if !isLetter && !isUnder {
 				return false
 			}
 			continue
 		}
-		if !(isLetter || isDigit || isUnder) {
+		if !isLetter && !isDigit && !isUnder {
 			return false
 		}
 	}

--- a/pkg/sidecar/reader.go
+++ b/pkg/sidecar/reader.go
@@ -33,13 +33,13 @@ const SealedPrefix = "agc1:"
 // Cookie is the public shape returned by ReadSidecar. Fields mirror
 // the columns kooky-style consumers already inspect.
 type Cookie struct {
-	HostKey     string
-	Name        string
-	Value       string
-	Path        string
-	ExpiresUTC  int64
-	IsSecure    bool
-	IsHTTPOnly  bool
+	HostKey    string
+	Name       string
+	Value      string
+	Path       string
+	ExpiresUTC int64
+	IsSecure   bool
+	IsHTTPOnly bool
 }
 
 // DefaultPath returns the default sidecar location. agentcookie sink


### PR DESCRIPTION
## Summary

Ports the automations from the PP repos and last30days-skill that fit a Go security tool onto agentcookie. Most of those repos' automations are repo-type-specific (npm publish, skill-drift, catalog/manifest checks) and don't apply to a Go binary; these four do.

## What's added

- **greptile.json** — tunes the Greptile review just enabled on this repo. Generic workflow-security P0 rules (pull_request_target+head-checkout, id-token:write, GOPROXY/GOFLAGS tampering) plus agentcookie-specific rules: flag unexpected credential-path reads outside the Chrome/Keychain surface, new network exfil sinks beyond the Tailscale peer transport, and any sync path that loads the blocklist without fail-closed handling.
- **govulncheck workflow** — reachable-vulnerability scan on every PR. Green on current main.
- **golangci-lint** — `.golangci.yml` (govet, errcheck, staticcheck, unused, modernize, gofmt) + workflow pinned to v2.11.4, replacing bare `go vet`. Also aligns `ci.yml`'s Go version with `go.mod` (was hardcoded 1.24).
- **PR hygiene** — PR template + Conventional Commit title check.

## Lint debt

Introducing golangci-lint surfaced 67 pre-existing findings. Cleared them: auto-fixed the mechanical majority (modernize/gofmt/staticcheck rewrites — `interface{}`→`any`, `maps.Copy`, `strings.Cut`, De Morgan's), accepted idiomatic deferred `Close`/`Rollback`/`Remove` via the std-error-handling preset, excluded the `omitzero` rewrite (would change config/wire serialization) and test-only nil-deref false positives, and `//nolint`'d three intentionally-retained unused funcs. This is why the diff is file-heavy; every change is behavior-preserving.

## Verified

- `go build ./...`, `go vet ./...`, `go test ./...` pass
- `golangci-lint run ./...` — 0 issues
- `govulncheck ./...` — no reachable vulnerabilities

## Notes

Not ported: the heavyweight `verify-supply-chain.py` verifier (coupled to PP's OIDC/publish allowlists), mergify/lefthook/conversation-gate dev-ergonomics, and release-please (agentcookie uses goreleaser). Found while clearing lint debt: `watcher.go:maxBackoff()` is unwired — the documented exponential-backoff cap is not applied in the run loop. Left as a follow-up.
