### PR TITLE
feat(chrome): pluggable Chromium source-browser adapter (Chrome/Brave/Edge/Arc)

### DIFF
--- a/examples/source.yaml
+++ b/examples/source.yaml
@@ -10,6 +10,12 @@ chrome:
   # if omitted. Set explicitly to read from a non-default profile.
   db_path: ~/Library/Application Support/Google/Chrome/Default/Cookies
 
+# Optional source browser adapter. Omit for Google Chrome. Set name/profile
+# when reading cookies from another Chromium-family source browser.
+# browser:
+#   name: chrome # chrome or atlas
+#   profile: Default
+
 peer:
   # Hostname of the sink machine. After `agentcookie pair --as source`
   # finishes, this is the filename under ~/.config/agentcookie/keys/.

--- a/examples/source.yaml
+++ b/examples/source.yaml
@@ -12,8 +12,11 @@ chrome:
 
 # Optional source browser adapter. Omit for Google Chrome. Set name/profile
 # when reading cookies from another Chromium-family source browser.
+# Supported: chrome, brave, edge, arc. (atlas is recognized but cannot be
+# decrypted by a third-party tool -- see issue #80; `agentcookie doctor`
+# reports the gap.)
 # browser:
-#   name: chrome # chrome or atlas
+#   name: brave # chrome | brave | edge | arc
 #   profile: Default
 
 peer:

--- a/internal/chrome/browser.go
+++ b/internal/chrome/browser.go
@@ -40,17 +40,31 @@ var browserRegistry = map[string]Browser{
 		// user-<uuid> profile, so callers must set browser.profile to that dir
 		// explicitly -- the "Default" default resolves to an empty Cookies DB.
 		SupportDir: []string{"com.openai.atlas", "browser-data", "host"},
-		// DECRYPTION IS NOT YET SUPPORTED for Atlas. Cookies are tagged v10
-		// (standard Chromium AES-128-GCM shape), but on the inspected build
-		// Atlas ships NO "<App> Safe Storage" keychain item (in either the
-		// login or System keychain), carries no os_crypt key in Local State,
-		// and its v10 ciphertext does not decrypt with the Chrome Safe Storage
-		// key or Chromium's "peanuts" fallback. Atlas appears to use a custom
-		// key provider whose key is not externally recoverable without further
-		// work. These keychain fields are therefore placeholders: with no
-		// matching item, SafeStoragePasswordFor fails and the doctor source-
-		// adapter check reports the decryption gap loudly rather than silently
-		// shipping undecryptable cookies. See issue #80.
+		// DECRYPTION IS ARCHITECTURALLY UNSUPPORTED for Atlas via this adapter.
+		// Cookies are tagged v10 (standard Chromium AES-128-CBC shape on macOS),
+		// but Atlas does NOT use the legacy file-based "<App> Safe Storage"
+		// keychain item that Chrome uses (and that agentcookie reads). On the
+		// inspected build there is no such item in the login or System keychain,
+		// no os_crypt/encrypted_key in Local State, and the v10 ciphertext does
+		// not decrypt with the Chrome Safe Storage key or Chromium's "peanuts"
+		// fallback.
+		//
+		// Root cause: Atlas (signed by OpenAI OpCo, team 2DC432GLL2) declares
+		// keychain-access-groups ["2DC432GLL2.com.openai.shared"] and stores its
+		// cookie key in the macOS DATA-PROTECTION keychain under that access
+		// group. Data-protection keychain items are gated by code signature +
+		// access group, so only a binary signed by OpenAI's team with that group
+		// can read the key. No third-party tool (agentcookie included) can reach
+		// it from the SQLite-path side -- this is a deliberate hardening away
+		// from the world-readable Safe Storage model, not a missing-config bug.
+		//
+		// Path discovery still works (set browser.profile to your user-<uuid>
+		// dir), and the doctor source-adapter check reports the decryption gap
+		// loudly. A working Atlas integration would need a CDP/remote-debugging
+		// path (read cookies through a running Atlas), which is out of scope for
+		// this path-based adapter. These keychain fields are inert placeholders;
+		// with no matching file-keychain item SafeStoragePasswordFor fails by
+		// design. See issue #80.
 		KeychainAccount: "Atlas",
 		KeychainService: "Atlas Safe Storage",
 	},

--- a/internal/chrome/browser.go
+++ b/internal/chrome/browser.go
@@ -30,14 +30,27 @@ var browserRegistry = map[string]Browser{
 		KeychainService: keychainService,
 	},
 	"atlas": {
-		Name:       "atlas",
-		SupportDir: []string{"OpenAI", "Atlas"},
-		// UNVERIFIED: Atlas paths/keychain strings are best-known from
-		// Chromium-fork conventions (Brave="Brave Safe Storage", Edge=
-		// "Microsoft Edge Safe Storage"). Confirm against a real Atlas
-		// install before relying on the atlas adapter. The doctor check
-		// surfaces a wrong path/keychain as a loud failure rather than a
-		// silent miss.
+		Name: "atlas",
+		// VERIFIED against ChatGPT Atlas 149.0.7827.29 (bundle com.openai.atlas)
+		// on 2026-06-02. Atlas is Chromium underneath but does NOT follow the
+		// standard profile layout: the profile root is
+		// ~/Library/Application Support/com.openai.atlas/browser-data/host/,
+		// and profiles are UUID-scoped ("user-<uuid>", plus an empty "Default"
+		// and a "login-staging-<uuid>"). The live session lives in the
+		// user-<uuid> profile, so callers must set browser.profile to that dir
+		// explicitly -- the "Default" default resolves to an empty Cookies DB.
+		SupportDir: []string{"com.openai.atlas", "browser-data", "host"},
+		// DECRYPTION IS NOT YET SUPPORTED for Atlas. Cookies are tagged v10
+		// (standard Chromium AES-128-GCM shape), but on the inspected build
+		// Atlas ships NO "<App> Safe Storage" keychain item (in either the
+		// login or System keychain), carries no os_crypt key in Local State,
+		// and its v10 ciphertext does not decrypt with the Chrome Safe Storage
+		// key or Chromium's "peanuts" fallback. Atlas appears to use a custom
+		// key provider whose key is not externally recoverable without further
+		// work. These keychain fields are therefore placeholders: with no
+		// matching item, SafeStoragePasswordFor fails and the doctor source-
+		// adapter check reports the decryption gap loudly rather than silently
+		// shipping undecryptable cookies. See issue #80.
 		KeychainAccount: "Atlas",
 		KeychainService: "Atlas Safe Storage",
 	},

--- a/internal/chrome/browser.go
+++ b/internal/chrome/browser.go
@@ -1,0 +1,100 @@
+package chrome
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const (
+	defaultBrowserName    = "chrome"
+	defaultBrowserProfile = "Default"
+)
+
+// Browser describes the Chromium-family source browser surfaces that vary by
+// fork: the on-disk profile root and the Safe Storage keychain item.
+type Browser struct {
+	Name            string
+	SupportDir      []string
+	KeychainAccount string
+	KeychainService string
+}
+
+var browserRegistry = map[string]Browser{
+	defaultBrowserName: {
+		Name:            defaultBrowserName,
+		SupportDir:      []string{"Google", "Chrome"},
+		KeychainAccount: keychainAccount,
+		KeychainService: keychainService,
+	},
+	"atlas": {
+		Name:       "atlas",
+		SupportDir: []string{"OpenAI", "Atlas"},
+		// UNVERIFIED: Atlas paths/keychain strings are best-known from
+		// Chromium-fork conventions (Brave="Brave Safe Storage", Edge=
+		// "Microsoft Edge Safe Storage"). Confirm against a real Atlas
+		// install before relying on the atlas adapter. The doctor check
+		// surfaces a wrong path/keychain as a loud failure rather than a
+		// silent miss.
+		KeychainAccount: "Atlas",
+		KeychainService: "Atlas Safe Storage",
+	},
+}
+
+// LookupBrowser returns the browser descriptor for name. Empty name defaults
+// to Chrome for backward compatibility.
+func LookupBrowser(name string) (Browser, error) {
+	key := strings.ToLower(strings.TrimSpace(name))
+	if key == "" {
+		key = defaultBrowserName
+	}
+	b, ok := browserRegistry[key]
+	if !ok {
+		return Browser{}, fmt.Errorf("unsupported browser %q (supported: %s)", name, strings.Join(SupportedBrowserNames(), ", "))
+	}
+	b.SupportDir = append([]string(nil), b.SupportDir...)
+	return b, nil
+}
+
+// SupportedBrowserNames returns the configured source-browser adapter names.
+func SupportedBrowserNames() []string {
+	names := make([]string, 0, len(browserRegistry))
+	for name := range browserRegistry {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// ProfileDir returns this browser's profile directory. Empty profile defaults
+// to "Default".
+func (b Browser) ProfileDir(profile string) string {
+	if profile == "" {
+		profile = defaultBrowserProfile
+	}
+	home, _ := os.UserHomeDir()
+	parts := []string{home, "Library", "Application Support"}
+	parts = append(parts, b.SupportDir...)
+	parts = append(parts, profile)
+	return filepath.Join(parts...)
+}
+
+// CookiesPath returns this browser's Cookies SQLite path for profile. Empty
+// profile defaults to "Default".
+func (b Browser) CookiesPath(profile string) string {
+	return filepath.Join(b.ProfileDir(profile), "Cookies")
+}
+
+// LocalStorageLevelDB returns this browser's Local Storage LevelDB directory
+// for profile. Empty profile defaults to "Default".
+func (b Browser) LocalStorageLevelDB(profile string) string {
+	return filepath.Join(b.ProfileDir(profile), "Local Storage", "leveldb")
+}
+
+// IndexedDBDir returns this browser's IndexedDB directory for profile. Empty
+// profile defaults to "Default".
+func (b Browser) IndexedDBDir(profile string) string {
+	return filepath.Join(b.ProfileDir(profile), "IndexedDB")
+}

--- a/internal/chrome/browser.go
+++ b/internal/chrome/browser.go
@@ -68,6 +68,34 @@ var browserRegistry = map[string]Browser{
 		KeychainAccount: "Atlas",
 		KeychainService: "Atlas Safe Storage",
 	},
+	// Brave / Edge / Arc use the standard file-based "<App> Safe Storage"
+	// keychain model that Chrome uses (unlike Atlas), so the path + keychain
+	// adapter applies directly. Profile paths verified on disk on 2026-06-02;
+	// keychain account/service follow the well-established macOS convention
+	// (browser_cookie3 / kooky / pycookiecheat use the same strings). Cookie
+	// decryption was not exercised on the build machine (none were logged in,
+	// so no Safe Storage item existed yet); the doctor source-adapter check
+	// verifies decryption at runtime. Default profile is "Default" for all.
+	"brave": {
+		Name:            "brave",
+		SupportDir:      []string{"BraveSoftware", "Brave-Browser"},
+		KeychainAccount: "Brave",
+		KeychainService: "Brave Safe Storage",
+	},
+	"edge": {
+		Name:            "edge",
+		SupportDir:      []string{"Microsoft Edge"},
+		KeychainAccount: "Microsoft Edge",
+		KeychainService: "Microsoft Edge Safe Storage",
+	},
+	"arc": {
+		Name: "arc",
+		// Arc inserts a "User Data" layer between the support dir and the
+		// profile: ~/Library/Application Support/Arc/User Data/<profile>/.
+		SupportDir:      []string{"Arc", "User Data"},
+		KeychainAccount: "Arc",
+		KeychainService: "Arc Safe Storage",
+	},
 }
 
 // LookupBrowser returns the browser descriptor for name. Empty name defaults

--- a/internal/chrome/browser_test.go
+++ b/internal/chrome/browser_test.go
@@ -1,0 +1,82 @@
+package chrome
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLookupBrowserDefaultsToChrome(t *testing.T) {
+	b, err := LookupBrowser("")
+	if err != nil {
+		t.Fatalf("LookupBrowser(\"\"): %v", err)
+	}
+	if b.Name != "chrome" {
+		t.Errorf("Name: got %q, want chrome", b.Name)
+	}
+	if b.KeychainAccount != "Chrome" || b.KeychainService != "Chrome Safe Storage" {
+		t.Errorf("keychain: got account=%q service=%q", b.KeychainAccount, b.KeychainService)
+	}
+}
+
+func TestLookupBrowserAtlas(t *testing.T) {
+	b, err := LookupBrowser("atlas")
+	if err != nil {
+		t.Fatalf("LookupBrowser(atlas): %v", err)
+	}
+	if b.Name != "atlas" {
+		t.Errorf("Name: got %q, want atlas", b.Name)
+	}
+	if b.KeychainAccount != "Atlas" || b.KeychainService != "Atlas Safe Storage" {
+		t.Errorf("keychain: got account=%q service=%q", b.KeychainAccount, b.KeychainService)
+	}
+}
+
+func TestLookupBrowserUnknownListsSupportedNames(t *testing.T) {
+	_, err := LookupBrowser("dia")
+	if err == nil {
+		t.Fatal("expected unsupported browser error")
+	}
+	if !strings.Contains(err.Error(), "supported: atlas, chrome") {
+		t.Errorf("error should list supported names, got %v", err)
+	}
+}
+
+func TestBrowserCookiesPath(t *testing.T) {
+	home, _ := os.UserHomeDir()
+
+	chromeBrowser, err := LookupBrowser("chrome")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := chromeBrowser.CookiesPath(""), filepath.Join(home, "Library", "Application Support", "Google", "Chrome", "Default", "Cookies"); got != want {
+		t.Errorf("chrome default path: got %q, want %q", got, want)
+	}
+	if got, want := chromeBrowser.ProfileDir(""), filepath.Join(home, "Library", "Application Support", "Google", "Chrome", "Default"); got != want {
+		t.Errorf("chrome default profile dir: got %q, want %q", got, want)
+	}
+	if got, want := chromeBrowser.LocalStorageLevelDB(""), filepath.Join(home, "Library", "Application Support", "Google", "Chrome", "Default", "Local Storage", "leveldb"); got != want {
+		t.Errorf("chrome default local storage path: got %q, want %q", got, want)
+	}
+	if got, want := chromeBrowser.IndexedDBDir(""), filepath.Join(home, "Library", "Application Support", "Google", "Chrome", "Default", "IndexedDB"); got != want {
+		t.Errorf("chrome default indexeddb path: got %q, want %q", got, want)
+	}
+
+	atlasBrowser, err := LookupBrowser("atlas")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := atlasBrowser.CookiesPath("Profile 1"), filepath.Join(home, "Library", "Application Support", "OpenAI", "Atlas", "Profile 1", "Cookies"); got != want {
+		t.Errorf("atlas profile path: got %q, want %q", got, want)
+	}
+	if got, want := atlasBrowser.ProfileDir("Profile 1"), filepath.Join(home, "Library", "Application Support", "OpenAI", "Atlas", "Profile 1"); got != want {
+		t.Errorf("atlas profile dir: got %q, want %q", got, want)
+	}
+	if got, want := atlasBrowser.LocalStorageLevelDB("Profile 1"), filepath.Join(home, "Library", "Application Support", "OpenAI", "Atlas", "Profile 1", "Local Storage", "leveldb"); got != want {
+		t.Errorf("atlas local storage path: got %q, want %q", got, want)
+	}
+	if got, want := atlasBrowser.IndexedDBDir("Profile 1"), filepath.Join(home, "Library", "Application Support", "OpenAI", "Atlas", "Profile 1", "IndexedDB"); got != want {
+		t.Errorf("atlas indexeddb path: got %q, want %q", got, want)
+	}
+}

--- a/internal/chrome/browser_test.go
+++ b/internal/chrome/browser_test.go
@@ -67,16 +67,16 @@ func TestBrowserCookiesPath(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got, want := atlasBrowser.CookiesPath("Profile 1"), filepath.Join(home, "Library", "Application Support", "OpenAI", "Atlas", "Profile 1", "Cookies"); got != want {
+	if got, want := atlasBrowser.CookiesPath("Profile 1"), filepath.Join(home, "Library", "Application Support", "com.openai.atlas", "browser-data", "host", "Profile 1", "Cookies"); got != want {
 		t.Errorf("atlas profile path: got %q, want %q", got, want)
 	}
-	if got, want := atlasBrowser.ProfileDir("Profile 1"), filepath.Join(home, "Library", "Application Support", "OpenAI", "Atlas", "Profile 1"); got != want {
+	if got, want := atlasBrowser.ProfileDir("Profile 1"), filepath.Join(home, "Library", "Application Support", "com.openai.atlas", "browser-data", "host", "Profile 1"); got != want {
 		t.Errorf("atlas profile dir: got %q, want %q", got, want)
 	}
-	if got, want := atlasBrowser.LocalStorageLevelDB("Profile 1"), filepath.Join(home, "Library", "Application Support", "OpenAI", "Atlas", "Profile 1", "Local Storage", "leveldb"); got != want {
+	if got, want := atlasBrowser.LocalStorageLevelDB("Profile 1"), filepath.Join(home, "Library", "Application Support", "com.openai.atlas", "browser-data", "host", "Profile 1", "Local Storage", "leveldb"); got != want {
 		t.Errorf("atlas local storage path: got %q, want %q", got, want)
 	}
-	if got, want := atlasBrowser.IndexedDBDir("Profile 1"), filepath.Join(home, "Library", "Application Support", "OpenAI", "Atlas", "Profile 1", "IndexedDB"); got != want {
+	if got, want := atlasBrowser.IndexedDBDir("Profile 1"), filepath.Join(home, "Library", "Application Support", "com.openai.atlas", "browser-data", "host", "Profile 1", "IndexedDB"); got != want {
 		t.Errorf("atlas indexeddb path: got %q, want %q", got, want)
 	}
 }

--- a/internal/chrome/browser_test.go
+++ b/internal/chrome/browser_test.go
@@ -38,8 +38,36 @@ func TestLookupBrowserUnknownListsSupportedNames(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected unsupported browser error")
 	}
-	if !strings.Contains(err.Error(), "supported: atlas, chrome") {
+	if !strings.Contains(err.Error(), "supported:") || !strings.Contains(err.Error(), "chrome") {
 		t.Errorf("error should list supported names, got %v", err)
+	}
+}
+
+func TestLookupBrowserStandardForks(t *testing.T) {
+	home, _ := os.UserHomeDir()
+	cases := []struct {
+		name       string
+		cookiesDir []string // path segments under Application Support, before profile
+		account    string
+		service    string
+	}{
+		{"brave", []string{"BraveSoftware", "Brave-Browser"}, "Brave", "Brave Safe Storage"},
+		{"edge", []string{"Microsoft Edge"}, "Microsoft Edge", "Microsoft Edge Safe Storage"},
+		{"arc", []string{"Arc", "User Data"}, "Arc", "Arc Safe Storage"},
+	}
+	for _, tc := range cases {
+		b, err := LookupBrowser(tc.name)
+		if err != nil {
+			t.Fatalf("LookupBrowser(%s): %v", tc.name, err)
+		}
+		if b.KeychainAccount != tc.account || b.KeychainService != tc.service {
+			t.Errorf("%s keychain: got account=%q service=%q", tc.name, b.KeychainAccount, b.KeychainService)
+		}
+		base := append([]string{home, "Library", "Application Support"}, tc.cookiesDir...)
+		wantCookies := filepath.Join(append(append([]string{}, base...), "Default", "Cookies")...)
+		if got := b.CookiesPath(""); got != wantCookies {
+			t.Errorf("%s cookies path: got %q, want %q", tc.name, got, wantCookies)
+		}
 	}
 }
 

--- a/internal/chrome/keychain.go
+++ b/internal/chrome/keychain.go
@@ -54,27 +54,42 @@ const (
 // Plan 2026-05-17-004's wizard set-keychain-access step is what makes that
 // last condition true for new binaries.
 func SafeStoragePassword() (string, error) {
-	if pw, err := safeStoragePasswordViaKeybase(); err == nil {
+	b, _ := LookupBrowser(defaultBrowserName)
+	return SafeStoragePasswordFor(b)
+}
+
+// SafeStoragePasswordFor returns b's Safe Storage password from the macOS
+// Keychain using b's account/service pair.
+func SafeStoragePasswordFor(b Browser) (string, error) {
+	if pw, err := safeStoragePasswordViaKeybaseFor(b.KeychainService, b.KeychainAccount); err == nil {
 		return pw, nil
 	}
+	remediation := safeStorageRemediationFor(b)
 	// Fall back to `security` CLI shell-out, bounded by a timeout so a
 	// hung GUI Keychain prompt fails loud instead of blocking forever.
 	ctx, cancel := context.WithTimeout(context.Background(), safeStorageReadTimeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "security",
 		"find-generic-password",
-		"-a", keychainAccount,
-		"-s", keychainService,
+		"-a", b.KeychainAccount,
+		"-s", b.KeychainService,
 		"-w",
 	)
 	out, err := cmd.Output()
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-		return "", fmt.Errorf("read Chrome Safe Storage from Keychain timed out after %s; this binary is not yet in the Safe Storage partition. %s", safeStorageReadTimeout, SafeStorageRemediation)
+		return "", fmt.Errorf("read %s from Keychain timed out after %s; this binary is not yet in the Safe Storage partition. %s", b.KeychainService, safeStorageReadTimeout, remediation)
 	}
 	if err != nil {
-		return "", fmt.Errorf("read Chrome Safe Storage from Keychain (did you grant access?): %w", err)
+		return "", fmt.Errorf("read %s from Keychain (did you grant access?): %w; %s", b.KeychainService, err, remediation)
 	}
 	return strings.TrimRight(string(out), "\n"), nil
+}
+
+func safeStorageRemediationFor(b Browser) string {
+	if b.Name == defaultBrowserName {
+		return SafeStorageRemediation
+	}
+	return fmt.Sprintf("grant agentcookie read access to the %q Keychain item (the set-keychain-access wizard currently targets Chrome only)", b.KeychainService)
 }
 
 // DeriveAESKey turns the Safe Storage password into the AES-128 key Chrome uses

--- a/internal/chrome/keychain_keybase.go
+++ b/internal/chrome/keychain_keybase.go
@@ -41,14 +41,14 @@ var ErrKeybaseTimedOut = errors.New("keybase keychain GetGenericPassword timed o
 // each rebuild invalidates the cdhash that the per-app trust list
 // pinned, so subsequent SecItem calls hit a prompt that no one will
 // answer.
-func safeStoragePasswordViaKeybase() (string, error) {
+func safeStoragePasswordViaKeybaseFor(service, account string) (string, error) {
 	type result struct {
 		pw  []byte
 		err error
 	}
 	ch := make(chan result, 1)
 	go func() {
-		password, err := keychain.GetGenericPassword(keychainService, keychainAccount, "", "")
+		password, err := keychain.GetGenericPassword(service, account, "", "")
 		ch <- result{pw: password, err: err}
 	}()
 

--- a/internal/chrome/keychain_keybase_stub.go
+++ b/internal/chrome/keychain_keybase_stub.go
@@ -4,6 +4,6 @@ package chrome
 
 import "errors"
 
-func safeStoragePasswordViaKeybase() (string, error) {
+func safeStoragePasswordViaKeybaseFor(_, _ string) (string, error) {
 	return "", errors.New("safeStoragePasswordViaKeybase: requires darwin+cgo build")
 }

--- a/internal/chrome/keychain_partition_test.go
+++ b/internal/chrome/keychain_partition_test.go
@@ -162,3 +162,27 @@ func TestSafeStorageRemediation_PointsToOnePasswordNotGUI(t *testing.T) {
 		t.Errorf("remediation must not send a headless sink to a GUI prompt: %q", SafeStorageRemediation)
 	}
 }
+
+func TestSafeStorageRemediationForChromeUsesWizard(t *testing.T) {
+	b, err := LookupBrowser("chrome")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := safeStorageRemediationFor(b); got != SafeStorageRemediation {
+		t.Errorf("chrome remediation = %q, want %q", got, SafeStorageRemediation)
+	}
+}
+
+func TestSafeStorageRemediationForNonChromeAvoidsChromeWizard(t *testing.T) {
+	b, err := LookupBrowser("atlas")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := safeStorageRemediationFor(b)
+	if !strings.Contains(got, `grant agentcookie read access to the "Atlas Safe Storage" Keychain item`) {
+		t.Errorf("atlas remediation should name the Atlas Keychain item: %q", got)
+	}
+	if strings.Contains(got, "AGENTCOOKIE_LOGIN_PASSWORD") {
+		t.Errorf("atlas remediation must not point at Chrome wizard env flow: %q", got)
+	}
+}

--- a/internal/chrome/read.go
+++ b/internal/chrome/read.go
@@ -6,8 +6,6 @@ import (
 	"crypto/cipher"
 	"database/sql"
 	"fmt"
-	"os"
-	"path/filepath"
 
 	_ "github.com/mattn/go-sqlite3"
 )
@@ -34,8 +32,8 @@ type Cookie struct {
 
 // DefaultCookiesPath returns the default Chrome cookies SQLite path on macOS.
 func DefaultCookiesPath() string {
-	home, _ := os.UserHomeDir()
-	return filepath.Join(home, "Library", "Application Support", "Google", "Chrome", "Default", "Cookies")
+	b, _ := LookupBrowser(defaultBrowserName)
+	return b.CookiesPath(defaultBrowserProfile)
 }
 
 // ReadCookiesForHost opens the given SQLite path read-only and returns all

--- a/internal/cli/browser_registry_consistency_test.go
+++ b/internal/cli/browser_registry_consistency_test.go
@@ -1,0 +1,82 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/mvanhorn/agentcookie/internal/chrome"
+	"github.com/mvanhorn/agentcookie/internal/chromepaths"
+	"github.com/mvanhorn/agentcookie/internal/config"
+)
+
+// The source-browser adapter table is intentionally maintained in two places:
+// internal/chrome (which derives the Cookies path AND owns the Safe Storage
+// keychain strings) and internal/config (which derives the Cookies path while
+// staying free of the chrome package's CGO sqlite dependency). The two tables
+// must agree, or a source.yaml `browser:` block could resolve a Cookies path
+// the decryptor was never told about. These guards fail loudly the moment a
+// new fork is added to one table but not the other.
+//
+// The cleaner long-term shape is a single dependency-free registry (e.g. in
+// internal/chromepaths) consumed by both packages; until that refactor lands
+// these tests are the drift backstop.
+
+func TestSourceBrowserRegistriesAgreeOnSupportedNames(t *testing.T) {
+	chromeNames := chrome.SupportedBrowserNames()
+	configNames := config.SupportedBrowserNames()
+
+	if len(chromeNames) != len(configNames) {
+		t.Fatalf("supported-browser sets differ in size: chrome=%v config=%v", chromeNames, configNames)
+	}
+	for i := range chromeNames {
+		if chromeNames[i] != configNames[i] {
+			t.Fatalf("supported-browser sets differ at %d: chrome=%v config=%v", i, chromeNames, configNames)
+		}
+	}
+}
+
+func TestSourceBrowserRegistriesAgreeOnCookiesPath(t *testing.T) {
+	for _, name := range chrome.SupportedBrowserNames() {
+		b, err := chrome.LookupBrowser(name)
+		if err != nil {
+			t.Fatalf("chrome.LookupBrowser(%q): %v", name, err)
+		}
+		// Both sides default an empty profile to "Default"; pass "" to each
+		// so the comparison also covers that defaulting path.
+		want := b.CookiesPath("")
+
+		got, err := config.SourceBrowserCookiesPath(name, "")
+		if err != nil {
+			t.Fatalf("config.SourceBrowserCookiesPath(%q): %v", name, err)
+		}
+		if got != want {
+			t.Errorf("Cookies path drift for %q: chrome=%q config=%q", name, want, got)
+		}
+	}
+}
+
+// The chrome (default) adapter must resolve the same Default-profile surfaces
+// as internal/chromepaths, which the sink side and other chrome-specific call
+// sites still use directly. If the chrome registry entry's SupportDir is ever
+// changed without updating chromepaths (or vice versa), the source adapter and
+// the rest of the chrome-default code would silently disagree on where the
+// profile lives.
+func TestChromeAdapterMatchesChromepaths(t *testing.T) {
+	chromeBrowser, err := chrome.LookupBrowser("chrome")
+	if err != nil {
+		t.Fatalf("chrome.LookupBrowser(\"chrome\"): %v", err)
+	}
+	cases := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"cookies", chromeBrowser.CookiesPath(""), chromepaths.CookiesDB()},
+		{"localStorage", chromeBrowser.LocalStorageLevelDB(""), chromepaths.LocalStorageLevelDB()},
+		{"indexedDB", chromeBrowser.IndexedDBDir(""), chromepaths.IndexedDBDir()},
+	}
+	for _, tc := range cases {
+		if tc.got != tc.want {
+			t.Errorf("chrome adapter %s path drift: adapter=%q chromepaths=%q", tc.name, tc.got, tc.want)
+		}
+	}
+}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -68,6 +69,10 @@ type doctorDeps struct {
 	LoadSourceState func() (*state.SourceState, error)
 	LoadSinkState   func() (*state.SinkState, error)
 	MasterKeyExists func() bool
+
+	SourceAdapterCookiesExists func(path string) error
+	SourceAdapterPassword      func(chrome.Browser) (string, error)
+	SourceAdapterDecrypt       func(path string, key []byte) error
 }
 
 var doctorCmd = &cobra.Command{
@@ -104,6 +109,12 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 			return state.LoadSink(state.SinkPath(home))
 		},
 		MasterKeyExists: keystore.MasterKeyExists,
+		SourceAdapterCookiesExists: func(path string) error {
+			_, err := os.Stat(path)
+			return err
+		},
+		SourceAdapterPassword: chrome.SafeStoragePasswordFor,
+		SourceAdapterDecrypt:  sourceAdapterDecryptSmoke,
 	}
 
 	report := buildReport(deps)
@@ -181,9 +192,15 @@ func buildReport(d doctorDeps) DoctorReport {
 		st, err := d.LoadSourceState()
 		checks = append(checks, checkSourceStateFrom(st, err))
 		checks = append(checks, checkDBSCFrom(st))
+		checks = append(checks, checkSourceAdapter(srcCfg, d.SourceAdapterCookiesExists, d.SourceAdapterPassword, d.SourceAdapterDecrypt))
 	} else {
 		checks = append(checks, Check{
 			Name:     "Source state",
+			Severity: SeveritySkipped,
+			Detail:   "sink-only install",
+		})
+		checks = append(checks, Check{
+			Name:     "Source adapter",
 			Severity: SeveritySkipped,
 			Detail:   "sink-only install",
 		})
@@ -516,6 +533,105 @@ func checkConfigLoaded(configDir string) (Check, *config.SourceConfig, *config.S
 		Severity: SeverityOK,
 		Detail:   strings.Join(parts, " + ") + " present, parses OK",
 	}, srcCfg, sinkCfg
+}
+
+var errSourceAdapterNoEncryptedCookies = errors.New("no encrypted cookies found")
+
+// checkSourceAdapter validates the browser-specific source surfaces: Cookies
+// SQLite path, Safe Storage keychain entry, and a one-cookie decrypt smoke.
+func checkSourceAdapter(
+	srcCfg *config.SourceConfig,
+	cookiesExists func(path string) error,
+	passwordFor func(chrome.Browser) (string, error),
+	decryptSmoke func(path string, key []byte) error,
+) Check {
+	if srcCfg == nil {
+		return Check{
+			Name:     "Source adapter",
+			Severity: SeveritySkipped,
+			Detail:   "sink-only install",
+		}
+	}
+	if cookiesExists == nil {
+		cookiesExists = func(path string) error {
+			_, err := os.Stat(path)
+			return err
+		}
+	}
+	if passwordFor == nil {
+		passwordFor = chrome.SafeStoragePasswordFor
+	}
+	if decryptSmoke == nil {
+		decryptSmoke = sourceAdapterDecryptSmoke
+	}
+
+	b, err := chrome.LookupBrowser(srcCfg.Browser.Name)
+	if err != nil {
+		return Check{
+			Name:        "Source adapter",
+			Severity:    SeverityFail,
+			Detail:      err.Error(),
+			Remediation: "set source.yaml browser.name to one of: " + strings.Join(chrome.SupportedBrowserNames(), ", "),
+		}
+	}
+	if err := cookiesExists(srcCfg.Chrome.DBPath); err != nil {
+		return Check{
+			Name:        "Source adapter",
+			Severity:    SeverityFail,
+			Detail:      fmt.Sprintf("adapter: %s - cookies SQLite missing at %s", b.Name, srcCfg.Chrome.DBPath),
+			Remediation: "open the configured browser/profile once, or set chrome.db_path to the correct Cookies file",
+		}
+	}
+	pw, err := passwordFor(b)
+	if err != nil {
+		return Check{
+			Name:        "Source adapter",
+			Severity:    SeverityFail,
+			Detail:      fmt.Sprintf("adapter: %s - Safe Storage keychain entry unreadable: %v", b.Name, err),
+			Remediation: fmt.Sprintf("confirm the %q Keychain item exists and grant agentcookie access", b.KeychainService),
+		}
+	}
+	key, err := chrome.DeriveAESKey(pw)
+	if err != nil {
+		return Check{
+			Name:        "Source adapter",
+			Severity:    SeverityFail,
+			Detail:      fmt.Sprintf("adapter: %s - derive cookie key failed: %v", b.Name, err),
+			Remediation: "confirm the Safe Storage keychain value is readable",
+		}
+	}
+	if err := decryptSmoke(srcCfg.Chrome.DBPath, key); err != nil {
+		if errors.Is(err, errSourceAdapterNoEncryptedCookies) {
+			return Check{
+				Name:        "Source adapter",
+				Severity:    SeverityWarn,
+				Detail:      fmt.Sprintf("adapter: %s - decryption: no encrypted cookies available to test", b.Name),
+				Remediation: "log into at least one site in the configured browser/profile, then re-run doctor",
+			}
+		}
+		return Check{
+			Name:        "Source adapter",
+			Severity:    SeverityFail,
+			Detail:      fmt.Sprintf("adapter: %s - decryption: unsupported on this build", b.Name),
+			Remediation: fmt.Sprintf("verify %s uses Chromium v10 cookie encryption and the configured Cookies path/keychain entry are correct (cause: %v)", b.Name, err),
+		}
+	}
+	return Check{
+		Name:     "Source adapter",
+		Severity: SeverityOK,
+		Detail:   fmt.Sprintf("adapter: %s - cookies: present, keychain: readable, decryption: ok", b.Name),
+	}
+}
+
+func sourceAdapterDecryptSmoke(path string, key []byte) error {
+	result, err := chrome.ProbeCookiesFile(path, key, 1)
+	if err != nil {
+		return err
+	}
+	if result.RowsChecked == 0 {
+		return errSourceAdapterNoEncryptedCookies
+	}
+	return nil
 }
 
 // checkKeystore validates that every configured peer hostname has a

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -463,6 +463,100 @@ func TestCheckCookieDelivery(t *testing.T) {
 	})
 }
 
+func TestCheckSourceAdapter(t *testing.T) {
+	exists := func(string) error { return nil }
+	password := func(chrome.Browser) (string, error) { return "safe-storage-password", nil }
+	decryptOK := func(string, []byte) error { return nil }
+
+	t.Run("sink-only skipped", func(t *testing.T) {
+		c := checkSourceAdapter(nil, exists, password, decryptOK)
+		if c.Severity != SeveritySkipped {
+			t.Fatalf("got %q, want SKIPPED", c.Severity)
+		}
+	})
+
+	t.Run("ok reports adapter", func(t *testing.T) {
+		cfg := &config.SourceConfig{
+			Chrome:  config.ChromeRef{DBPath: "/tmp/Cookies"},
+			Browser: config.BrowserRef{Name: "atlas"},
+		}
+		c := checkSourceAdapter(cfg, exists, password, decryptOK)
+		if c.Severity != SeverityOK {
+			t.Fatalf("got %q (%q), want OK", c.Severity, c.Detail)
+		}
+		if !strings.Contains(c.Detail, "adapter: atlas") {
+			t.Errorf("detail should name atlas adapter: %q", c.Detail)
+		}
+	})
+
+	t.Run("missing cookies path fails loud", func(t *testing.T) {
+		cfg := &config.SourceConfig{Chrome: config.ChromeRef{DBPath: "/tmp/missing"}}
+		c := checkSourceAdapter(cfg, func(string) error { return os.ErrNotExist }, password, decryptOK)
+		if c.Severity != SeverityFail {
+			t.Fatalf("got %q (%q), want FAIL", c.Severity, c.Detail)
+		}
+		if !strings.Contains(c.Detail, "cookies SQLite missing") {
+			t.Errorf("detail: %q", c.Detail)
+		}
+	})
+
+	t.Run("keychain unreadable fails loud", func(t *testing.T) {
+		cfg := &config.SourceConfig{Chrome: config.ChromeRef{DBPath: "/tmp/Cookies"}}
+		c := checkSourceAdapter(cfg, exists, func(chrome.Browser) (string, error) {
+			return "", errors.New("not allowed")
+		}, decryptOK)
+		if c.Severity != SeverityFail {
+			t.Fatalf("got %q (%q), want FAIL", c.Severity, c.Detail)
+		}
+		if !strings.Contains(c.Detail, "Safe Storage keychain entry unreadable") {
+			t.Errorf("detail: %q", c.Detail)
+		}
+	})
+
+	t.Run("decrypt failure uses requested unsupported shape", func(t *testing.T) {
+		cfg := &config.SourceConfig{
+			Chrome:  config.ChromeRef{DBPath: "/tmp/Cookies"},
+			Browser: config.BrowserRef{Name: "atlas"},
+		}
+		c := checkSourceAdapter(cfg, exists, password, func(string, []byte) error {
+			return errors.New("bad prefix")
+		})
+		if c.Severity != SeverityFail {
+			t.Fatalf("got %q (%q), want FAIL", c.Severity, c.Detail)
+		}
+		if c.Detail != "adapter: atlas - decryption: unsupported on this build" {
+			t.Errorf("detail: got %q", c.Detail)
+		}
+	})
+
+	t.Run("no encrypted cookies warns", func(t *testing.T) {
+		cfg := &config.SourceConfig{Chrome: config.ChromeRef{DBPath: "/tmp/Cookies"}}
+		c := checkSourceAdapter(cfg, exists, password, func(string, []byte) error {
+			return errSourceAdapterNoEncryptedCookies
+		})
+		if c.Severity != SeverityWarn {
+			t.Fatalf("got %q (%q), want WARN", c.Severity, c.Detail)
+		}
+		if !strings.Contains(c.Detail, "no encrypted cookies") {
+			t.Errorf("detail: %q", c.Detail)
+		}
+	})
+
+	t.Run("unknown browser lists supported names", func(t *testing.T) {
+		cfg := &config.SourceConfig{
+			Chrome:  config.ChromeRef{DBPath: "/tmp/Cookies"},
+			Browser: config.BrowserRef{Name: "dia"},
+		}
+		c := checkSourceAdapter(cfg, exists, password, decryptOK)
+		if c.Severity != SeverityFail {
+			t.Fatalf("got %q (%q), want FAIL", c.Severity, c.Detail)
+		}
+		if !strings.Contains(c.Detail, "supported: atlas, chrome") {
+			t.Errorf("detail should list supported names: %q", c.Detail)
+		}
+	})
+}
+
 // TestHostMatchesAnyAdapter covers the substring fallback used by the
 // adapter coverage check.
 func TestHostMatchesAnyAdapter(t *testing.T) {
@@ -512,17 +606,21 @@ peer:
 		LoadSourceState: func() (*state.SourceState, error) {
 			return &state.SourceState{LastPush: time.Now().Add(-30 * time.Second)}, nil
 		},
-		LoadSinkState:   func() (*state.SinkState, error) { return nil, nil },
-		MasterKeyExists: func() bool { return false },
+		LoadSinkState:              func() (*state.SinkState, error) { return nil, nil },
+		MasterKeyExists:            func() bool { return false },
+		SourceAdapterCookiesExists: func(string) error { return nil },
+		SourceAdapterPassword:      func(chrome.Browser) (string, error) { return "safe-storage-password", nil },
+		SourceAdapterDecrypt:       func(string, []byte) error { return nil },
 	})
 
 	// v0.12.0-beta.3 added two checks: Adapter coverage + CDP injector.
 	// v0.13 added the Secrets bus check. DBSC resilience added the DBSC
 	// check (source role only; present here since this fixture is source).
 	// The consumption bridge added the Secret coverage + Binary install checks.
-	// Universal cookie delivery added the Cookie delivery check.
-	if got := len(report.Checks); got != 15 {
-		t.Fatalf("got %d checks, want 15", got)
+	// Universal cookie delivery added the Cookie delivery check. Source browser
+	// adapters added the Source adapter check.
+	if got := len(report.Checks); got != 16 {
+		t.Fatalf("got %d checks, want 16", got)
 	}
 
 	// Serialize the envelope and confirm it round-trips.
@@ -544,6 +642,7 @@ peer:
 		"Sink state":      SeveritySkipped,
 		"Sealing":         SeveritySkipped,
 		"Cookie delivery": SeveritySkipped,
+		"Source adapter":  SeverityOK,
 	}
 	for _, c := range report.Checks {
 		if w, ok := want[c.Name]; ok && c.Severity != w {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -551,7 +551,7 @@ func TestCheckSourceAdapter(t *testing.T) {
 		if c.Severity != SeverityFail {
 			t.Fatalf("got %q (%q), want FAIL", c.Severity, c.Detail)
 		}
-		if !strings.Contains(c.Detail, "supported: atlas, chrome") {
+		if !strings.Contains(c.Detail, "supported:") || !strings.Contains(c.Detail, "chrome") {
 			t.Errorf("detail should list supported names: %q", c.Detail)
 		}
 	})

--- a/internal/cli/source.go
+++ b/internal/cli/source.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/mvanhorn/agentcookie/internal/chrome"
 	"github.com/mvanhorn/agentcookie/internal/chromedirsync"
-	"github.com/mvanhorn/agentcookie/internal/chromepaths"
 	"github.com/mvanhorn/agentcookie/internal/cli/httpserver"
 	"github.com/mvanhorn/agentcookie/internal/config"
 	"github.com/mvanhorn/agentcookie/internal/pairing"
@@ -85,9 +84,13 @@ func runSource(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	password, err := chrome.SafeStoragePassword()
+	sourceBrowser, err := chrome.LookupBrowser(cfg.Browser.Name)
 	if err != nil {
-		return fmt.Errorf("read Chrome Safe Storage from Keychain: %w", err)
+		return err
+	}
+	password, err := chrome.SafeStoragePasswordFor(sourceBrowser)
+	if err != nil {
+		return fmt.Errorf("read %s from Keychain: %w", sourceBrowser.KeychainService, err)
 	}
 	key, err := chrome.DeriveAESKey(password)
 	if err != nil {
@@ -128,8 +131,8 @@ func runSource(cmd *cobra.Command, args []string) error {
 	// window: a write to any surface coalesces into one full envelope push.
 	w, err := watcher.New(watcher.Config{
 		CookiesPath:     cfg.Chrome.DBPath,
-		LocalStorageDir: chromepaths.LocalStorageLevelDB(),
-		IndexedDBDir:    chromepaths.IndexedDBDir(),
+		LocalStorageDir: sourceBrowser.LocalStorageLevelDB(cfg.Browser.Profile),
+		IndexedDBDir:    sourceBrowser.IndexedDBDir(cfg.Browser.Profile),
 		Push:            push,
 		OnEvent: func(ev watcher.Event) {
 			if sourceVerbose {
@@ -140,7 +143,7 @@ func runSource(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("init watcher: %w", err)
 	}
-	fmt.Fprintf(os.Stderr, "agentcookie source --watch: watching %s, sink=%s\n", cfg.Chrome.DBPath, cfg.Sink.URL)
+	fmt.Fprintf(os.Stderr, "agentcookie source --watch: adapter=%s watching %s, sink=%s\n", sourceBrowser.Name, cfg.Chrome.DBPath, cfg.Sink.URL)
 
 	// v0.13: also watch ~/.agentcookie/secrets/ so a write to a per-CLI
 	// secrets.env triggers the same push pipeline as a Chrome cookie
@@ -323,15 +326,18 @@ func pushOnce(
 		return 0, dbsc, nil
 	}
 
-	// v0.7: pack Local Storage and IndexedDB alongside cookies. Both are
-	// directories of LevelDB files in Chrome's Default profile; we tar
-	// them, the envelope carries the bytes, the sink unpacks into its
-	// real Chrome profile. Errors fetching either are non-fatal so the
-	// source still pushes whatever it could read.
+	// v0.7: pack Local Storage and IndexedDB alongside cookies from the
+	// configured source browser/profile. The envelope carries the bytes, the
+	// sink unpacks into its real Chrome profile. Errors fetching either are
+	// non-fatal so the source still pushes whatever it could read.
+	sourceBrowser, err := chrome.LookupBrowser(cfg.Browser.Name)
+	if err != nil {
+		sourceBrowser, _ = chrome.LookupBrowser("")
+	}
 	var lsTarball []byte
 	var idbTarball []byte
 	var idbSkipped []string
-	if lt, _, err := chromedirsync.Pack(chromepaths.LocalStorageLevelDB(), 0); err == nil {
+	if lt, _, err := chromedirsync.Pack(sourceBrowser.LocalStorageLevelDB(cfg.Browser.Profile), 0); err == nil {
 		lsTarball = lt
 	} else if !errors.Is(err, chromedirsync.ErrSourceMissing) {
 		fmt.Fprintf(os.Stderr, "agentcookie source: localStorage pack failed (%v); continuing without it\n", err)
@@ -342,7 +348,7 @@ func pushOnce(
 	// or cookies; IndexedDB is rarely an auth-state surface in practice.
 	// Set AGENTCOOKIE_SYNC_INDEXEDDB=1 to opt in.
 	if os.Getenv("AGENTCOOKIE_SYNC_INDEXEDDB") == "1" {
-		if it, sk, err := chromedirsync.Pack(chromepaths.IndexedDBDir(), 5*1024*1024); err == nil {
+		if it, sk, err := chromedirsync.Pack(sourceBrowser.IndexedDBDir(cfg.Browser.Profile), 5*1024*1024); err == nil {
 			idbTarball = it
 			idbSkipped = sk
 		} else if !errors.Is(err, chromedirsync.ErrSourceMissing) {

--- a/internal/cli/source.go
+++ b/internal/cli/source.go
@@ -90,7 +90,9 @@ func runSource(cmd *cobra.Command, args []string) error {
 	}
 	password, err := chrome.SafeStoragePasswordFor(sourceBrowser)
 	if err != nil {
-		return fmt.Errorf("read %s from Keychain: %w", sourceBrowser.KeychainService, err)
+		// SafeStoragePasswordFor already prefixes its error with
+		// "read <service> from Keychain ..."; don't double the prefix.
+		return err
 	}
 	key, err := chrome.DeriveAESKey(password)
 	if err != nil {
@@ -330,9 +332,14 @@ func pushOnce(
 	// configured source browser/profile. The envelope carries the bytes, the
 	// sink unpacks into its real Chrome profile. Errors fetching either are
 	// non-fatal so the source still pushes whatever it could read.
+	// Resolve the same adapter the watcher uses. cfg.Browser.Name was already
+	// validated in LoadSource, so a failure here means the config changed
+	// underneath us; fail loud rather than silently packing Chrome's profile
+	// (which would mismatch the cookies/localStorage/IndexedDB the watcher and
+	// the rest of this push are reading from the configured browser).
 	sourceBrowser, err := chrome.LookupBrowser(cfg.Browser.Name)
 	if err != nil {
-		sourceBrowser, _ = chrome.LookupBrowser("")
+		return 0, dbsc, err
 	}
 	var lsTarball []byte
 	var idbTarball []byte

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -20,6 +21,7 @@ import (
 type SourceConfig struct {
 	Sink     SinkRef     `yaml:"sink" json:"sink"`
 	Chrome   ChromeRef   `yaml:"chrome" json:"chrome"`
+	Browser  BrowserRef  `yaml:"browser,omitempty" json:"browser,omitempty"`
 	Peer     PeerRef     `yaml:"peer,omitempty" json:"peer,omitempty"`
 	Security SecurityRef `yaml:"security,omitempty" json:"security,omitempty"`
 }
@@ -80,6 +82,25 @@ type ChromeRef struct {
 	DBPath string `yaml:"db_path" json:"db_path"`
 }
 
+type BrowserRef struct {
+	Name    string `yaml:"name" json:"name"`
+	Profile string `yaml:"profile" json:"profile"`
+}
+
+type browserPathRef struct {
+	SupportDir []string
+}
+
+const (
+	defaultBrowserName    = "chrome"
+	defaultBrowserProfile = "Default"
+)
+
+var sourceBrowserPaths = map[string]browserPathRef{
+	defaultBrowserName: {SupportDir: []string{"Google", "Chrome"}},
+	"atlas":            {SupportDir: []string{"OpenAI", "Atlas"}},
+}
+
 // SecurityRef holds transport credentials. SharedSecret is the pre-pairing
 // stopgap; U5 replaces it with a pairing-derived per-peer key persisted in the
 // OS keychain.
@@ -104,8 +125,21 @@ func LoadSource(dir string) (*SourceConfig, error) {
 	if err := validateSharedSecret(path, cfg.Security.SharedSecret); err != nil {
 		return nil, err
 	}
+	if cfg.Browser.Name != "" {
+		if _, err := lookupSourceBrowserPath(cfg.Browser.Name); err != nil {
+			return nil, fmt.Errorf("%s: %w", path, err)
+		}
+	}
 	if cfg.Chrome.DBPath == "" {
-		cfg.Chrome.DBPath = DefaultChromeCookiesPath()
+		if cfg.Browser.Name != "" || cfg.Browser.Profile != "" {
+			dbPath, err := SourceBrowserCookiesPath(cfg.Browser.Name, cfg.Browser.Profile)
+			if err != nil {
+				return nil, fmt.Errorf("%s: %w", path, err)
+			}
+			cfg.Chrome.DBPath = dbPath
+		} else {
+			cfg.Chrome.DBPath = DefaultChromeCookiesPath()
+		}
 	}
 	return &cfg, nil
 }
@@ -190,9 +224,50 @@ func ExpandTilde(p string) string {
 // macOS. Kept here so config can populate omitted db_path fields without
 // importing chrome (which pulls CGO sqlite).
 func DefaultChromeCookiesPath() string {
+	path, _ := SourceBrowserCookiesPath(defaultBrowserName, defaultBrowserProfile)
+	return path
+}
+
+// SourceBrowserCookiesPath returns the Cookies SQLite path for the configured
+// source browser. Empty name/profile default to Chrome/Default.
+func SourceBrowserCookiesPath(name, profile string) (string, error) {
+	ref, err := lookupSourceBrowserPath(name)
+	if err != nil {
+		return "", err
+	}
+	if profile == "" {
+		profile = defaultBrowserProfile
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return ""
+		return "", err
 	}
-	return filepath.Join(home, "Library", "Application Support", "Google", "Chrome", "Default", "Cookies")
+	parts := []string{home, "Library", "Application Support"}
+	parts = append(parts, ref.SupportDir...)
+	parts = append(parts, profile, "Cookies")
+	return filepath.Join(parts...), nil
+}
+
+func lookupSourceBrowserPath(name string) (browserPathRef, error) {
+	key := strings.ToLower(strings.TrimSpace(name))
+	if key == "" {
+		key = defaultBrowserName
+	}
+	ref, ok := sourceBrowserPaths[key]
+	if !ok {
+		return browserPathRef{}, fmt.Errorf("unsupported browser %q (supported: %s)", name, strings.Join(SupportedBrowserNames(), ", "))
+	}
+	ref.SupportDir = append([]string(nil), ref.SupportDir...)
+	return ref, nil
+}
+
+// SupportedBrowserNames returns the source-browser adapter names accepted by
+// source.yaml.
+func SupportedBrowserNames() []string {
+	names := make([]string, 0, len(sourceBrowserPaths))
+	for name := range sourceBrowserPaths {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -96,9 +96,16 @@ const (
 	defaultBrowserProfile = "Default"
 )
 
+// Mirror of internal/chrome's browser registry (path side only). Kept in
+// sync by the guard tests in internal/cli; config stays free of the chrome
+// package's CGO sqlite dependency. See internal/chrome/browser.go for the
+// keychain strings and per-browser notes.
 var sourceBrowserPaths = map[string]browserPathRef{
 	defaultBrowserName: {SupportDir: []string{"Google", "Chrome"}},
 	"atlas":            {SupportDir: []string{"com.openai.atlas", "browser-data", "host"}},
+	"brave":            {SupportDir: []string{"BraveSoftware", "Brave-Browser"}},
+	"edge":             {SupportDir: []string{"Microsoft Edge"}},
+	"arc":              {SupportDir: []string{"Arc", "User Data"}},
 }
 
 // SecurityRef holds transport credentials. SharedSecret is the pre-pairing

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -98,7 +98,7 @@ const (
 
 var sourceBrowserPaths = map[string]browserPathRef{
 	defaultBrowserName: {SupportDir: []string{"Google", "Chrome"}},
-	"atlas":            {SupportDir: []string{"OpenAI", "Atlas"}},
+	"atlas":            {SupportDir: []string{"com.openai.atlas", "browser-data", "host"}},
 }
 
 // SecurityRef holds transport credentials. SharedSecret is the pre-pairing

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -122,7 +122,7 @@ security:
 	if err == nil {
 		t.Fatal("expected unsupported browser error")
 	}
-	if !strings.Contains(err.Error(), "supported: atlas, chrome") {
+	if !strings.Contains(err.Error(), "supported:") || !strings.Contains(err.Error(), "chrome") {
 		t.Errorf("error should list supported browsers, got %v", err)
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -40,6 +40,93 @@ security:
 	}
 }
 
+func TestLoadSourceBrowserBlockParsesAndDerivesPath(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "source.yaml", `
+sink:
+  url: http://example.test:9999/sync
+browser:
+  name: atlas
+  profile: Profile 1
+security:
+  shared_secret: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+`)
+	cfg, err := LoadSource(dir)
+	if err != nil {
+		t.Fatalf("LoadSource: %v", err)
+	}
+	if cfg.Browser.Name != "atlas" || cfg.Browser.Profile != "Profile 1" {
+		t.Errorf("browser ref: got %+v", cfg.Browser)
+	}
+	home, _ := os.UserHomeDir()
+	want := filepath.Join(home, "Library", "Application Support", "OpenAI", "Atlas", "Profile 1", "Cookies")
+	if cfg.Chrome.DBPath != want {
+		t.Errorf("derived DBPath: got %q, want %q", cfg.Chrome.DBPath, want)
+	}
+}
+
+func TestLoadSourceDBPathOverridesBrowserDerivedPath(t *testing.T) {
+	dir := t.TempDir()
+	explicit := filepath.Join(dir, "Custom", "Cookies")
+	writeFile(t, dir, "source.yaml", `
+sink:
+  url: http://example.test:9999/sync
+chrome:
+  db_path: `+explicit+`
+browser:
+  name: atlas
+  profile: Profile 1
+security:
+  shared_secret: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+`)
+	cfg, err := LoadSource(dir)
+	if err != nil {
+		t.Fatalf("LoadSource: %v", err)
+	}
+	if cfg.Chrome.DBPath != explicit {
+		t.Errorf("explicit db_path should win: got %q, want %q", cfg.Chrome.DBPath, explicit)
+	}
+	if cfg.Browser.Name != "atlas" {
+		t.Errorf("browser name should remain available for keychain selection, got %q", cfg.Browser.Name)
+	}
+}
+
+func TestLoadSourceWithoutBrowserDefaultsChrome(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "source.yaml", `
+sink:
+  url: http://example.test:9999/sync
+security:
+  shared_secret: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+`)
+	cfg, err := LoadSource(dir)
+	if err != nil {
+		t.Fatalf("LoadSource: %v", err)
+	}
+	if cfg.Chrome.DBPath != DefaultChromeCookiesPath() {
+		t.Errorf("default DBPath: got %q, want %q", cfg.Chrome.DBPath, DefaultChromeCookiesPath())
+	}
+}
+
+func TestLoadSourceUnknownBrowserFailsWithSupportedNames(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "source.yaml", `
+sink:
+  url: http://example.test:9999/sync
+browser:
+  name: dia
+security:
+  shared_secret: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+`)
+	_, err := LoadSource(dir)
+	if err == nil {
+		t.Fatal("expected unsupported browser error")
+	}
+	if !strings.Contains(err.Error(), "supported: atlas, chrome") {
+		t.Errorf("error should list supported browsers, got %v", err)
+	}
+}
+
 func TestLoadSourceMissingSinkURL(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, dir, "source.yaml", `

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -59,7 +59,7 @@ security:
 		t.Errorf("browser ref: got %+v", cfg.Browser)
 	}
 	home, _ := os.UserHomeDir()
-	want := filepath.Join(home, "Library", "Application Support", "OpenAI", "Atlas", "Profile 1", "Cookies")
+	want := filepath.Join(home, "Library", "Application Support", "com.openai.atlas", "browser-data", "host", "Profile 1", "Cookies")
 	if cfg.Chrome.DBPath != want {
 		t.Errorf("derived DBPath: got %q, want %q", cfg.Chrome.DBPath, want)
 	}


### PR DESCRIPTION
## Summary

Makes the cookie-source side a pluggable Chromium adapter so agentcookie can target source browsers other than Google Chrome. A `Browser` registry parameterizes the two things that vary by fork (the profile path and the Safe Storage keychain entry); sealed transport, sink-side materialization, App-Bound prefix handling, and PBKDF2 derivation stay shared. Default behavior is unchanged: with no `browser:` block, the source reads Chrome byte-for-byte as before.

```yaml
browser:
  name: brave      # chrome (default) | brave | edge | arc
  profile: Default
```

`chrome.db_path`, when set, still overrides the adapter-derived path.

## Verified

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...`
- [x] `golangci-lint run ./...` (0 issues)
- [x] `govulncheck ./...` (0 called vulnerabilities)

Tests cover registry lookup, default-to-chrome, unknown-name errors, per-browser path composition, config resolution order, and two drift guards (chrome vs config tables; chrome adapter vs `internal/chromepaths`).

## Notes

On-disk config change: adds an optional `browser:` block to `source.yaml` (`name`, `profile`). Omitting it is fully backward compatible. The loader uses `KnownFields(true)`, so an old binary reading a new block errors rather than silently ignoring it.

The adapter applies to every synced surface, not just cookies: `source --watch` and the push path derive the Local Storage and IndexedDB directories from the configured browser/profile too.

`agentcookie doctor` gains a Source-adapter check (cookies present, keychain readable, one-cookie decrypt smoke) that reports `adapter: <name> - decryption: unsupported on this build` instead of failing silently. Keychain-timeout remediation is browser-aware (the `set-keychain-access` wizard is Chrome-only).

### Supported browsers

- **chrome** (default) - unchanged, byte-identical behavior.
- **brave / edge / arc** - standard file-based Safe Storage keychain model, same as Chrome. Profile paths verified on disk; keychain strings follow the established macOS convention (Brave -> `Brave Safe Storage`, Edge -> `Microsoft Edge Safe Storage`, Arc -> `Arc Safe Storage`; Arc has an extra `User Data` path layer). Cookie decryption wasn't exercised on the build machine (none were logged in, so no Safe Storage item existed yet) - the doctor check verifies it at runtime.
- **atlas** - recognized with correct path discovery, but cookie decryption is architecturally impossible for a third-party tool. Atlas stores its key in the macOS data-protection keychain under OpenAI's access group (`2DC432GLL2.com.openai.shared`), and its custom browser host ignores `--user-data-dir`, which also rules out a CDP workaround on Chrome 136+. Full writeup in #80 (closed as not supportable on current Atlas builds). The doctor check reports the gap honestly.

The chrome and config packages keep parallel browser tables on purpose (config stays free of the chrome package's CGO sqlite dependency); guard tests fail loudly if they drift. Folding both into a single dependency-free registry is a reasonable follow-up.
