### PR TITLE
feat: cmux cookie delivery + local loop (Chrome -> cmux)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## [Unreleased]
 
+### cmux local loop: `agentcookie cmux-sync`
+
+Same-machine loop so this Mac's Chrome logins flow into this Mac's cmux
+browser, with no sink, no peer, and no Tailscale hop. `cmux-sync --once`
+does one read+inject cycle; `--watch` re-injects on every Chrome cookie
+change (fsnotify, the same watcher `source --watch` uses). It reuses
+`source.yaml`'s Chrome path and blocklist plus the shared decrypt + DBSC
+read pipeline, and the cmux injection adapter from the sink surface.
+
+Configure under a `cmux:` block in `source.yaml` (same shape as the sink
+block); `--domain`, `--cmux-path`, `--browser` flags override. Run it from
+inside cmux and it passes the default `cmuxOnly` socket gate with no cmux
+change; the launchd path needs the socketControlMode change, which
+`agentcookie doctor` now reports for the source-side loop as well as the
+sink surface. Run the installed signed binary so reading Chrome's Safe
+Storage key does not prompt (the grant is per-binary; `go run` prompts).
+
 ### cmux cookie-delivery surface (opt-in)
 
 A fourth sink delivery surface that injects the synced session into

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## [Unreleased]
 
+### cmux cookie-delivery surface (opt-in)
+
+A fourth sink delivery surface that injects the synced session into
+cmux's embedded WebKit browser after every sync via
+`cmux rpc browser.cookies.set`, so an agent driving cmux's browser pane
+wakes up authenticated. cmux holds its own WebKit cookie jar separate
+from Chrome's SQLite, so this is purely additive.
+
+Opt in with `cmux.enabled: true` in `sink.yaml` (optional `cmux_path`
+and `domain_filter`). Implemented as a `sinkpush.Adapter`, so it inherits
+blocklist/DBSC filtering, the non-fatal contract, and `wizard
+verify-adapters` visibility, and is registered at sink startup only when
+enabled. Cookie values pass through verbatim (no second App-Bound strip);
+domains keep their leading dot (WebKit accepts it, unlike CDP); the
+adapter opens and reuses one unfocused `about:blank` browser surface
+since `browser.cookies.set` requires a surface and injected cookies
+persist at the profile level.
+
+`agentcookie doctor` gains a "cmux delivery" check that detects the
+common gotcha: cmux's default `socketControlMode: cmuxOnly` rejects the
+LaunchAgent sink, and the fix (set `allowAll`/`password` in
+`~/.config/cmux/cmux.json` and fully restart cmux) is printed as the
+remediation. See the "cmux delivery" section in the README.
+
 ### v0.14.0-beta.1: secrets bus adoption standard
 
 A standard projects can adopt to opt into agentcookie sync. Layered on

--- a/README.md
+++ b/README.md
@@ -115,6 +115,30 @@ Then fully restart cmux (Quit and reopen). The mode is read only at app launch; 
 
 Caveats: the surface delivers cookies only, so sites whose session also lives in localStorage/IndexedDB or is device-bound (DBSC, e.g. Google/Workspace) may still need a one-time sign-in inside the cmux pane; WebKit's ITP can also drop some cross-site cookies. The surface is best-effort and non-fatal: if cmux is not running or still gated, the sync and the other three surfaces are unaffected.
 
+### Local loop (one machine, no sink)
+
+The sink surface above is for the two-machine model. If you just want *this* Mac's Chrome logins to flow into *this* Mac's cmux browser, use the local loop instead. No second machine, no Tailscale, no pairing.
+
+```bash
+# one-shot: read Chrome now, inject into cmux
+agentcookie cmux-sync --once
+
+# continuous: re-inject whenever Chrome cookies change (fsnotify)
+agentcookie cmux-sync --watch
+
+# narrow to specific sites
+agentcookie cmux-sync --watch --domain "%github.com" --domain "%amazon%"
+```
+
+It reuses `source.yaml`'s Chrome path and blocklist (so your block rules still apply) and the same decrypt + DBSC filtering as `source`. Configure defaults under a `cmux:` block in `source.yaml` (same shape as the sink block above); flags override.
+
+Run model and the `cmuxOnly` gate:
+
+- **From inside cmux (recommended):** run `cmux-sync` in a cmux terminal. The process is a cmux child, so it passes the default `cmuxOnly` gate with no cmux change at all.
+- **Unattended (launchd):** a LaunchAgent is not a cmux child, so it needs `socketControlMode` set to `allowAll`/`password` and a cmux restart (same as the sink, above). `agentcookie doctor` reports the local loop's state and prints the fix.
+
+Keychain note: run the **installed, signed `agentcookie`** binary. Reading Chrome's Safe Storage key is a one-time Keychain grant for that signed binary (set up at `wizard install`), so it does not prompt. Running via `go run` or an unsigned/rebuilt binary will pop the macOS Keychain password prompt on every run, because the grant is scoped per binary.
+
 ## Install
 
 Prereqs: Tailscale running on both Macs, Chrome installed, Go 1.22+ (or a pre-built release).

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ agentcookie source --watch  (decrypt Chrome with Keychain key,
                                                                 v
                                               agentcookie sink (LaunchAgent)
                                                 |
-                                                | one of three cookie delivery surfaces:
+                                                | cookie delivery surfaces:
                                                 v
                                               1. Chrome's Cookies SQLite (re-encrypted for sink Keychain)
                                               2. Plaintext sidecar at ~/.agentcookie/cookies-plain.db
@@ -71,17 +71,49 @@ agentcookie source --watch  (decrypt Chrome with Keychain key,
                                                    ebay       -> config.toml + cookies.json
                                                    pagliacci  -> config.toml + cookies.json
                                                    table-reservation-goat -> session.json
+                                              4. cmux WebKit browser (opt-in) via
+                                                   cmux rpc browser.cookies.set
 
                                               plus the secrets bus mirror:
                                                 ~/.agentcookie/secrets/<cli>/secrets.env  (mode 0600,
                                                   optional sealed twin under the v0.12 master key)
 ```
 
-Three cookie surfaces because different agents read cookies differently. Universal delivery (surface 1, the real Default profile plus the one-password Safe Storage open) is the default and is what makes any unmodified cookie tool work; the sidecar (surface 2) and per-CLI adapters (surface 3) are the agentcookie-aware paths that also work in degraded mode, when no login password is available to open the key. The sink runs all three after every sync, so the agent picks what fits.
+Multiple cookie surfaces because different agents read cookies differently. Universal delivery (surface 1, the real Default profile plus the one-password Safe Storage open) is the default and is what makes any unmodified cookie tool work; the sidecar (surface 2) and per-CLI adapters (surface 3) are the agentcookie-aware paths that also work in degraded mode, when no login password is available to open the key. The sink runs surfaces 1 through 3 after every sync, so the agent picks what fits.
+
+Surface 4 is the opt-in cmux surface. cmux ([cmux.com](https://cmux.com)) ships its own embedded browser on Apple WebKit with a cookie jar separate from Chrome's, so none of the other surfaces reach it. Enable it and the sink injects the synced session into cmux's browser after every sync (`cmux rpc browser.cookies.set`), so an agent driving cmux's browser pane wakes up authenticated. Injected cookies persist at cmux's profile level, so one injection carries to the agent's later panes. See [cmux delivery](#cmux-delivery-opt-in).
 
 Bearer tokens, API keys, and other per-CLI auth blobs ride the same encrypted push and land at `~/.agentcookie/secrets/<cli>/secrets.env` on the sink. CLIs read them via environment variables, the in-process `pkg/agentcookiesecret` Go library, or a project's own `agentcookie.toml` manifest (see the adoption standard below).
 
 New cookie adapters are roughly 50 lines of Go and a `Register()` call; the runbook walks through it. New secrets bus consumers usually require no agentcookie-side change at all: drop an `agentcookie.toml` next to your CLI and `agentcookie discover` finds it.
+
+## cmux delivery (opt-in)
+
+cmux's browser is Apple WebKit, with a cookie jar separate from Chrome's, so it needs its own surface. Enable it in `sink.yaml`:
+
+```yaml
+cmux:
+  enabled: true
+  # cmux_path: /custom/path/to/cmux   # optional; default resolves the app bundle, then PATH
+  # domain_filter:                     # optional; SQLite-LIKE host_key patterns. empty = all synced cookies
+  #   - "%github.com"
+  #   - "%openai.com"
+```
+
+One required cmux-side step: cmux's RPC socket defaults to `socketControlMode: "cmuxOnly"`, which only accepts processes started inside cmux. The agentcookie sink is a LaunchAgent, not a cmux child, so with the default it is rejected and no cookies land. Open the socket to the sink:
+
+```jsonc
+// ~/.config/cmux/cmux.json
+{
+  "automation": {
+    "socketControlMode": "allowAll"   // or "password" (then set automation.socketPassword)
+  }
+}
+```
+
+Then fully restart cmux (Quit and reopen). The mode is read only at app launch; `cmux reload-config` does not apply it. Verify with `cmux capabilities | grep access_mode` (it should no longer say `cmuxOnly`), or just run `agentcookie doctor`, which reports the cmux delivery surface and prints this exact remediation when the gate is still closed.
+
+Caveats: the surface delivers cookies only, so sites whose session also lives in localStorage/IndexedDB or is device-bound (DBSC, e.g. Google/Workspace) may still need a one-time sign-in inside the cmux pane; WebKit's ITP can also drop some cross-site cookies. The surface is best-effort and non-fatal: if cmux is not running or still gated, the sync and the other three surfaces are unaffected.
 
 ## Install
 

--- a/docs/plans/2026-06-03-001-feat-cmux-cookie-delivery-surface-plan.md
+++ b/docs/plans/2026-06-03-001-feat-cmux-cookie-delivery-surface-plan.md
@@ -1,0 +1,256 @@
+---
+title: "feat: cmux WebKit cookie-delivery surface on the sink"
+status: active
+date: 2026-06-03
+type: feat
+---
+
+# feat: cmux WebKit cookie-delivery surface on the sink
+
+## Summary
+
+agentcookie already replicates a logged-in session to the sink and lands it on three delivery surfaces after every sync: the real Default Chrome profile (universal delivery), the plaintext sidecar, and the per-CLI adapters. cmux-based agent runtimes do not read any of those: cmux ships its own embedded browser on Apple WebKit (WKWebView), with a separate cookie jar (`~/Library/HTTPStorages/com.cmuxterm.app.binarycookies`) that none of the existing surfaces touch.
+
+This adds a fourth delivery surface: a `sinkpush.Adapter` that, after every sync, injects the already-synced, already-decrypted, already-blocklist-filtered cookies into cmux's WebKit browser over the cmux control socket (`cmux rpc browser.cookies.set`). The result is the same promise agentcookie already makes for Chrome readers, extended to cmux: an agent driving cmux's browser wakes up authenticated, with no per-site login.
+
+It rides the existing after-sync fan-out (`sinkpush.RunAll`), so there is no new sync trigger, no new timer, and no change to the source side or the transport. Cadence is inherited: whenever the source's Chrome cookies change, a sync lands and the cmux surface fires right after, seconds later.
+
+---
+
+## Problem Frame
+
+The product promise is "your agent's browser is already logged in." cmux is a terminal Matt actually runs agents in, and its browser pane is WebKit, not Chromium. Today a cmux agent that opens a browser pane is logged out everywhere, because:
+
+- cmux's cookie jar is a distinct WKWebsiteDataStore, separate from Chrome's SQLite store that universal delivery writes.
+- cmux's own `browser import --from "Google Chrome"` is one-time and manual (a snapshot, not a sync), and it is unverified whether it decrypts Chrome 127+ App-Bound cookies at all - which is exactly the gap agentcookie already closes on the source side.
+
+So agentcookie is the right home for continuous cmux session delivery: it already has the decrypted, filtered, DBSC-aware cookie stream on the sink. The only missing piece is a surface that writes that stream into cmux.
+
+The operational catch, verified during investigation: cmux's RPC socket defaults to `socketControlMode: "cmuxOnly"`, which only accepts connections from processes started inside cmux. The agentcookie sink is a LaunchAgent and is not a cmux child, so a raw push is rejected ("Access denied - only processes started inside cmux can connect" / "Broken pipe"). This must be surfaced and remediated, not silently failed.
+
+---
+
+## Requirements
+
+- R1. After every sink sync, push the synced cookie set into cmux's WebKit browser when the surface is enabled and cmux is reachable.
+- R2. The surface is opt-in via sink config, defaulting off, and never breaks existing `sink.yaml` files.
+- R3. Fail soft. A missing, stopped, or `cmuxOnly`-gated cmux is a skip, never a sync abort. One bad surface never blocks the other three.
+- R4. Pass cookie values through verbatim. Never re-strip the App-Bound prefix (already stripped once on the source side).
+- R5. Reuse the sink's existing blocklist filtering and DBSC handling. Do not re-solve either at the cmux layer.
+- R6. Translate Chrome cookie records to WebKit-correct cookie parameters (domain, SameSite, Secure, expiry, session-scoping), verified empirically against `cmux rpc browser.cookies.set` rather than assumed from the CDP path.
+- R7. Surface status and a one-line remediation in `agentcookie doctor`, including detection of the `cmuxOnly` gate. The surface also appears in `wizard verify-adapters` for free.
+- R8. Never log cookie values. Record counts and outcomes only, consistent with the other surfaces.
+
+---
+
+## Key Technical Decisions
+
+- KTD1. Implement as a `sinkpush.Adapter` (`internal/sinkpush/adapter_cmux.go`), not a new inline surface in the `/sync` handler. It plugs into the existing `sinkpush.RunAll(cookies)` call at `internal/cli/sink.go` with zero handler changes, and inherits blocklist filtering, the non-fatal contract, stderr logging, `sink-state.json` results, `doctor`, and `wizard verify-adapters`. (Alternative - a global CDP-style surface in `internal/cdp` - considered below.)
+- KTD2. Source of truth is the in-memory `[]chrome.Cookie` slice handed to `Push(cookies)`, not the plaintext sidecar. The slice carries `SameSite`, `SourceScheme`, and `SourcePort`; the public sidecar reader drops SameSite. This supersedes the initial sidecar idea from scoping.
+- KTD3. The surface wants the full synced set, so `CookieHostPatterns()` returns the configured `domain_filter` (anchored host matches) or `nil` to signal "every cookie" - the interface's documented full-set escape hatch.
+- KTD4. Reuse the cookie-translation shape from `internal/cdp/setcookies.go` (`buildCookieParam`: domain de-dot, URL synthesis for SameSite correctness, `chromeSameSiteToCDP`, microseconds-since-1601 to Unix epoch, session-cookie preservation) but re-verify every rule against WebKit. WebKit's `WKHTTPCookieStore` historically wants the leading dot (opposite of CDP), and WebKit ITP may drop cross-site cookies more aggressively. A spike (U1) confirms the real contract before the adapter hard-codes it.
+- KTD5. Value passthrough. `Push` sends `c.Value` unmodified. A test asserts no second App-Bound strip (the v0.12.0-beta.3 bug that caused a measured 64% cookie drop).
+- KTD6. Binary resolution mirrors `internal/tsclient`: a `const cmuxAppCLI = "/Applications/cmux.app/Contents/Resources/bin/cmux"` with `exec.LookPath("cmux")` fallback and a typed not-installed signal feeding `IsInstalled()`.
+- KTD7. The `cmuxOnly` gate is detected and remediated in `doctor`, not worked around in code. agentcookie does not silently flip a user's cmux security posture; it tells them to run the one-liner and restart cmux.
+
+---
+
+## High-Level Technical Design
+
+Where the surface sits in the existing after-sync fan-out (the cmux box is the only new node):
+
+```mermaid
+flowchart TD
+  SYNC["/sync handler (internal/cli/sink.go)"] --> FILT["blocklist + DBSC filter\n(already applied)"]
+  FILT --> S1["Surface 1: Chrome SQLite\n(universal delivery)"]
+  FILT --> S2["Surface 2: plaintext sidecar"]
+  FILT --> CDP["CDP injector (optional)"]
+  FILT --> RUNALL["sinkpush.RunAll(cookies)"]
+  RUNALL --> A1["instacart / airbnb / ebay / ..."]
+  RUNALL --> CMUX["Surface 4: CmuxAdapter (NEW)"]
+  CMUX --> CHK{"cmux installed\n+ reachable?"}
+  CHK -- no --> SKIP["skip (non-fatal),\nrecord reason"]
+  CHK -- yes --> XLATE["translate cookies\nto WebKit params (U1-verified)"]
+  XLATE --> RPC["cmux rpc browser.cookies.set\n(stdin JSON, stderr captured)"]
+  RPC --> WK["cmux WebKit jar\n(agent wakes authenticated)"]
+```
+
+The adapter is one of the `RunAll` participants; everything upstream of `RunAll` already exists.
+
+---
+
+## Implementation Units
+
+### U1. Spike: confirm `browser.cookies.set` WebKit semantics
+
+**Goal:** Resolve the WebKit-specific cookie contract empirically before the adapter encodes it, following the repo's `cmd/spike-*` precedent. Throwaway probe.
+
+**Requirements:** R6 (informs), R1 (informs)
+
+**Dependencies:** none
+
+**Files:**
+- `cmd/spike-cmux/main.go` (throwaway; removed or left as a documented probe before merge)
+
+**Approach:** Drive `cmux rpc browser.cookies.set` / `browser.cookies.get` directly and record answers to the open questions:
+- Does `browser.cookies.set` require a live browser `surface_id`, or can it target a profile / website-data-store without an open pane? (Observed in investigation: get/set accepted a `surface_id`.) If a surface is required, determine the lightest way the adapter ensures one (open a headless/background pane vs reuse an existing one) and whether the cookie persists to the profile after the pane closes.
+- Leading-dot domain: does WebKit want `.example.com` or `example.com`? (CDP wants no dot; WebKit may be the opposite.)
+- Exact param names/shape the RPC expects (name, value, domain, path, secure, httpOnly, sameSite encoding, expiry units).
+- Session cookie handling (no expiry).
+- Behavior under `cmuxOnly` vs `allowAll`/`password` (confirm the access-denied/broken-pipe signature for the doctor check).
+
+**Execution note:** Spike to learn, not to keep. Capture findings in the U2/U3 approach and (post-merge) via `/ce-compound`, since there is no prior cmux institutional knowledge.
+
+**Patterns to follow:** `cmd/spike-source/`, `cmd/spike-sink/`.
+
+**Test scenarios:** Test expectation: none -- throwaway spike; its output is documented findings, not shipped behavior.
+
+**Verification:** A short findings note answering each question above, with the confirmed param shape pasted into U2's approach.
+
+### U2. CmuxAdapter implementing `sinkpush.Adapter`
+
+**Goal:** The delivery surface: translate the synced cookie slice to WebKit params and push via the cmux socket, fail-soft.
+
+**Requirements:** R1, R3, R4, R5, R6, R8
+
+**Dependencies:** U1 (cookie param contract), U3 (config struct for filter/path/profile)
+
+**Files:**
+- `internal/sinkpush/adapter_cmux.go` (new)
+- `internal/sinkpush/adapter_cmux_test.go` (new)
+- `internal/sinkpush/init.go` (register `NewCmux()`)
+
+**Approach:** Implement the `Adapter` interface:
+- `Name()` -> stable identifier (e.g., `cmux`).
+- `CLIBinary()` -> resolved cmux path (KTD6: const app path, LookPath fallback).
+- `IsInstalled()` -> binary present (skips cleanly when cmux absent).
+- `CookieHostPatterns()` -> configured `domain_filter` or `nil` for full set (KTD3); anchored host matching only (`= d` or ends-with `.d`), never loose suffix (the v0.11 `xopentable.com` vs `opentable.com` bug).
+- `Push(cookies []chrome.Cookie)` -> for each cookie, build the WebKit param using the U1-confirmed contract (reusing the `internal/cdp/setcookies.go` mapping shape adjusted for WebKit), send via `exec` of `cmux rpc browser.cookies.set` with JSON on stdin and stderr captured into the wrapped error (mirror `adapter_instacart.go`). Value passed verbatim (KTD5). Treat an access-denied / broken-pipe (cmuxOnly) result as a returned error that `RunAll` logs and records, not a panic.
+
+Decide in U1 whether one RPC call per cookie or a batch call is supported; prefer batch if available.
+
+**Execution note:** Implement the cookie-translation and value-passthrough behavior test-first; these are the two historically bug-prone areas (SameSite/expiry mapping and double-strip).
+
+**Patterns to follow:** `internal/sinkpush/adapter_instacart.go` (exec + stderr capture), `internal/cdp/setcookies.go` (`buildCookieParam`, `normalizeDomain`, `chromeSameSiteToCDP`, `cookieExpiresEpoch`), `internal/tsclient/tsclient.go` (binary resolution), `internal/sinkpush/validate.go` (runs before Push).
+
+**Test scenarios:**
+- Happy path: a slice of cookies (secure + non-secure, with and without expiry, varied SameSite) produces the expected WebKit param set; the exec target and stdin payload match expectations via a stubbed binary.
+- Covers R4. Value passthrough: a cookie value longer than the App-Bound prefix length arrives byte-identical (no second strip); explicitly regression-guards the 64% drop.
+- SameSite/Secure/expiry translation: Chrome `-1/0/1/2` map to the WebKit-correct values; microseconds-since-1601 expiry converts to the right epoch; `ExpiresUTC == 0` stays a session cookie.
+- Leading-dot domain handled per U1 finding (dot present or stripped as WebKit requires).
+- Host scoping: `domain_filter` of `opentable.com` matches `opentable.com` and `www.opentable.com` but not `xopentable.com`.
+- Fail-soft: cmux binary absent -> `IsInstalled()` false -> `RunAll` skips (Skipped, reason "not installed"), no error. cmux present but RPC returns access-denied -> `Push` returns error, `RunAll` records FAIL, other adapters still run.
+- Empty/filtered-to-zero set -> skipped with reason, no exec call.
+- No cookie values appear in any log/error string (R8).
+
+**Verification:** `go test ./internal/sinkpush/...` passes; with a stub cmux binary, a sync delivers the expected cookies and a missing/denied cmux is a clean skip/fail without aborting the run.
+
+### U3. Sink config: `Cmux` surface options
+
+**Goal:** Opt-in configuration for the surface, backward compatible.
+
+**Requirements:** R2, R3, R5
+
+**Dependencies:** none
+
+**Files:**
+- `internal/config/config.go` (add `Cmux CmuxRef` to `SinkConfig`; new `CmuxRef` struct)
+- `internal/config/config_test.go` (load/validate cases)
+
+**Approach:** Add `Cmux CmuxRef \`yaml:"cmux,omitempty"\`` to `SinkConfig`, mirroring `CDPRef`. `CmuxRef` fields: `Enabled bool`, `CmuxPath string` (override binary path), `TargetProfile string` (cmux profile/surface target, shaped by U1), `DomainFilter []string` (anchored host patterns; empty = all). Tilde-expand any path in `LoadSink`. Because the loader uses `KnownFields(true)`, the field must exist in the struct; `omitempty` keeps existing `sink.yaml` files valid (absent block -> disabled).
+
+**Test scenarios:**
+- A `sink.yaml` with no `cmux:` block loads with the surface disabled and no error (backward compat).
+- A `cmux:` block with `enabled: true` and a `domain_filter` parses into the struct; tilde paths expand.
+- Unknown sub-key under `cmux:` is rejected by `KnownFields(true)` (documents the contract).
+
+**Verification:** `go test ./internal/config/...` passes; round-trips a representative `sink.yaml`.
+
+### U4. Doctor: cmux delivery health category
+
+**Goal:** Make the surface and its one operational gotcha visible and self-service.
+
+**Requirements:** R7
+
+**Dependencies:** U2, U3
+
+**Files:**
+- `internal/cli/doctor.go` (`checkCmuxDelivery`, appended in `buildReport` sink-only block; bump the category count in the command `Long`)
+- `internal/cli/doctor_test.go` (cases)
+
+**Approach:** Add `func checkCmuxDelivery(sinkCfg *config.SinkConfig) Check` mirroring `checkCDPInjector`:
+- SKIPPED when the surface is disabled or this is a source-only install.
+- OK when cmux is installed and the socket accepts a probe (e.g., a benign `cmux rpc` read) - meaning mode is not `cmuxOnly`.
+- WARN/FAIL with remediation when cmux is installed but the probe hits the `cmuxOnly` access-denied signature: remediation text = set `automation.socketControlMode` to `allowAll` (or `password`) in `~/.config/cmux/cmux.json` and fully restart cmux (the mode is read only at app launch; `reload-config` does not apply it). Optionally point at the helper if one ships.
+- WARN when cmux is not installed but the surface is enabled.
+Append inside the existing `if sinkCfg != nil { ... }` block; bump the numbered count in the doctor `Long` description.
+
+**Test scenarios:**
+- Disabled surface -> SKIPPED.
+- Source-only install -> SKIPPED.
+- Enabled + cmux missing -> WARN with install guidance.
+- Enabled + cmux present + cmuxOnly probe failure -> WARN/FAIL carrying the socketControlMode + restart remediation.
+- Enabled + reachable -> OK.
+
+**Verification:** `go test ./internal/cli/...` passes; `agentcookie doctor` on a sink shows the new line in each state.
+
+### U5. Docs: fourth surface, setup, and the cmux gate
+
+**Goal:** Document the surface as a first-class delivery option and the required cmux-side setup.
+
+**Requirements:** R2, R7
+
+**Dependencies:** U2, U3, U4
+
+**Files:**
+- `README.md` (delivery-surfaces section: add cmux as surface 4; note WebKit jar is separate from Chrome)
+- `docs/quickstart.md` (opt-in `cmux:` block + the socketControlMode/restart prerequisite)
+- `CHANGELOG.md` (entry)
+- optional: `docs/runbook-cmux-delivery.md` if setup detail outgrows the quickstart
+
+**Approach:** Explain that cmux is WebKit with its own jar, that the surface fires after each sync like the others, that it requires cmux's `socketControlMode` to be `allowAll` or `password` plus a one-time cmux restart (with the exact reason: mode is read at launch), and that DBSC/fingerprint-bound sessions (Google/Workspace) and WebKit ITP may not produce durable logins - sign in once in the cmux pane for those.
+
+**Test scenarios:** Test expectation: none -- documentation only.
+
+**Verification:** A reader can enable the surface and pass `agentcookie doctor` without external help.
+
+---
+
+## Scope Boundaries
+
+In scope: the cmux delivery surface (adapter + registration), its config, its doctor check, and docs. Cookies only.
+
+Outside this product's identity: any change to the source side, the transport, or the sync trigger; defeating DBSC; modifying the user's cmux security posture automatically.
+
+### Deferred to Follow-Up Work
+- Catch-up listener: subscribe to `cmux events` and do a full push when cmux starts or a browser pane opens, so a cmux that was down during a sync self-heals without waiting for the next source-side change. v1 fires after each sync and skips if cmux is down.
+- localStorage / sessionStorage sync via `cmux rpc browser.storage.set` for sites whose session is token-bound (many SaaS) rather than cookie-only. v1 matches agentcookie's existing cookie-only model.
+- A setup helper command (analogous to the standalone `setup_cmux.py` concept) to flip `socketControlMode` and prompt the restart, if the doctor remediation proves too manual.
+
+---
+
+## Risk Analysis & Mitigation
+
+- The cmuxOnly gate makes the surface silently ineffective if undocumented. Mitigation: U4 doctor check with exact remediation; U5 docs; fail-soft so it never breaks sync.
+- WebKit cookie semantics differ from CDP (leading dot, ITP cross-site dropping, SameSite defaulting). Mitigation: U1 spike confirms the real contract before U2 encodes it; tests assert the mapping.
+- Double App-Bound strip regressing the 64% drop. Mitigation: KTD5 value passthrough + explicit regression test.
+- Surface requires an open browser pane (unconfirmed). Mitigation: U1 resolves whether a pane is required and the lightest way to ensure one; if heavy, reconsider surface vs profile-level injection before U2.
+- DBSC/fingerprint sessions will not persist in WebKit. Mitigation: inherit source-side DBSC flagging; set expectations in docs; no attempt to solve at this layer.
+- Greptile reviews the PR. Resolve all findings before merge per project convention.
+
+---
+
+## Alternatives Considered
+
+- Global CDP-style surface in `internal/cdp` instead of a `sinkpush.Adapter`. The "all synced cookies into a general browser" framing matches the CDP/global model conceptually. Rejected for v1 because the `sinkpush.Adapter` path is strictly less integration surface (zero `/sync` handler changes) and gets doctor + verify-adapters + state recording + fail-soft for free, while still delivering the full set via `CookieHostPatterns() == nil`. Revisit if the surface needs lifecycle behavior the adapter contract cannot express.
+- cmux's built-in `browser import --from "Google Chrome"`. Rejected as the mechanism: it is one-time and manual, and it is unverified whether it decrypts Chrome 127+ App-Bound cookies - the exact gap agentcookie already closes. agentcookie delivering the already-decrypted stream continuously is the differentiated path.
+- Reading the plaintext sidecar as the source of truth. Rejected per KTD2: the in-memory slice carries SameSite that the sidecar reader drops.
+
+---
+
+## Sources & Research
+
+- cmux browser engine confirmed WebKit (links `/System/Library/Frameworks/WebKit.framework`); separate cookie jar at `~/Library/HTTPStorages/com.cmuxterm.app.binarycookies`; live `browser.cookies.set` round-trip verified during investigation (set + `document.cookie` readback).
+- cmux `socketControlMode` enum and the cmuxOnly ancestry gate confirmed via `cmux capabilities` (`access_mode`) and a launchd-context reproduction; mode applies only at app launch (no live RPC, `reload-config` does not apply it).
+- agentcookie extension point: `internal/sinkpush/` (`adapter.go`, `registry.go`, `init.go`), fired at `internal/cli/sink.go` `sinkpush.RunAll(cookies)`; cookie translation reference `internal/cdp/setcookies.go`; config `internal/config/config.go` (`SinkConfig`, `CDPRef`, YAML `KnownFields(true)`); doctor `internal/cli/doctor.go` (`checkCDPInjector`, `checkAdapterCoverage`); binary resolution `internal/tsclient/tsclient.go`.
+- Hazards from repo history: App-Bound double-strip 64% drop (`docs/dry-run-2026-05-21.md`), unanchored host-match bug (`docs/runbook-v0.11-adapter-cookie-push.md`), keychain duplicate-item race and Safe Storage value-preservation invariant (`docs/runbook-v0.13-one-password-keychain.md`, `docs/plans/2026-05-31-005-...`), DBSC scope (`docs/threat-model.md`).

--- a/docs/plans/2026-06-03-002-feat-cmux-local-loop-plan.md
+++ b/docs/plans/2026-06-03-002-feat-cmux-local-loop-plan.md
@@ -1,0 +1,256 @@
+---
+title: "feat: local loop - Chrome to cmux on one machine"
+status: active
+date: 2026-06-03
+type: feat
+---
+
+# feat: local loop - Chrome to cmux on one machine
+
+Builds on PR #86 / `docs/plans/2026-06-03-001-feat-cmux-cookie-delivery-surface-plan.md`, which added the `CmuxAdapter` (the injection mechanism). This plan adds the missing piece: a same-machine loop that reads this Mac's Chrome and feeds that adapter, continuously and automatically, with no second machine, no Tailscale hop, and no pairing.
+
+## Summary
+
+agentcookie's two-machine model (source Mac browses, sink Mac receives) means the cmux delivery surface only fires on a separate sink. The actually-wanted shape is the local loop: on your daily-driver Mac, your Chrome logins flow into that same machine's cmux browser automatically, so a cmux agent on the machine you already use wakes up authenticated.
+
+The read side already exists (the `source` command's Chrome decrypt + blocklist + DBSC filter) and the write side already exists (the `CmuxAdapter` from PR #86). This plan extracts the read pipeline into a shared helper and adds an `agentcookie cmux-sync` command that runs read -> filter -> inject locally, once or on an fsnotify watch. No transport, no sink, no peer.
+
+Crucially, when run from inside cmux (a cmux child) the loop bypasses cmux's default `cmuxOnly` socket gate, so it needs no cmux restart and no socketControlMode change. A launchd option is documented for unattended autostart (which does need the socketControlMode change the doctor check already flags).
+
+---
+
+## Problem Frame
+
+The cmux delivery surface added in PR #86 lives on the sink. On a one-Mac setup (the common case for "I want my terminal agent's browser logged in like my Chrome is"), there is no sink, so nothing delivers to cmux. Verified live this session: reading Chrome and injecting via the adapter works end-to-end (Amazon showed "Hello, Matt" in a cmux pane), but only because it was driven by hand. There is no shipped command that closes that loop automatically on one machine.
+
+The loop is pure composition of code that already exists:
+- Read: `chrome.SafeStoragePasswordFor` -> `chrome.DeriveAESKey` -> `chrome.ReadCookiesForHost(db, "%", key)` (App-Bound handled on read), then `protocol.NewBlocklistMatcher(bl).Filter(...)` and `chrome.ClassifyCookies(...)` for DBSC.
+- Watch: `watcher.New(...)` (fsnotify on Chrome's Cookies file, debounced) as used by `source --watch`.
+- Write: `sinkpush.CmuxAdapter.Push(cookies)` from PR #86.
+
+What is missing is the glue command and a small refactor so the read pipeline is callable outside the source-push path.
+
+---
+
+## Requirements
+
+- R1. `agentcookie cmux-sync --once` reads this machine's Chrome, applies the blocklist and DBSC filter, and injects the result into this machine's cmux browser via the `CmuxAdapter`, then exits.
+- R2. `agentcookie cmux-sync --watch` runs the same pipeline continuously: on each debounced Chrome Cookies change, re-read and re-inject. `--once` and `--watch` are mutually exclusive, mirroring `source`.
+- R3. Reuse the existing read pipeline (decrypt, blocklist, DBSC) rather than reimplementing it, so local and push paths cannot drift.
+- R4. Opt-in domain narrowing via config and/or a flag; empty means the full set (after blocklist).
+- R5. Fail soft: cmux not running or `cmuxOnly`-gated is a clear, non-fatal message, never a crash; `--watch` keeps running and retries on the next change.
+- R6. No second machine, no transport, no pairing required. The loop works with only `source.yaml`'s Chrome/blocklist settings present (or sensible defaults), independent of any sink/peer config.
+- R7. `agentcookie doctor` reports the local cmux loop's reachability (including the `cmuxOnly` gate) when the local loop is configured, not only in the sink role.
+- R8. Never log cookie values. Counts and outcomes only.
+
+---
+
+## Key Technical Decisions
+
+- KTD1. New dedicated command `agentcookie cmux-sync` (not a flag on `source`). `source` means "push to a peer sink"; overloading it with local injection would muddy that contract. (Confirmed with user.)
+- KTD2. Extract the source read+filter pipeline (`ReadCookiesForHost("%") -> blocklist.Filter -> ClassifyCookies`) into one reusable helper, then call it from both `source` push and `cmux-sync`. This is the refactor that keeps R3 true.
+- KTD3. Reuse the existing `CmuxRef` config struct. Add an optional `Cmux CmuxRef` block to `SourceConfig` (the local loop runs on the source machine; there is no sink.yaml there). Flags on `cmux-sync` (`--domain`, `--cmux-path`, `--browser`) override config.
+- KTD4. Default run model is foreground / launched-from-cmux, which is a cmux child and so passes the default `cmuxOnly` gate with zero cmux changes. A launchd plist is documented for unattended autostart, which requires the socketControlMode change the PR #86 doctor check already prints. (Confirmed with user: support both, default docs to the from-cmux path.)
+- KTD5. `--watch` reuses `watcher.New` (the same fsnotify+debounce wrapper `source --watch` uses), watching `cfg.Chrome.DBPath`. No new watch machinery.
+- KTD6. The loop reads ALL cookies each cycle and injects the full current set (idempotent), consistent with the adapter's design and the persisted WebKit jar, so a missed change never leaves cmux permanently stale.
+
+---
+
+## High-Level Technical Design
+
+The local loop reuses both ends; only the dashed box is new glue:
+
+```mermaid
+flowchart LR
+  CH["Chrome Cookies SQLite\n(this Mac)"] -->|fsnotify change| W["watcher.New\n(debounced)"]
+  W --> P["shared read pipeline (KTD2):\nSafeStoragePassword -> DeriveAESKey\n-> ReadCookiesForHost(%)\n-> blocklist.Filter -> ClassifyCookies"]
+  P --> CMD(["agentcookie cmux-sync (NEW)"])
+  CMD --> ADP["sinkpush.CmuxAdapter.Push\n(from PR #86)"]
+  ADP -->|cmux rpc browser.cookies.set| CMUX["cmux WebKit jar\n(same Mac)"]
+  P -. also feeds .-> SRC["source push to peer\n(existing, unchanged)"]
+```
+
+Same-machine, no network leg. The `source -> peer` path stays exactly as is and now shares the read pipeline.
+
+---
+
+## Implementation Units
+
+### U1. Extract the shared Chrome read+filter pipeline
+
+**Goal:** Factor the decrypt + blocklist + DBSC read pipeline out of the source-push path into one reusable function both callers use.
+
+**Requirements:** R3
+
+**Dependencies:** none
+
+**Files:**
+- `internal/cli/source.go` (extract the read+filter block currently inline near the push helper)
+- a shared home for the helper: either `internal/chrome` (a `ReadFiltered`-style helper taking key + blocklist + DBSC options) or a small new `internal/localsync` package; decide during implementation based on import cleanliness (config/protocol/chrome dependency direction)
+- the corresponding `*_test.go` for the new helper's home
+
+**Approach:** Pull "read all cookies for key, apply `protocol.NewBlocklistMatcher(bl).Filter`, apply `chrome.ClassifyCookies(..., skipDBSC)`" into one function returning the filtered `[]chrome.Cookie` (plus the dropped-host/DBSC summary for logging). Rewire `source` to call it so behavior is unchanged. Watch the import direction: if the helper needs both `config` (blocklist type) and `chrome`, place it where neither cycle nor CGO-in-config rules are violated (config currently avoids importing chrome on purpose).
+
+**Execution note:** Characterization-first - capture the current source read+filter output before extracting, so the refactor is provably behavior-preserving.
+
+**Patterns to follow:** the existing inline pipeline in `internal/cli/source.go` (`ReadCookiesForHost(dbPath, "%", key)`, `NewBlocklistMatcher(...).Filter`, `ClassifyCookies(...)`).
+
+**Test scenarios:**
+- Happy path: a key + cookie set + blocklist yields the same filtered slice the inline source path produced (golden/characterization).
+- Blocklist drop: a blocked host is excluded; a non-blocked host passes (anchored match, no loose suffix).
+- DBSC: with skip=true, DBSC-suspect cookies are dropped; with skip=false they pass through (flagged).
+- Empty/nil blocklist passes everything.
+
+**Verification:** `source --once`/`--watch` behavior is unchanged; the helper has direct unit coverage.
+
+### U2. cmux-sync config: local loop options
+
+**Goal:** Configure the local loop without requiring sink.yaml.
+
+**Requirements:** R4, R6
+
+**Dependencies:** none
+
+**Files:**
+- `internal/config/config.go` (add `Cmux CmuxRef` to `SourceConfig`; reuse the existing `CmuxRef`)
+- `internal/config/config_test.go`
+
+**Approach:** Add `Cmux CmuxRef \`yaml:"cmux,omitempty"\`` to `SourceConfig`, mirroring the sink. Tilde-expand `CmuxPath` in `LoadSource` as done for other paths. `omitempty` keeps existing source.yaml valid (absent = local loop off). The `cmux-sync` command reads this block; flags override.
+
+**Test scenarios:**
+- A `source.yaml` with no `cmux:` block loads with the loop disabled, no error (backward compat).
+- A `cmux:` block with `enabled`, `domain_filter`, and a tilde `cmux_path` parses and expands.
+- Unknown key under `cmux:` is rejected by `KnownFields(true)`.
+
+**Verification:** `go test ./internal/config/...` passes; representative `source.yaml` round-trips.
+
+### U3. `agentcookie cmux-sync` command (once + watch)
+
+**Goal:** The local loop command itself, both modes.
+
+**Requirements:** R1, R2, R5, R6, R8
+
+**Dependencies:** U1, U2, and the `CmuxAdapter` from PR #86
+
+**Files:**
+- `internal/cli/cmux_sync.go` (new cobra command, registered in `internal/cli/root.go`)
+- `internal/cli/cmux_sync_test.go`
+
+**Approach:** Add a `cmux-sync` cobra command mirroring `source`'s flag handling (`--once`/`--watch` mutually exclusive; `--domain`, `--cmux-path`, `--browser`, `--verbose`, `--dry-run`). Resolve config from `source.yaml` (Chrome path, browser, blocklist) plus the `Cmux` block, flags overriding. Build the key via `chrome.SafeStoragePasswordFor` + `DeriveAESKey`. Construct the adapter via `sinkpush.NewCmux(cmuxPath, domainFilter)`.
+- `--once`: run the U1 helper, then `adapter.Push(cookies)`; print a one-line outcome (count pushed / skipped reason). cmux unreachable or `cmuxOnly`-gated -> clear non-fatal message naming the doctor remediation; non-zero exit only on a real error per the command's contract.
+- `--watch`: see U4.
+Reuse `source`'s blocklist load + DBSC flag plumbing. Never print cookie values (verbose prints names/counts only).
+
+**Execution note:** Implement `--once` test-first against a faked adapter and a faked Chrome reader so the wiring (config resolve -> read -> filter -> push, and the fail-soft message) is covered without a live cmux or Chrome.
+
+**Patterns to follow:** `internal/cli/source.go` (flag wiring, `--once` path, dry-run/verbose), `internal/cli/sink.go` (how the adapter is constructed and results logged), `internal/sinkpush/adapter_instacart.go` (exec/stderr conventions inherited by the adapter).
+
+**Test scenarios:**
+- Happy path (`--once`): given a faked reader returning N cookies and a faked adapter, the command resolves config, pushes N, and reports the count.
+- Domain filter from flag overrides config; empty = full set.
+- Mutually-exclusive flags: passing both `--once` and `--watch` errors; passing neither errors (mirror source).
+- Fail-soft: adapter returns a `cmuxOnly`/connection error -> command prints the remediation, does not panic; `--dry-run` performs read+filter but no push.
+- No cookie values appear in verbose output or errors.
+
+**Verification:** `agentcookie cmux-sync --once` from inside cmux injects the current Chrome session and the cmux browser shows logged-in; `--dry-run` reports counts without touching cmux.
+
+### U4. Continuous watch mode
+
+**Goal:** Automatic re-injection whenever Chrome cookies change.
+
+**Requirements:** R2, R5
+
+**Dependencies:** U3
+
+**Files:**
+- `internal/cli/cmux_sync.go` (watch branch)
+- `internal/cli/cmux_sync_test.go`
+
+**Approach:** In `--watch`, construct `watcher.New(watcher.Config{...})` over `cfg.Chrome.DBPath` (mirror `source --watch`), and on each debounced event run the same `--once` pipeline (read -> filter -> push). Log one line per cycle (pushed/skip/err). A failed cycle (cmux down) logs and continues; the next change retries. Honor context cancellation for clean shutdown.
+
+**Test scenarios:**
+- A simulated watcher event triggers exactly one read+filter+push cycle.
+- A push error in one cycle is logged and does not stop the watcher; a subsequent event still triggers a cycle.
+- Context cancel stops the loop cleanly.
+
+**Verification:** `agentcookie cmux-sync --watch` from inside cmux; logging into a new site in Chrome results in that session appearing in cmux within the debounce window, hands-free.
+
+### U5. Doctor: local cmux loop reachability
+
+**Goal:** Surface the local loop's health and the `cmuxOnly` gate from the source machine, not just the sink.
+
+**Requirements:** R7
+
+**Dependencies:** U2
+
+**Files:**
+- `internal/cli/doctor.go` (generalize the PR #86 `checkCmuxDelivery` to accept the cmux config + enabled flag from either role; run it when `source.yaml` has `cmux.enabled`)
+- `internal/cli/doctor_test.go`
+
+**Approach:** Refactor `checkCmuxDelivery` to take the resolved `CmuxRef` (and a label) rather than a `*SinkConfig`, so it can be invoked for the sink surface and for the source-side local loop. In `buildReport`, when source config has `cmux.enabled`, add the check. Same severity logic: SKIPPED when disabled, WARN when cmux missing or socket unreachable / `cmuxOnly`, OK when reachable. Reuse `probeCmuxAccessMode`.
+
+**Test scenarios:**
+- Source role with `cmux.enabled` and a `cmuxOnly` probe -> WARN with socketControlMode+restart remediation.
+- Source role, loop disabled -> SKIPPED.
+- Sink role behavior from PR #86 is unchanged (regression).
+
+**Verification:** `agentcookie doctor` on the source machine shows the local cmux loop line with the right state and remediation.
+
+### U6. Docs: the local loop
+
+**Goal:** Document the local loop as the primary single-machine path.
+
+**Requirements:** R6, R7
+
+**Dependencies:** U3, U4, U5
+
+**Files:**
+- `README.md` (local loop section: one Mac, `cmux-sync --watch`, the from-cmux run model that needs no cmux change, and the launchd option that needs socketControlMode allowAll/password)
+- `docs/quickstart.md` or a short `docs/runbook-cmux-local-loop.md`
+- `CHANGELOG.md`
+
+**Approach:** Explain the one-machine framing (no sink/peer needed), the two run models (foreground/from-cmux vs launchd) and which needs the socketControlMode change, the cookies-persist-profile-wide behavior, and the DBSC/ITP caveats inherited from PR #86. Make clear `source.yaml`'s blocklist still applies.
+
+**Test scenarios:** Test expectation: none -- documentation only.
+
+**Verification:** A reader on one Mac can enable and run the local loop from the docs alone.
+
+---
+
+## Scope Boundaries
+
+In scope: the `cmux-sync` command (once + watch), the shared read-pipeline refactor, source-side cmux config, the doctor generalization, and docs.
+
+Outside this product's identity: changes to the source->sink transport or pairing; defeating DBSC; auto-flipping cmux's socketControlMode.
+
+### Deferred to Follow-Up Work
+- A launchd installer for the local loop via `agentcookie wizard` (v1 documents the plist; wizard automation is follow-up).
+- localStorage/sessionStorage sync (carried over from PR #86's deferred list).
+- Auto-managing cmux's socketControlMode for the unattended/launchd case (today: doctor remediation + manual change).
+
+---
+
+## Risk Analysis & Mitigation
+
+- The refactor (U1) could change source push behavior. Mitigation: characterization-first; source tests stay green.
+- launchd run model hits `cmuxOnly` (not a cmux child). Mitigation: default docs to the from-cmux model; doctor flags the gate with remediation; fail-soft so it never crashes.
+- Keychain access for the Chrome read. On the user's own machine the signed binary reads Safe Storage via the one-time partition-list setup (no per-run prompt); document that a fresh setup may prompt once.
+- DBSC/fingerprint sessions (Google/Workspace) and WebKit ITP may not produce durable logins. Mitigation: inherit source-side DBSC filtering; set expectations in docs.
+- Greptile reviews the PR; resolve all findings before merge.
+
+---
+
+## Alternatives Considered
+
+- A flag on `source` (`source --to-cmux --local`) instead of a new command. Rejected (KTD1): `source` is the push-to-peer path; a local injection loop is a different contract and deserves its own verb.
+- A long-lived `cmux events` listener that injects on pane-open instead of watching Chrome. Rejected for v1: watching Chrome (the source of truth) is the direct expression of "keep cmux in sync with my Chrome"; the events-driven catch-up remains a PR #86 follow-up.
+- Running the local loop as the existing sink pointed at localhost. Rejected: it would require standing up sink.yaml + pairing + the HTTP listener for a same-process, same-machine data flow that needs none of it.
+
+---
+
+## Sources & Research
+
+- Existing read pipeline to reuse: `internal/cli/source.go` (`SafeStoragePasswordFor`, `DeriveAESKey`, `ReadCookiesForHost(db,"%",key)`, `protocol.NewBlocklistMatcher().Filter`, `chrome.ClassifyCookies`).
+- Watch wrapper: `internal/watcher` (`watcher.New`), as used by `source --watch`.
+- Injection mechanism + WebKit semantics + the `cmuxOnly` gate + doctor check: PR #86 / `docs/plans/2026-06-03-001-feat-cmux-cookie-delivery-surface-plan.md` and the `internal/sinkpush.CmuxAdapter`.
+- Live-verified this session: read 30 Amazon cookies from Chrome, injected via the real adapter, cmux pane rendered "Hello, Matt" - the exact loop this command automates.

--- a/internal/cli/cmux_sync.go
+++ b/internal/cli/cmux_sync.go
@@ -154,6 +154,7 @@ func runCmuxSync(cmd *cobra.Command, args []string) error {
 	// change retries.
 	w, err := watcher.New(watcher.Config{
 		CookiesPath: cfg.Chrome.DBPath,
+		LogLabel:    "agentcookie cmux-sync --watch",
 		Push:        syncOnce,
 		OnEvent: func(ev watcher.Event) {
 			if cmuxSyncVerbose {

--- a/internal/cli/cmux_sync.go
+++ b/internal/cli/cmux_sync.go
@@ -1,0 +1,169 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mvanhorn/agentcookie/internal/chrome"
+	"github.com/mvanhorn/agentcookie/internal/config"
+	"github.com/mvanhorn/agentcookie/internal/sinkpush"
+	"github.com/mvanhorn/agentcookie/internal/watcher"
+)
+
+var (
+	cmuxSyncOnce     bool
+	cmuxSyncWatch    bool
+	cmuxSyncVerbose  bool
+	cmuxSyncDryRun   bool
+	cmuxSyncSkipDBSC bool
+	cmuxSyncDomains  []string
+	cmuxSyncCmuxPath string
+	cmuxSyncBrowser  string
+)
+
+var cmuxSyncCmd = &cobra.Command{
+	Use:   "cmux-sync",
+	Short: "Local loop: read this machine's Chrome and inject the session into this machine's cmux browser",
+	Long: `cmux-sync is the same-machine local loop. It reads this Mac's Chrome
+cookies (decrypt + blocklist + DBSC filter, the same pipeline source uses)
+and injects them into this Mac's cmux WebKit browser via
+cmux rpc browser.cookies.set, so an agent driving cmux's browser pane wakes
+up authenticated. No sink, no peer, no Tailscale hop.
+
+Two modes:
+
+  agentcookie cmux-sync --once    one read+inject cycle, then exit.
+  agentcookie cmux-sync --watch   long-running; fsnotify watches Chrome's
+                                  Cookies SQLite and re-injects on change.
+
+Run it from inside cmux (a cmux child) and it passes cmux's default
+socketControlMode "cmuxOnly" with no cmux change. To run it unattended via
+launchd, set automation.socketControlMode to allowAll or password in
+~/.config/cmux/cmux.json and restart cmux (see` + " `agentcookie doctor`" + `).`,
+	RunE: runCmuxSync,
+}
+
+func init() {
+	cmuxSyncCmd.Flags().BoolVar(&cmuxSyncOnce, "once", false, "single read+inject cycle, then exit")
+	cmuxSyncCmd.Flags().BoolVar(&cmuxSyncWatch, "watch", false, "long-running fsnotify watcher; re-injects on every Chrome cookie write (debounced)")
+	cmuxSyncCmd.Flags().BoolVar(&cmuxSyncVerbose, "verbose", false, "log per-cycle counts to stderr")
+	cmuxSyncCmd.Flags().BoolVar(&cmuxSyncDryRun, "dry-run", false, "read + filter but do not inject into cmux")
+	cmuxSyncCmd.Flags().BoolVar(&cmuxSyncSkipDBSC, "skip-dbsc-suspect", false, "drop cookies that look device-bound (DBSC); also honored via AGENTCOOKIE_SKIP_DBSC_SUSPECT=1")
+	cmuxSyncCmd.Flags().StringSliceVar(&cmuxSyncDomains, "domain", nil, "limit to these host_key LIKE patterns (repeatable), e.g. --domain %github.com; overrides cmux.domain_filter")
+	cmuxSyncCmd.Flags().StringVar(&cmuxSyncCmuxPath, "cmux-path", "", "override the cmux CLI path (default: cmux.cmux_path, then the app bundle)")
+	cmuxSyncCmd.Flags().StringVar(&cmuxSyncBrowser, "browser", "", "source browser name (default: source.yaml browser, then Chrome)")
+}
+
+func runCmuxSync(cmd *cobra.Command, args []string) error {
+	if !cmuxSyncOnce && !cmuxSyncWatch {
+		return fmt.Errorf("pass either --once for a single pass or --watch for the long-running watcher")
+	}
+	if cmuxSyncOnce && cmuxSyncWatch {
+		return fmt.Errorf("--once and --watch are mutually exclusive")
+	}
+
+	cfg, err := config.LoadSource(common.ConfigDir)
+	if err != nil {
+		return err
+	}
+	// Blocklist is optional; fail fast on a broken file, reload per cycle.
+	if _, err := loadFreshBlocklist(); err != nil {
+		return err
+	}
+
+	browserName := cmuxSyncBrowser
+	if browserName == "" {
+		browserName = cfg.Browser.Name
+	}
+	sourceBrowser, err := chrome.LookupBrowser(browserName)
+	if err != nil {
+		return err
+	}
+	password, err := chrome.SafeStoragePasswordFor(sourceBrowser)
+	if err != nil {
+		return err
+	}
+	key, err := chrome.DeriveAESKey(password)
+	if err != nil {
+		return err
+	}
+
+	skipDBSC := cmuxSyncSkipDBSC || os.Getenv("AGENTCOOKIE_SKIP_DBSC_SUSPECT") == "1"
+
+	// cmux target: flags override config.
+	cmuxPath := cmuxSyncCmuxPath
+	if cmuxPath == "" {
+		cmuxPath = cfg.Cmux.CmuxPath
+	}
+	domainFilter := cmuxSyncDomains
+	if len(domainFilter) == 0 {
+		domainFilter = cfg.Cmux.DomainFilter
+	}
+	adapter := sinkpush.NewCmux(cmuxPath, domainFilter)
+	if !adapter.IsInstalled() {
+		return fmt.Errorf("cmux CLI not found at %s (install cmux, or set --cmux-path / cmux.cmux_path in source.yaml)", adapter.CLIBinary())
+	}
+
+	syncOnce := func(ctx context.Context) (int, error) {
+		blocklist, err := loadFreshBlocklist()
+		if err != nil {
+			return 0, err
+		}
+		cookies, st, err := readFilteredCookies(cfg.Chrome.DBPath, blocklist, key, skipDBSC, time.Now().UTC())
+		if err != nil {
+			return 0, err
+		}
+		// Apply the cmux domain filter the same way RunAll would before Push.
+		cookies = sinkpush.FilterByHostPatterns(cookies, domainFilter)
+		if cmuxSyncVerbose {
+			fmt.Fprintf(os.Stderr, "agentcookie cmux-sync: read %d, blocked %d, dbsc(warn=%d skip=%d), injecting %d\n",
+				st.totalRead, st.totalDropped, st.dbsc.warned, st.dbsc.skipped, len(cookies))
+		}
+		if cmuxSyncDryRun {
+			fmt.Fprintf(os.Stderr, "agentcookie cmux-sync: dry-run; not injecting %d cookies\n", len(cookies))
+			return 0, nil
+		}
+		if len(cookies) == 0 {
+			return 0, nil
+		}
+		if err := adapter.Push(cookies); err != nil {
+			return 0, err
+		}
+		return len(cookies), nil
+	}
+
+	if cmuxSyncOnce {
+		ctx, cancel := context.WithTimeout(cmd.Context(), 60*time.Second)
+		defer cancel()
+		n, err := syncOnce(ctx)
+		if err != nil {
+			// Fail soft on cmux-side problems (down / cmuxOnly-gated): name the
+			// remediation, exit non-zero so a one-shot caller sees the failure.
+			return fmt.Errorf("cmux-sync: %w (if cmux is running, check socketControlMode -- `agentcookie doctor` prints the fix)", err)
+		}
+		fmt.Fprintf(os.Stderr, "agentcookie cmux-sync: injected %d cookies into cmux\n", n)
+		return nil
+	}
+
+	// --watch: re-inject on every debounced Chrome Cookies change. A failed
+	// cycle (cmux down) is logged and the watcher keeps running; the next
+	// change retries.
+	w, err := watcher.New(watcher.Config{
+		CookiesPath: cfg.Chrome.DBPath,
+		Push:        syncOnce,
+		OnEvent: func(ev watcher.Event) {
+			if cmuxSyncVerbose {
+				fmt.Fprintf(os.Stderr, "agentcookie cmux-sync --watch: %s\n", ev.String())
+			}
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("init watcher: %w", err)
+	}
+	fmt.Fprintf(os.Stderr, "agentcookie cmux-sync --watch: watching %s, injecting into cmux\n", cfg.Chrome.DBPath)
+	return w.Run(cmd.Context())
+}

--- a/internal/cli/cmux_sync.go
+++ b/internal/cli/cmux_sync.go
@@ -66,7 +66,10 @@ func runCmuxSync(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("--once and --watch are mutually exclusive")
 	}
 
-	cfg, err := config.LoadSource(common.ConfigDir)
+	// LoadSourceLocal, not LoadSource: the local loop has no push target,
+	// so it must not require sink.url or a peer/secret. A missing
+	// source.yaml is fine (defaults: default Chrome path, no blocklist).
+	cfg, err := config.LoadSourceLocal(common.ConfigDir)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/cmux_sync_test.go
+++ b/internal/cli/cmux_sync_test.go
@@ -1,0 +1,35 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// runCmuxSync validates the mode flags before any Chrome/keychain/cmux I/O,
+// mirroring `source`. These cases exercise that gate without touching the
+// system.
+func TestCmuxSyncFlagValidation(t *testing.T) {
+	reset := func(once, watch bool) {
+		cmuxSyncOnce = once
+		cmuxSyncWatch = watch
+	}
+	t.Cleanup(func() { reset(false, false) })
+
+	t.Run("neither --once nor --watch errors", func(t *testing.T) {
+		reset(false, false)
+		err := runCmuxSync(&cobra.Command{}, nil)
+		if err == nil || !strings.Contains(err.Error(), "either --once") {
+			t.Fatalf("expected mode-required error, got %v", err)
+		}
+	})
+
+	t.Run("both --once and --watch errors", func(t *testing.T) {
+		reset(true, true)
+		err := runCmuxSync(&cobra.Command{}, nil)
+		if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+			t.Fatalf("expected mutual-exclusion error, got %v", err)
+		}
+	})
+}

--- a/internal/cli/cookie_pipeline.go
+++ b/internal/cli/cookie_pipeline.go
@@ -1,0 +1,50 @@
+package cli
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/mvanhorn/agentcookie/internal/chrome"
+	"github.com/mvanhorn/agentcookie/internal/config"
+	"github.com/mvanhorn/agentcookie/internal/protocol"
+)
+
+// readStats summarizes one read+filter pass for logging by the caller.
+type readStats struct {
+	totalRead    int
+	totalDropped int
+	droppedHosts map[string]int
+	dbsc         dbscSummary
+}
+
+// readFilteredCookies reads every cookie from the browser's Cookies DB,
+// applies the blocklist, and runs the DBSC classifier -- the shared read
+// pipeline behind both `source` (push to a peer) and `cmux-sync` (local
+// loop into cmux). Keeping it in one place is what guarantees the two
+// paths filter identically.
+//
+// It returns the cookies that survive both filters (DBSC "shipped"),
+// plus stats for the caller to log however fits its surface. Logging and
+// result-map shaping stay with the caller so each command keeps its own
+// output voice.
+func readFilteredCookies(dbPath string, blocklist *config.Blocklist, key []byte, skipDBSC bool, now time.Time) ([]chrome.Cookie, readStats, error) {
+	all, err := chrome.ReadCookiesForHost(dbPath, "%", key)
+	if err != nil {
+		return nil, readStats{}, fmt.Errorf("read cookies: %w", err)
+	}
+	st := readStats{totalRead: len(all)}
+
+	all, st.droppedHosts = protocol.NewBlocklistMatcher(blocklist).Filter(all)
+	for _, n := range st.droppedHosts {
+		st.totalDropped += n
+	}
+
+	dbscRes := chrome.ClassifyCookies(all, now, skipDBSC)
+	all = dbscRes.Shipped
+	st.dbsc = dbscSummary{
+		warned:  len(dbscRes.Warned),
+		skipped: len(dbscRes.Skipped),
+		sample:  dbscSampleReasons(dbscRes),
+	}
+	return all, st, nil
+}

--- a/internal/cli/cookie_pipeline_test.go
+++ b/internal/cli/cookie_pipeline_test.go
@@ -1,0 +1,46 @@
+package cli
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/mvanhorn/agentcookie/internal/chrome"
+	"github.com/mvanhorn/agentcookie/internal/config"
+)
+
+func TestReadFilteredCookies(t *testing.T) {
+	key := []byte("0123456789abcdef")
+	dbPath := filepath.Join(t.TempDir(), "Cookies")
+	seedSourceCookiesDB(t, dbPath, []chrome.Cookie{
+		{HostKey: ".blocked.com", Name: "b", Value: "1", Path: "/"},
+		{HostKey: ".allowed.com", Name: "a", Value: "2", Path: "/"},
+	}, key)
+
+	t.Run("nil blocklist passes everything", func(t *testing.T) {
+		cookies, st, err := readFilteredCookies(dbPath, nil, key, false, time.Now().UTC())
+		if err != nil {
+			t.Fatalf("readFilteredCookies: %v", err)
+		}
+		if st.totalRead != 2 || len(cookies) != 2 {
+			t.Errorf("got totalRead=%d passing=%d, want 2/2", st.totalRead, len(cookies))
+		}
+		if st.totalDropped != 0 {
+			t.Errorf("totalDropped=%d, want 0", st.totalDropped)
+		}
+	})
+
+	t.Run("blocklist drops the matching host only", func(t *testing.T) {
+		bl := &config.Blocklist{Version: 1, Domains: []config.BlocklistEntry{{Pattern: "%.blocked.com"}}}
+		cookies, st, err := readFilteredCookies(dbPath, bl, key, false, time.Now().UTC())
+		if err != nil {
+			t.Fatalf("readFilteredCookies: %v", err)
+		}
+		if len(cookies) != 1 || cookies[0].HostKey != ".allowed.com" {
+			t.Fatalf("expected only .allowed.com to pass, got %+v", cookies)
+		}
+		if st.totalDropped != 1 {
+			t.Errorf("totalDropped=%d, want 1", st.totalDropped)
+		}
+	})
+}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -245,16 +245,29 @@ func buildReport(d doctorDeps) DoctorReport {
 		})
 	}
 
-	// 10b. cmux delivery -- sink role only. Verifies the opt-in cmux
+	// 10b. cmux delivery (sink surface) -- verifies the opt-in cmux sink
 	// surface can reach cmux, and specifically that socketControlMode is
 	// not the default "cmuxOnly" that would reject the LaunchAgent sink.
 	if sinkCfg != nil {
-		checks = append(checks, checkCmuxDelivery(sinkCfg))
+		checks = append(checks, checkCmuxDelivery(sinkCfg.Cmux, "cmux delivery"))
 	} else {
 		checks = append(checks, Check{
 			Name:     "cmux delivery",
 			Severity: SeveritySkipped,
 			Detail:   "source-only install",
+		})
+	}
+
+	// 10c. cmux local loop (source side) -- verifies `cmux-sync` can reach
+	// cmux when the local loop is configured in source.yaml. Same gate as
+	// the sink surface, surfaced from the machine that runs the loop.
+	if srcCfg != nil {
+		checks = append(checks, checkCmuxDelivery(srcCfg.Cmux, "cmux local loop"))
+	} else {
+		checks = append(checks, Check{
+			Name:     "cmux local loop",
+			Severity: SeveritySkipped,
+			Detail:   "sink-only install",
 		})
 	}
 
@@ -937,55 +950,55 @@ func hostMatchesAnyAdapter(hostKey string, adapters []sinkpush.Adapter) bool {
 // usable: cdp.profile_dir exists and is writable, AND Chrome.app is
 // installed on this Mac. WARN when configured but unusable; SKIPPED
 // when cdp.enabled is false.
-// checkCmuxDelivery reports whether the opt-in cmux cookie-delivery
-// surface can actually reach cmux. The headline failure it catches: the
-// sink is a LaunchAgent, not a cmux child, so cmux's default
-// socketControlMode "cmuxOnly" rejects it and cookies silently never
-// land. WARN (not FAIL) and always non-fatal -- the surface degrades
-// cleanly and the other surfaces are unaffected.
-func checkCmuxDelivery(sinkCfg *config.SinkConfig) Check {
-	return checkCmuxDeliveryWith(sinkCfg, probeCmuxAccessMode)
+// checkCmuxDelivery reports whether an opt-in cmux cookie-delivery path
+// can actually reach cmux. Used for both the sink surface and the
+// source-side local loop (`cmux-sync`); the label distinguishes them.
+// The headline failure it catches: a non-cmux-child caller (the sink
+// LaunchAgent, or a launchd-run local loop) is rejected by cmux's
+// default socketControlMode "cmuxOnly", so cookies silently never land.
+// WARN (not FAIL) and always non-fatal.
+func checkCmuxDelivery(cmux config.CmuxRef, label string) Check {
+	return checkCmuxDeliveryWith(cmux, label, probeCmuxAccessMode)
 }
 
-func checkCmuxDeliveryWith(sinkCfg *config.SinkConfig, probe func(binary string) (string, error)) Check {
-	const name = "cmux delivery"
-	if !sinkCfg.Cmux.Enabled {
+func checkCmuxDeliveryWith(cmux config.CmuxRef, label string, probe func(binary string) (string, error)) Check {
+	if !cmux.Enabled {
 		return Check{
-			Name:     name,
+			Name:     label,
 			Severity: SeveritySkipped,
 			Detail:   "cmux.enabled is false",
 		}
 	}
-	binary := sinkpush.ResolveCmuxBinary(sinkCfg.Cmux.CmuxPath)
+	binary := sinkpush.ResolveCmuxBinary(cmux.CmuxPath)
 	if info, err := os.Stat(binary); err != nil || info.IsDir() {
 		return Check{
-			Name:        name,
+			Name:        label,
 			Severity:    SeverityWarn,
 			Detail:      "cmux.enabled but the cmux CLI was not found at " + binary,
-			Remediation: "install cmux (https://cmux.com), or set cmux.cmux_path in sink.yaml to the CLI location",
+			Remediation: "install cmux (https://cmux.com), or set cmux.cmux_path in your config to the CLI location",
 		}
 	}
 	mode, err := probe(binary)
 	if err != nil {
 		return Check{
-			Name:        name,
+			Name:        label,
 			Severity:    SeverityWarn,
 			Detail:      "cmux is installed but its control socket did not answer (is cmux running?): " + err.Error(),
-			Remediation: "start cmux; if it is already running, its socketControlMode may be blocking the sink -- set automation.socketControlMode to allowAll (or password) in ~/.config/cmux/cmux.json and fully restart cmux",
+			Remediation: "start cmux; if it is already running, its socketControlMode may be blocking a non-cmux-child caller -- set automation.socketControlMode to allowAll (or password) in ~/.config/cmux/cmux.json and fully restart cmux",
 		}
 	}
 	if mode == "cmuxOnly" {
 		return Check{
-			Name:        name,
+			Name:        label,
 			Severity:    SeverityWarn,
-			Detail:      "cmux socketControlMode is \"cmuxOnly\", which rejects the sink (a LaunchAgent, not a cmux child); cookies will not be delivered",
-			Remediation: "set automation.socketControlMode to allowAll (or password) in ~/.config/cmux/cmux.json, then FULLY restart cmux -- the mode is read only at app launch; `cmux reload-config` does not apply it",
+			Detail:      "cmux socketControlMode is \"cmuxOnly\", which rejects a non-cmux-child caller (a LaunchAgent or launchd-run loop); cookies will not be delivered unless the caller runs inside cmux",
+			Remediation: "run from inside cmux, OR set automation.socketControlMode to allowAll (or password) in ~/.config/cmux/cmux.json and FULLY restart cmux -- the mode is read only at app launch; `cmux reload-config` does not apply it",
 		}
 	}
 	return Check{
-		Name:     name,
+		Name:     label,
 		Severity: SeverityOK,
-		Detail:   "cmux installed, socketControlMode=" + mode + "; sink can inject cookies",
+		Detail:   "cmux installed, socketControlMode=" + mode + "; cookies can be injected",
 	}
 }
 

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -245,6 +245,19 @@ func buildReport(d doctorDeps) DoctorReport {
 		})
 	}
 
+	// 10b. cmux delivery -- sink role only. Verifies the opt-in cmux
+	// surface can reach cmux, and specifically that socketControlMode is
+	// not the default "cmuxOnly" that would reject the LaunchAgent sink.
+	if sinkCfg != nil {
+		checks = append(checks, checkCmuxDelivery(sinkCfg))
+	} else {
+		checks = append(checks, Check{
+			Name:     "cmux delivery",
+			Severity: SeveritySkipped,
+			Detail:   "source-only install",
+		})
+	}
+
 	// 11. Secrets bus (v0.13). Reports how many CLIs are registered,
 	// total key count, sealed-vs-plaintext mode, sync freshness.
 	// Reads from the secrets root on whichever machine is running
@@ -924,6 +937,80 @@ func hostMatchesAnyAdapter(hostKey string, adapters []sinkpush.Adapter) bool {
 // usable: cdp.profile_dir exists and is writable, AND Chrome.app is
 // installed on this Mac. WARN when configured but unusable; SKIPPED
 // when cdp.enabled is false.
+// checkCmuxDelivery reports whether the opt-in cmux cookie-delivery
+// surface can actually reach cmux. The headline failure it catches: the
+// sink is a LaunchAgent, not a cmux child, so cmux's default
+// socketControlMode "cmuxOnly" rejects it and cookies silently never
+// land. WARN (not FAIL) and always non-fatal -- the surface degrades
+// cleanly and the other surfaces are unaffected.
+func checkCmuxDelivery(sinkCfg *config.SinkConfig) Check {
+	return checkCmuxDeliveryWith(sinkCfg, probeCmuxAccessMode)
+}
+
+func checkCmuxDeliveryWith(sinkCfg *config.SinkConfig, probe func(binary string) (string, error)) Check {
+	const name = "cmux delivery"
+	if !sinkCfg.Cmux.Enabled {
+		return Check{
+			Name:     name,
+			Severity: SeveritySkipped,
+			Detail:   "cmux.enabled is false",
+		}
+	}
+	binary := sinkpush.ResolveCmuxBinary(sinkCfg.Cmux.CmuxPath)
+	if info, err := os.Stat(binary); err != nil || info.IsDir() {
+		return Check{
+			Name:        name,
+			Severity:    SeverityWarn,
+			Detail:      "cmux.enabled but the cmux CLI was not found at " + binary,
+			Remediation: "install cmux (https://cmux.com), or set cmux.cmux_path in sink.yaml to the CLI location",
+		}
+	}
+	mode, err := probe(binary)
+	if err != nil {
+		return Check{
+			Name:        name,
+			Severity:    SeverityWarn,
+			Detail:      "cmux is installed but its control socket did not answer (is cmux running?): " + err.Error(),
+			Remediation: "start cmux; if it is already running, its socketControlMode may be blocking the sink -- set automation.socketControlMode to allowAll (or password) in ~/.config/cmux/cmux.json and fully restart cmux",
+		}
+	}
+	if mode == "cmuxOnly" {
+		return Check{
+			Name:        name,
+			Severity:    SeverityWarn,
+			Detail:      "cmux socketControlMode is \"cmuxOnly\", which rejects the sink (a LaunchAgent, not a cmux child); cookies will not be delivered",
+			Remediation: "set automation.socketControlMode to allowAll (or password) in ~/.config/cmux/cmux.json, then FULLY restart cmux -- the mode is read only at app launch; `cmux reload-config` does not apply it",
+		}
+	}
+	return Check{
+		Name:     name,
+		Severity: SeverityOK,
+		Detail:   "cmux installed, socketControlMode=" + mode + "; sink can inject cookies",
+	}
+}
+
+// probeCmuxAccessMode runs `cmux capabilities` and returns the server's
+// access_mode (the effective socketControlMode). It reflects the running
+// cmux's configured mode regardless of the caller.
+func probeCmuxAccessMode(binary string) (string, error) {
+	out, err := exec.Command(binary, "capabilities").Output()
+	if err != nil {
+		detail := ""
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			detail = strings.TrimSpace(string(ee.Stderr))
+		}
+		return "", fmt.Errorf("%w (%s)", err, detail)
+	}
+	var caps struct {
+		AccessMode string `json:"access_mode"`
+	}
+	if err := json.Unmarshal(out, &caps); err != nil {
+		return "", fmt.Errorf("parse capabilities: %w", err)
+	}
+	return caps.AccessMode, nil
+}
+
 func checkCDPInjector(sinkCfg *config.SinkConfig) Check {
 	if !sinkCfg.CDP.Enabled {
 		return Check{

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -329,7 +329,7 @@ func TestCheckCmuxDelivery(t *testing.T) {
 
 	t.Run("disabled is skipped", func(t *testing.T) {
 		cfg := &config.SinkConfig{Cmux: config.CmuxRef{Enabled: false}}
-		c := checkCmuxDeliveryWith(cfg, okProbe)
+		c := checkCmuxDeliveryWith(cfg.Cmux, "cmux delivery", okProbe)
 		if c.Severity != SeveritySkipped {
 			t.Fatalf("got %q, want SKIPPED", c.Severity)
 		}
@@ -338,7 +338,7 @@ func TestCheckCmuxDelivery(t *testing.T) {
 	t.Run("enabled but cmux binary missing warns", func(t *testing.T) {
 		missing := filepath.Join(t.TempDir(), "no-cmux")
 		cfg := &config.SinkConfig{Cmux: config.CmuxRef{Enabled: true, CmuxPath: missing}}
-		c := checkCmuxDeliveryWith(cfg, okProbe)
+		c := checkCmuxDeliveryWith(cfg.Cmux, "cmux delivery", okProbe)
 		if c.Severity != SeverityWarn {
 			t.Fatalf("got %q (%q), want WARN", c.Severity, c.Detail)
 		}
@@ -350,7 +350,7 @@ func TestCheckCmuxDelivery(t *testing.T) {
 	t.Run("cmuxOnly mode warns with restart remediation", func(t *testing.T) {
 		bin := writeExecutable(t)
 		cfg := &config.SinkConfig{Cmux: config.CmuxRef{Enabled: true, CmuxPath: bin}}
-		c := checkCmuxDeliveryWith(cfg, cmuxOnlyProbe)
+		c := checkCmuxDeliveryWith(cfg.Cmux, "cmux delivery", cmuxOnlyProbe)
 		if c.Severity != SeverityWarn {
 			t.Fatalf("got %q, want WARN", c.Severity)
 		}
@@ -365,7 +365,7 @@ func TestCheckCmuxDelivery(t *testing.T) {
 	t.Run("unreachable socket warns", func(t *testing.T) {
 		bin := writeExecutable(t)
 		cfg := &config.SinkConfig{Cmux: config.CmuxRef{Enabled: true, CmuxPath: bin}}
-		c := checkCmuxDeliveryWith(cfg, errProbe)
+		c := checkCmuxDeliveryWith(cfg.Cmux, "cmux delivery", errProbe)
 		if c.Severity != SeverityWarn {
 			t.Fatalf("got %q, want WARN", c.Severity)
 		}
@@ -374,7 +374,7 @@ func TestCheckCmuxDelivery(t *testing.T) {
 	t.Run("reachable non-cmuxOnly mode is OK", func(t *testing.T) {
 		bin := writeExecutable(t)
 		cfg := &config.SinkConfig{Cmux: config.CmuxRef{Enabled: true, CmuxPath: bin}}
-		c := checkCmuxDeliveryWith(cfg, okProbe)
+		c := checkCmuxDeliveryWith(cfg.Cmux, "cmux delivery", okProbe)
 		if c.Severity != SeverityOK {
 			t.Fatalf("got %q (%q), want OK", c.Severity, c.Detail)
 		}
@@ -691,8 +691,8 @@ peer:
 	// Universal cookie delivery added the Cookie delivery check. Source browser
 	// adapters added the Source adapter check. The cmux delivery surface added
 	// the cmux delivery check.
-	if got := len(report.Checks); got != 17 {
-		t.Fatalf("got %d checks, want 17", got)
+	if got := len(report.Checks); got != 18 {
+		t.Fatalf("got %d checks, want 18", got)
 	}
 
 	// Serialize the envelope and confirm it round-trips.

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -322,6 +322,77 @@ func TestCheckSealing(t *testing.T) {
 
 // TestCheckCDPInjector covers the v0.12.0-beta.3 CDP-injection check.
 // cdp.enabled=false reports SKIPPED. cdp.enabled=true with a valid
+func TestCheckCmuxDelivery(t *testing.T) {
+	okProbe := func(string) (string, error) { return "allowAll", nil }
+	cmuxOnlyProbe := func(string) (string, error) { return "cmuxOnly", nil }
+	errProbe := func(string) (string, error) { return "", errors.New("broken pipe") }
+
+	t.Run("disabled is skipped", func(t *testing.T) {
+		cfg := &config.SinkConfig{Cmux: config.CmuxRef{Enabled: false}}
+		c := checkCmuxDeliveryWith(cfg, okProbe)
+		if c.Severity != SeveritySkipped {
+			t.Fatalf("got %q, want SKIPPED", c.Severity)
+		}
+	})
+
+	t.Run("enabled but cmux binary missing warns", func(t *testing.T) {
+		missing := filepath.Join(t.TempDir(), "no-cmux")
+		cfg := &config.SinkConfig{Cmux: config.CmuxRef{Enabled: true, CmuxPath: missing}}
+		c := checkCmuxDeliveryWith(cfg, okProbe)
+		if c.Severity != SeverityWarn {
+			t.Fatalf("got %q (%q), want WARN", c.Severity, c.Detail)
+		}
+		if !strings.Contains(c.Detail, "not found") {
+			t.Errorf("detail: %q", c.Detail)
+		}
+	})
+
+	t.Run("cmuxOnly mode warns with restart remediation", func(t *testing.T) {
+		bin := writeExecutable(t)
+		cfg := &config.SinkConfig{Cmux: config.CmuxRef{Enabled: true, CmuxPath: bin}}
+		c := checkCmuxDeliveryWith(cfg, cmuxOnlyProbe)
+		if c.Severity != SeverityWarn {
+			t.Fatalf("got %q, want WARN", c.Severity)
+		}
+		if !strings.Contains(c.Detail, "cmuxOnly") {
+			t.Errorf("detail should name cmuxOnly: %q", c.Detail)
+		}
+		if !strings.Contains(c.Remediation, "socketControlMode") || !strings.Contains(c.Remediation, "restart") {
+			t.Errorf("remediation should mention socketControlMode + restart: %q", c.Remediation)
+		}
+	})
+
+	t.Run("unreachable socket warns", func(t *testing.T) {
+		bin := writeExecutable(t)
+		cfg := &config.SinkConfig{Cmux: config.CmuxRef{Enabled: true, CmuxPath: bin}}
+		c := checkCmuxDeliveryWith(cfg, errProbe)
+		if c.Severity != SeverityWarn {
+			t.Fatalf("got %q, want WARN", c.Severity)
+		}
+	})
+
+	t.Run("reachable non-cmuxOnly mode is OK", func(t *testing.T) {
+		bin := writeExecutable(t)
+		cfg := &config.SinkConfig{Cmux: config.CmuxRef{Enabled: true, CmuxPath: bin}}
+		c := checkCmuxDeliveryWith(cfg, okProbe)
+		if c.Severity != SeverityOK {
+			t.Fatalf("got %q (%q), want OK", c.Severity, c.Detail)
+		}
+		if !strings.Contains(c.Detail, "allowAll") {
+			t.Errorf("detail should report the mode: %q", c.Detail)
+		}
+	})
+}
+
+func writeExecutable(t *testing.T) string {
+	t.Helper()
+	bin := filepath.Join(t.TempDir(), "cmux")
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return bin
+}
+
 // profile dir reports OK when Chrome is found. cdp.enabled=true with
 // no profile dir reports WARN.
 func TestCheckCDPInjector(t *testing.T) {
@@ -618,9 +689,10 @@ peer:
 	// check (source role only; present here since this fixture is source).
 	// The consumption bridge added the Secret coverage + Binary install checks.
 	// Universal cookie delivery added the Cookie delivery check. Source browser
-	// adapters added the Source adapter check.
-	if got := len(report.Checks); got != 16 {
-		t.Fatalf("got %d checks, want 16", got)
+	// adapters added the Source adapter check. The cmux delivery surface added
+	// the cmux delivery check.
+	if got := len(report.Checks); got != 17 {
+		t.Fatalf("got %d checks, want 17", got)
 	}
 
 	// Serialize the envelope and confirm it round-trips.

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -46,7 +46,7 @@ func Execute() {
 	rootCmd.PersistentFlags().StringVar(&common.ConfigDir, "config-dir", defaultConfigDir(), "directory holding source.yaml, sink.yaml, blocklist.yaml")
 	rootCmd.PersistentFlags().BoolVar(&common.JSON, "json", false, "emit machine-readable JSON output where the subcommand supports it")
 
-	rootCmd.AddCommand(sourceCmd, sinkCmd, pairCmd, statusCmd, versionCmd, wizardCmd, doctorCmd, secretCmd, discoverCmd, cookiesCmd, accountsCmd)
+	rootCmd.AddCommand(sourceCmd, sinkCmd, pairCmd, statusCmd, versionCmd, wizardCmd, doctorCmd, secretCmd, discoverCmd, cookiesCmd, accountsCmd, cmuxSyncCmd)
 
 	if err := rootCmd.Execute(); err != nil {
 		// Cobra already prints usage on flag errors; surface RunE errors here.

--- a/internal/cli/sink.go
+++ b/internal/cli/sink.go
@@ -115,6 +115,17 @@ func runSink(cmd *cobra.Command, args []string) error {
 		ListenAddr: cfg.Listen.Addr,
 	}
 
+	// Opt-in cmux delivery surface (sink.yaml `cmux.enabled`). Registered
+	// here, not in sinkpush.init(), because it carries config (binary
+	// path, host filter) the package-load init cannot see. Once
+	// registered it fires after every sync via sinkpush.RunAll alongside
+	// the built-in per-CLI adapters, and shows up in `doctor` and
+	// `wizard verify-adapters` for free.
+	if cfg.Cmux.Enabled {
+		sinkpush.Register(sinkpush.NewCmux(cfg.Cmux.CmuxPath, cfg.Cmux.DomainFilter))
+		fmt.Fprintln(os.Stderr, "agentcookie sink: cmux delivery surface enabled")
+	}
+
 	mux := newSinkMux(cfg, transportSecret, key, seqTracker, stateWriter, sinkState)
 
 	srv := httpserver.Configure(&http.Server{Addr: cfg.Listen.Addr, Handler: mux}, httpserver.SinkSync)

--- a/internal/cli/source.go
+++ b/internal/cli/source.go
@@ -251,31 +251,22 @@ func pushOnce(
 ) (int, dbscSummary, error) {
 	var dbsc dbscSummary
 
-	all, err := chrome.ReadCookiesForHost(cfg.Chrome.DBPath, "%", key)
+	// Shared read pipeline (decrypt -> blocklist -> DBSC). See
+	// readFilteredCookies in cookie_pipeline.go; `source` and `cmux-sync`
+	// both use it so they filter identically.
+	all, st, err := readFilteredCookies(cfg.Chrome.DBPath, blocklist, key, skipDBSC, time.Now().UTC())
 	if err != nil {
-		return 0, dbsc, fmt.Errorf("read cookies: %w", err)
+		return 0, dbsc, err
 	}
-	totalRead := len(all)
-
-	blockMatcher := protocol.NewBlocklistMatcher(blocklist)
-	all, droppedHosts := blockMatcher.Filter(all)
-	totalDropped := 0
-	for _, n := range droppedHosts {
-		totalDropped += n
-	}
+	totalRead := st.totalRead
+	totalDropped := st.totalDropped
+	droppedHosts := st.droppedHosts
+	dbsc = st.dbsc
 	if verbose {
 		fmt.Fprintf(os.Stderr, "agentcookie source: read %d cookies, blocked %d on %d hosts, passing %d\n",
 			totalRead, totalDropped, len(droppedHosts), len(all))
 	}
 
-	// DBSC-suspect pass: flag (and optionally drop) cookies that look
-	// device-bound and would die on the sink. Warn mode (default) is
-	// non-destructive; skip mode drops them. See internal/chrome/dbsc.go.
-	dbscRes := chrome.ClassifyCookies(all, time.Now().UTC(), skipDBSC)
-	all = dbscRes.Shipped
-	dbsc.warned = len(dbscRes.Warned)
-	dbsc.skipped = len(dbscRes.Skipped)
-	dbsc.sample = dbscSampleReasons(dbscRes)
 	// Only print the DBSC detail block under --verbose: in --watch mode this
 	// fires on every cookie change and would flood the LaunchAgent log for
 	// any user with a persistent Google cookie. The durable signal lives in

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -51,7 +51,36 @@ type SinkConfig struct {
 	Security         SecurityRef `yaml:"security,omitempty" json:"security,omitempty"`
 	SkipChromeSQLite bool        `yaml:"skip_chrome_sqlite,omitempty" json:"skip_chrome_sqlite,omitempty"`
 	CDP              CDPRef      `yaml:"cdp,omitempty" json:"cdp,omitempty"`
+	Cmux             CmuxRef     `yaml:"cmux,omitempty" json:"cmux,omitempty"`
 	Delivery         string      `yaml:"delivery,omitempty" json:"delivery,omitempty"`
+}
+
+// CmuxRef configures the cmux cookie-delivery surface (a fourth surface
+// alongside Chrome SQLite, the sidecar, and the per-CLI adapters). When
+// Enabled, the sink injects the synced cookies into cmux's embedded
+// WebKit browser after each /sync via `cmux rpc browser.cookies.set`, so
+// an agent driving cmux's browser wakes up authenticated. cmux holds its
+// own WebKit cookie jar (separate from Chrome's SQLite), so this surface
+// is purely additive.
+//
+// omitempty keeps a pre-cmux sink.yaml valid with the surface off: an
+// absent block decodes to Enabled=false and the sink never touches cmux.
+//
+// NOTE: cmux's RPC socket defaults to socketControlMode "cmuxOnly", which
+// rejects this sink (a LaunchAgent, not a cmux child). `agentcookie
+// doctor` detects that and prints the one-line remediation
+// (socketControlMode allowAll/password in ~/.config/cmux/cmux.json, then
+// a full cmux restart -- the mode is read only at app launch).
+type CmuxRef struct {
+	Enabled bool `yaml:"enabled" json:"enabled"`
+	// CmuxPath overrides the cmux CLI location. Empty uses the
+	// canonical app-bundle path with a PATH fallback (see
+	// internal/sinkpush.NewCmux).
+	CmuxPath string `yaml:"cmux_path,omitempty" json:"cmux_path,omitempty"`
+	// DomainFilter narrows which cookies reach cmux, as SQLite-LIKE
+	// host_key patterns (e.g. "%github.com"). Empty means deliver the
+	// full synced set (after the sink's blocklist filter).
+	DomainFilter []string `yaml:"domain_filter,omitempty" json:"domain_filter,omitempty"`
 }
 
 // CDPRef configures the v0.12.0-beta.3 CDP-injection mode. When Enabled,
@@ -176,6 +205,9 @@ func LoadSink(dir string) (*SinkConfig, error) {
 	}
 	if cfg.Chrome.DBPath == "" {
 		cfg.Chrome.DBPath = DefaultChromeCookiesPath()
+	}
+	if cfg.Cmux.CmuxPath != "" {
+		cfg.Cmux.CmuxPath = ExpandTilde(cfg.Cmux.CmuxPath)
 	}
 	return &cfg, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,6 +24,11 @@ type SourceConfig struct {
 	Browser  BrowserRef  `yaml:"browser,omitempty" json:"browser,omitempty"`
 	Peer     PeerRef     `yaml:"peer,omitempty" json:"peer,omitempty"`
 	Security SecurityRef `yaml:"security,omitempty" json:"security,omitempty"`
+	// Cmux configures the same-machine local loop: `agentcookie cmux-sync`
+	// reads this machine's Chrome and injects into this machine's cmux
+	// browser. Independent of the sink/peer push path; absent = loop off.
+	// Reuses the CmuxRef shape (see SinkConfig.Cmux).
+	Cmux CmuxRef `yaml:"cmux,omitempty" json:"cmux,omitempty"`
 }
 
 // SinkConfig captures the sink machine's settings.
@@ -176,6 +181,9 @@ func LoadSource(dir string) (*SourceConfig, error) {
 		} else {
 			cfg.Chrome.DBPath = DefaultChromeCookiesPath()
 		}
+	}
+	if cfg.Cmux.CmuxPath != "" {
+		cfg.Cmux.CmuxPath = ExpandTilde(cfg.Cmux.CmuxPath)
 	}
 	return &cfg, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -156,7 +156,6 @@ func LoadSource(dir string) (*SourceConfig, error) {
 	if err := loadYAML(path, &cfg); err != nil {
 		return nil, err
 	}
-	cfg.Chrome.DBPath = ExpandTilde(cfg.Chrome.DBPath)
 	if cfg.Sink.URL == "" {
 		return nil, fmt.Errorf("%s: sink.url is required", path)
 	}
@@ -166,16 +165,47 @@ func LoadSource(dir string) (*SourceConfig, error) {
 	if err := validateSharedSecret(path, cfg.Security.SharedSecret); err != nil {
 		return nil, err
 	}
+	if err := resolveSourcePaths(path, &cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+// LoadSourceLocal loads source.yaml for local-only consumers like
+// `cmux-sync`, which read Chrome and act on this machine alone. Unlike
+// LoadSource it does NOT require sink.url or a peer/secret -- the local
+// loop has no push target, so demanding push config would break the
+// documented "no sink, no peer" use case. A missing source.yaml is fine:
+// it yields defaults (default Chrome path, no blocklist, cmux off).
+func LoadSourceLocal(dir string) (*SourceConfig, error) {
+	path := filepath.Join(dir, "source.yaml")
+	var cfg SourceConfig
+	if _, statErr := os.Stat(path); statErr == nil {
+		if err := loadYAML(path, &cfg); err != nil {
+			return nil, err
+		}
+	}
+	if err := resolveSourcePaths(path, &cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+// resolveSourcePaths applies the browser/Chrome-path/cmux-path resolution
+// shared by LoadSource and LoadSourceLocal (everything except the
+// push-only sink/peer/secret validation).
+func resolveSourcePaths(path string, cfg *SourceConfig) error {
+	cfg.Chrome.DBPath = ExpandTilde(cfg.Chrome.DBPath)
 	if cfg.Browser.Name != "" {
 		if _, err := lookupSourceBrowserPath(cfg.Browser.Name); err != nil {
-			return nil, fmt.Errorf("%s: %w", path, err)
+			return fmt.Errorf("%s: %w", path, err)
 		}
 	}
 	if cfg.Chrome.DBPath == "" {
 		if cfg.Browser.Name != "" || cfg.Browser.Profile != "" {
 			dbPath, err := SourceBrowserCookiesPath(cfg.Browser.Name, cfg.Browser.Profile)
 			if err != nil {
-				return nil, fmt.Errorf("%s: %w", path, err)
+				return fmt.Errorf("%s: %w", path, err)
 			}
 			cfg.Chrome.DBPath = dbPath
 		} else {
@@ -185,7 +215,7 @@ func LoadSource(dir string) (*SourceConfig, error) {
 	if cfg.Cmux.CmuxPath != "" {
 		cfg.Cmux.CmuxPath = ExpandTilde(cfg.Cmux.CmuxPath)
 	}
-	return &cfg, nil
+	return nil
 }
 
 // LoadSink reads sink.yaml from dir.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -286,6 +286,55 @@ security:
 	})
 }
 
+func TestLoadSourceLocal(t *testing.T) {
+	t.Run("source.yaml without sink/peer loads for local loop", func(t *testing.T) {
+		// The pure local-loop case: no sink, no peer/secret. LoadSource
+		// would reject this; LoadSourceLocal must accept it.
+		dir := t.TempDir()
+		writeFile(t, dir, "source.yaml", `
+chrome:
+  db_path: ~/cookies/Cookies
+cmux:
+  enabled: true
+`)
+		cfg, err := LoadSourceLocal(dir)
+		if err != nil {
+			t.Fatalf("LoadSourceLocal: %v", err)
+		}
+		if !cfg.Cmux.Enabled {
+			t.Errorf("Cmux.Enabled: got false, want true")
+		}
+		if strings.HasPrefix(cfg.Chrome.DBPath, "~") {
+			t.Errorf("Chrome.DBPath should be tilde-expanded, got %q", cfg.Chrome.DBPath)
+		}
+	})
+
+	t.Run("missing source.yaml yields defaults, no error", func(t *testing.T) {
+		dir := t.TempDir() // empty
+		cfg, err := LoadSourceLocal(dir)
+		if err != nil {
+			t.Fatalf("LoadSourceLocal with no source.yaml: %v", err)
+		}
+		if cfg.Chrome.DBPath == "" {
+			t.Errorf("Chrome.DBPath should default, got empty")
+		}
+		if cfg.Cmux.Enabled {
+			t.Errorf("Cmux should default to disabled")
+		}
+	})
+
+	t.Run("LoadSource still requires sink (regression)", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "source.yaml", `
+chrome:
+  db_path: ~/cookies/Cookies
+`)
+		if _, err := LoadSource(dir); err == nil {
+			t.Fatal("LoadSource should still require sink.url")
+		}
+	})
+}
+
 func TestLoadSourceCmuxLoop(t *testing.T) {
 	t.Run("enabled cmux loop round-trips with tilde-expanded path", func(t *testing.T) {
 		dir := t.TempDir()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -286,6 +286,53 @@ security:
 	})
 }
 
+func TestLoadSourceCmuxLoop(t *testing.T) {
+	t.Run("enabled cmux loop round-trips with tilde-expanded path", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "source.yaml", `
+sink:
+  url: https://100.80.229.80:9999
+security:
+  shared_secret: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+cmux:
+  enabled: true
+  cmux_path: ~/bin/cmux
+  domain_filter:
+    - "%github.com"
+`)
+		cfg, err := LoadSource(dir)
+		if err != nil {
+			t.Fatalf("LoadSource: %v", err)
+		}
+		if !cfg.Cmux.Enabled {
+			t.Errorf("Cmux.Enabled: got false, want true")
+		}
+		if strings.HasPrefix(cfg.Cmux.CmuxPath, "~") {
+			t.Errorf("Cmux.CmuxPath should be tilde-expanded, got %q", cfg.Cmux.CmuxPath)
+		}
+		if len(cfg.Cmux.DomainFilter) != 1 || cfg.Cmux.DomainFilter[0] != "%github.com" {
+			t.Errorf("Cmux.DomainFilter: got %v", cfg.Cmux.DomainFilter)
+		}
+	})
+
+	t.Run("absent cmux block defaults to disabled", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "source.yaml", `
+sink:
+  url: https://100.80.229.80:9999
+security:
+  shared_secret: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+`)
+		cfg, err := LoadSource(dir)
+		if err != nil {
+			t.Fatalf("LoadSource: %v", err)
+		}
+		if cfg.Cmux.Enabled {
+			t.Errorf("Cmux.Enabled: got true, want false (legacy default)")
+		}
+	})
+}
+
 func TestLoadSinkCmuxSurface(t *testing.T) {
 	t.Run("enabled cmux block round-trips with filter and tilde-expanded path", func(t *testing.T) {
 		dir := t.TempDir()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -286,6 +286,72 @@ security:
 	})
 }
 
+func TestLoadSinkCmuxSurface(t *testing.T) {
+	t.Run("enabled cmux block round-trips with filter and tilde-expanded path", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "sink.yaml", `
+listen:
+  addr: 100.80.229.80:9999
+cmux:
+  enabled: true
+  cmux_path: ~/bin/cmux
+  domain_filter:
+    - "%github.com"
+    - "%openai.com"
+security:
+  shared_secret: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+`)
+		cfg, err := LoadSink(dir)
+		if err != nil {
+			t.Fatalf("LoadSink: %v", err)
+		}
+		if !cfg.Cmux.Enabled {
+			t.Errorf("Cmux.Enabled: got false, want true")
+		}
+		if strings.HasPrefix(cfg.Cmux.CmuxPath, "~") {
+			t.Errorf("Cmux.CmuxPath should be tilde-expanded, got %q", cfg.Cmux.CmuxPath)
+		}
+		if len(cfg.Cmux.DomainFilter) != 2 || cfg.Cmux.DomainFilter[0] != "%github.com" {
+			t.Errorf("Cmux.DomainFilter: got %v", cfg.Cmux.DomainFilter)
+		}
+	})
+
+	t.Run("absent cmux block defaults to disabled (no migration)", func(t *testing.T) {
+		// A sink.yaml written before this field must load cleanly with the
+		// surface off -- no silent flip on a binary upgrade.
+		dir := t.TempDir()
+		writeFile(t, dir, "sink.yaml", `
+listen:
+  addr: 100.80.229.80:9999
+security:
+  shared_secret: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+`)
+		cfg, err := LoadSink(dir)
+		if err != nil {
+			t.Fatalf("LoadSink: %v", err)
+		}
+		if cfg.Cmux.Enabled {
+			t.Errorf("Cmux.Enabled: got true, want false (legacy default)")
+		}
+	})
+
+	t.Run("unknown key under cmux is rejected by KnownFields", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "sink.yaml", `
+listen:
+  addr: 100.80.229.80:9999
+cmux:
+  enabled: true
+  bogus_key: nope
+security:
+  shared_secret: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+`)
+		if _, err := LoadSink(dir); err == nil {
+			t.Fatal("expected error for unknown cmux key, got nil")
+		}
+	})
+}
+
 func TestLoadSinkHonorsExplicitListenAddr(t *testing.T) {
 	// Regression for v0.11 -> v0.12: an existing sink.yaml that already
 	// has a 100.x address keeps working without re-detection prompting.

--- a/internal/sinkpush/adapter.go
+++ b/internal/sinkpush/adapter.go
@@ -102,6 +102,16 @@ func (r Result) OK() bool {
 	return r.Err == nil
 }
 
+// FilterByHostPatterns applies the same SQLite-LIKE host filtering that
+// RunAll applies before an adapter's Push. Exported for callers that
+// invoke an adapter's Push directly (e.g. the cmux-sync local loop)
+// rather than through RunAll, so they honor the adapter's
+// CookieHostPatterns identically. An empty patterns slice returns the
+// full set.
+func FilterByHostPatterns(cookies []chrome.Cookie, patterns []string) []chrome.Cookie {
+	return filterByHostPatterns(cookies, patterns)
+}
+
 // filterByHostPatterns returns the subset of cookies whose host_key
 // matches at least one of the patterns. Pattern matching follows
 // SQLite LIKE semantics: '%' matches any sequence; bare hostnames

--- a/internal/sinkpush/adapter_cmux.go
+++ b/internal/sinkpush/adapter_cmux.go
@@ -228,10 +228,13 @@ func isSurfaceError(err error) bool {
 		return false
 	}
 	msg := strings.ToLower(err.Error())
+	// Match only stale/invalid-surface signatures. Deliberately NOT
+	// "not found": Go's exec.LookPath error ("executable file not found
+	// in $PATH") and unrelated OS errors contain that phrase, and would
+	// wrongly trigger the one-time reopen on a genuinely missing cmux.
 	return strings.Contains(msg, "surface") ||
 		strings.Contains(msg, "invalid_params") ||
-		strings.Contains(msg, "not a browser") ||
-		strings.Contains(msg, "not found")
+		strings.Contains(msg, "not a browser")
 }
 
 // execCmux runs a cmux subcommand, returning stdout. A non-zero exit

--- a/internal/sinkpush/adapter_cmux.go
+++ b/internal/sinkpush/adapter_cmux.go
@@ -1,0 +1,253 @@
+package sinkpush
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+	"sync"
+
+	"github.com/mvanhorn/agentcookie/internal/chrome"
+)
+
+// cmuxAppCLI is the canonical cmux CLI path inside a macOS cmux.app
+// install. A standalone install may drop `cmux` on PATH, which NewCmux
+// probes first (mirrors internal/tsclient.FindCLI).
+const cmuxAppCLI = "/Applications/cmux.app/Contents/Resources/bin/cmux"
+
+// chromeEpochOffsetSec is the gap between Chrome's 1601-01-01 epoch and
+// the Unix 1970-01-01 epoch, in seconds. Chrome stores cookie expiry as
+// microseconds since 1601; cmux's RPC wants Unix seconds.
+const chromeEpochOffsetSec = 11644473600
+
+// surfaceRefRE extracts the `surface:N` ref from `cmux browser open`
+// output, e.g. "OK surface=surface:45 pane=pane:32 placement=split".
+var surfaceRefRE = regexp.MustCompile(`surface:\d+`)
+
+// CmuxAdapter delivers synced cookies into cmux's embedded WebKit
+// browser via the cmux control socket, so an agent driving cmux's
+// browser pane wakes up authenticated. It is the fourth delivery
+// surface (alongside Chrome SQLite, the sidecar, and the per-CLI
+// adapters) and fires after every sync through sinkpush.RunAll.
+//
+// Unlike the per-CLI adapters, this surface is opt-in: the sink only
+// registers it when sink.yaml sets `cmux.enabled: true`. It is wired in
+// internal/cli/sink.go at sink startup rather than in init.go, because
+// it carries config (binary path, host filter) that init() cannot see.
+//
+// WebKit cookie semantics (confirmed empirically, differ from Chrome's
+// CDP path):
+//   - Domain is stored VERBATIM. ".example.com" is accepted, so unlike
+//     the CDP injector we do NOT strip the leading dot from host_key.
+//   - browser.cookies.set REQUIRES a browser surface_id; there is no
+//     profile-level set, and browser surfaces are not listed by
+//     surface.list. So the adapter opens its own about:blank surface
+//     (unfocused) and caches it for reuse. Injected cookies persist at
+//     the WKWebsiteDataStore (profile) level, surviving pane close, so
+//     a single injection authenticates the agent's future panes.
+//   - expires is Unix seconds; omit it for session cookies. WebKit
+//     clamps far-future expiries to its ~400-day max (expected).
+//   - Cookie values are passed through VERBATIM. The App-Bound (Chrome
+//     127+) 32-byte prefix is already stripped once on the source side
+//     (internal/chrome/read.go); a second strip silently dropped 64% of
+//     cookies in the v0.12.0-beta.3 dry-run. Never strip again here.
+type CmuxAdapter struct {
+	binary       string
+	domainFilter []string
+
+	mu        sync.Mutex
+	surfaceID string // cached browser surface ref, opened lazily, reused
+
+	// run executes a cmux subcommand and returns stdout. Swappable in
+	// tests; defaults to execCmux.
+	run func(args ...string) (string, error)
+}
+
+// NewCmux returns a cmux delivery adapter. cmuxPath overrides the binary
+// location; empty resolves the canonical app path with a PATH fallback.
+// domainFilter is the set of SQLite-LIKE host_key patterns to deliver
+// (nil/empty = the full synced set).
+func NewCmux(cmuxPath string, domainFilter []string) *CmuxAdapter {
+	a := &CmuxAdapter{binary: ResolveCmuxBinary(cmuxPath), domainFilter: domainFilter}
+	a.run = a.execCmux
+	return a
+}
+
+// ResolveCmuxBinary returns the cmux CLI path to use: the explicit
+// cmuxPath when set, otherwise a `cmux` on PATH, otherwise the canonical
+// app-bundle location. Shared by the adapter and the doctor check.
+func ResolveCmuxBinary(cmuxPath string) string {
+	if cmuxPath != "" {
+		return cmuxPath
+	}
+	if p, err := exec.LookPath("cmux"); err == nil {
+		return p
+	}
+	return cmuxAppCLI
+}
+
+func (a *CmuxAdapter) Name() string { return "cmux" }
+
+func (a *CmuxAdapter) CLIBinary() string { return a.binary }
+
+func (a *CmuxAdapter) IsInstalled() bool {
+	info, err := os.Stat(a.binary)
+	return err == nil && !info.IsDir()
+}
+
+func (a *CmuxAdapter) CookieHostPatterns() []string { return a.domainFilter }
+
+// Push injects each cookie into cmux's WebKit browser via
+// `cmux rpc browser.cookies.set`. It ensures a cached browser surface
+// exists (opening an unfocused about:blank pane on first use), and
+// reopens once if the cached surface has gone away. Errors are returned
+// for RunAll to log; a missing or cmuxOnly-gated cmux is a soft failure
+// that never aborts the sync or the other surfaces.
+func (a *CmuxAdapter) Push(cookies []chrome.Cookie) error {
+	if len(cookies) == 0 {
+		return nil
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if _, err := a.ensureSurfaceLocked(); err != nil {
+		return fmt.Errorf("cmux: open browser surface: %w", err)
+	}
+
+	reopened := false
+	for i, c := range cookies {
+		err := a.setCookieLocked(c)
+		if err == nil {
+			continue
+		}
+		// The cached surface may have been closed by the user between
+		// syncs. Reopen once and retry this cookie before giving up.
+		if !reopened && isSurfaceError(err) {
+			reopened = true
+			a.surfaceID = ""
+			if _, oerr := a.ensureSurfaceLocked(); oerr != nil {
+				return fmt.Errorf("cmux: reopen surface after %v: %w", err, oerr)
+			}
+			if rerr := a.setCookieLocked(c); rerr != nil {
+				return fmt.Errorf("cmux: set cookie %q after reopen: %w", c.Name, rerr)
+			}
+			continue
+		}
+		return fmt.Errorf("cmux: set cookie %q (%d/%d): %w", c.Name, i+1, len(cookies), err)
+	}
+	return nil
+}
+
+// ensureSurfaceLocked returns the cached browser surface ref, opening an
+// unfocused about:blank pane if none is cached. Caller must hold a.mu.
+func (a *CmuxAdapter) ensureSurfaceLocked() (string, error) {
+	if a.surfaceID != "" {
+		return a.surfaceID, nil
+	}
+	out, err := a.run("browser", "open", "about:blank", "--focus", "false")
+	if err != nil {
+		return "", err
+	}
+	sid := surfaceRefRE.FindString(out)
+	if sid == "" {
+		return "", fmt.Errorf("could not parse surface ref from %q", strings.TrimSpace(out))
+	}
+	a.surfaceID = sid
+	return sid, nil
+}
+
+// setCookieLocked sends one cookie to the cached surface. Caller must
+// hold a.mu and have a non-empty a.surfaceID.
+func (a *CmuxAdapter) setCookieLocked(c chrome.Cookie) error {
+	payload, err := cmuxCookieJSON(a.surfaceID, c)
+	if err != nil {
+		return fmt.Errorf("marshal cookie %q: %w", c.Name, err)
+	}
+	_, err = a.run("rpc", "browser.cookies.set", payload)
+	return err
+}
+
+// cmuxCookieJSON builds the browser.cookies.set params for one cookie.
+// Value and domain pass through verbatim (see the CmuxAdapter doc on why
+// no App-Bound re-strip and no leading-dot strip). expires is omitted
+// for session cookies (ExpiresUTC == 0).
+func cmuxCookieJSON(surfaceID string, c chrome.Cookie) (string, error) {
+	path := c.Path
+	if path == "" {
+		path = "/"
+	}
+	m := map[string]any{
+		"surface_id": surfaceID,
+		"name":       c.Name,
+		"value":      c.Value,   // verbatim -- already App-Bound-stripped on the source
+		"domain":     c.HostKey, // verbatim -- WebKit accepts the leading dot
+		"path":       path,
+		"secure":     c.IsSecure == 1,
+		"http_only":  c.IsHTTPOnly == 1,
+	}
+	if ss := cmuxSameSite(c.SameSite); ss != "" {
+		m["same_site"] = ss
+	}
+	if c.ExpiresUTC != 0 {
+		m["expires"] = chromeMicrosToUnixSec(c.ExpiresUTC)
+	}
+	b, err := json.Marshal(m)
+	return string(b), err
+}
+
+// cmuxSameSite maps Chrome's numeric SameSite (cookies.samesite) to the
+// string cmux expects. -1 (unspecified) returns "" so the field is
+// omitted and WebKit applies its default.
+func cmuxSameSite(s int) string {
+	switch s {
+	case 0:
+		return "none"
+	case 1:
+		return "lax"
+	case 2:
+		return "strict"
+	default:
+		return ""
+	}
+}
+
+// chromeMicrosToUnixSec converts Chrome's microseconds-since-1601 expiry
+// to Unix seconds.
+func chromeMicrosToUnixSec(chromeMicrosSince1601 int64) int64 {
+	return chromeMicrosSince1601/1_000_000 - chromeEpochOffsetSec
+}
+
+// isSurfaceError reports whether err looks like a stale/invalid surface
+// (e.g. the user closed the cached pane), which warrants one reopen.
+func isSurfaceError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "surface") ||
+		strings.Contains(msg, "invalid_params") ||
+		strings.Contains(msg, "not a browser") ||
+		strings.Contains(msg, "not found")
+}
+
+// execCmux runs a cmux subcommand, returning stdout. A non-zero exit
+// folds stderr (or stdout, when cmux writes the error there) into the
+// returned error so callers can match on the message.
+func (a *CmuxAdapter) execCmux(args ...string) (string, error) {
+	cmd := exec.Command(a.binary, args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		detail := strings.TrimSpace(stderr.String())
+		if detail == "" {
+			detail = strings.TrimSpace(stdout.String())
+		}
+		return stdout.String(), fmt.Errorf("%w (%s)", err, detail)
+	}
+	return stdout.String(), nil
+}

--- a/internal/sinkpush/adapter_cmux_live_test.go
+++ b/internal/sinkpush/adapter_cmux_live_test.go
@@ -1,0 +1,105 @@
+package sinkpush
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/mvanhorn/agentcookie/internal/chrome"
+)
+
+// TestCmuxLiveInjection drives the real CmuxAdapter against a running
+// cmux. It is opt-in (set AGENTCOOKIE_LIVE_CMUX=1) and must be run from
+// a process started inside cmux, because cmux's default socketControlMode
+// "cmuxOnly" only accepts cmux-child callers -- which is exactly the
+// constraint the sink hits in production (and what the doctor check
+// flags). It uses a throwaway test domain, verifies the injected value
+// round-trips byte-for-byte, and cleans up its own surface and cookies.
+//
+//	AGENTCOOKIE_LIVE_CMUX=1 go test ./internal/sinkpush/ -run TestCmuxLiveInjection -v
+func TestCmuxLiveInjection(t *testing.T) {
+	if os.Getenv("AGENTCOOKIE_LIVE_CMUX") == "" {
+		t.Skip("set AGENTCOOKIE_LIVE_CMUX=1 (and run inside cmux) to exercise the live cmux path")
+	}
+
+	a := NewCmux("", nil)
+	if !a.IsInstalled() {
+		t.Skipf("cmux CLI not found at %s", a.CLIBinary())
+	}
+
+	const (
+		// A scoped subdomain of the IANA example domain: WebKit accepts it
+		// (unlike a bare reserved TLD), and clear-by-url stays narrow to
+		// this host so we never touch unrelated cookies.
+		host    = ".livetest.example.com"
+		url     = "https://livetest.example.com/"
+		longVal = "0123456789abcdef0123456789abcdef" + "LIVE_PAYLOAD_AFTER_32_BYTES"
+	)
+	// ExpiresUTC is Chrome micros-since-1601 for 2027-01-01 (a future
+	// date; WebKit clamps to its ~400-day max but keeps it persistent).
+	const future2027Micros = 13443235200000000
+	cookies := []chrome.Cookie{
+		{HostKey: host, Name: "ac_live_session", Value: longVal, Path: "/", IsSecure: 1, SameSite: 1, ExpiresUTC: future2027Micros},
+		{HostKey: host, Name: "ac_live_temp", Value: "sessioncookie", Path: "/"}, // no expiry -> session
+	}
+
+	if err := a.Push(cookies); err != nil {
+		t.Fatalf("Push to live cmux failed: %v", err)
+	}
+	t.Cleanup(func() {
+		if a.surfaceID == "" {
+			return
+		}
+		_, _ = a.run("browser", "--surface", a.surfaceID, "cookies", "clear", "--url", url)
+		_, _ = a.run("rpc", "surface.close", `{"surface_id":"`+a.surfaceID+`"}`)
+	})
+
+	if a.surfaceID == "" {
+		t.Fatal("adapter did not cache a surface after Push")
+	}
+
+	out, err := a.run("rpc", "browser.cookies.get", `{"surface_id":"`+a.surfaceID+`","url":"`+url+`"}`)
+	if err != nil {
+		t.Fatalf("cookies.get: %v", err)
+	}
+	var got struct {
+		Cookies []struct {
+			Name        string `json:"name"`
+			Value       string `json:"value"`
+			Domain      string `json:"domain"`
+			SessionOnly bool   `json:"session_only"`
+		} `json:"cookies"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("parse cookies.get output %q: %v", out, err)
+	}
+
+	byName := map[string]struct {
+		value       string
+		sessionOnly bool
+	}{}
+	for _, c := range got.Cookies {
+		byName[c.Name] = struct {
+			value       string
+			sessionOnly bool
+		}{c.Value, c.SessionOnly}
+	}
+
+	sess, ok := byName["ac_live_session"]
+	if !ok {
+		t.Fatalf("ac_live_session not found in cmux after injection; got %d cookies for the domain", len(got.Cookies))
+	}
+	if sess.value != longVal {
+		t.Errorf("value not preserved (App-Bound double-strip regression?).\n got: %q\nwant: %q", sess.value, longVal)
+	}
+	if sess.sessionOnly {
+		t.Errorf("ac_live_session had an expiry; should be persistent, got session_only=true")
+	}
+	if temp, ok := byName["ac_live_temp"]; !ok {
+		t.Error("ac_live_temp (session cookie) not found after injection")
+	} else if !temp.sessionOnly {
+		t.Error("ac_live_temp had no expiry; expected session_only=true")
+	}
+
+	t.Logf("live injection OK: %d cookies landed in cmux surface %s, value round-tripped byte-for-byte", len(got.Cookies), a.surfaceID)
+}

--- a/internal/sinkpush/adapter_cmux_test.go
+++ b/internal/sinkpush/adapter_cmux_test.go
@@ -1,0 +1,264 @@
+package sinkpush
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/agentcookie/internal/chrome"
+)
+
+// fakeCmux records the cmux subcommands invoked and returns scripted
+// responses, so adapter tests never shell out to a real cmux.
+type fakeCmux struct {
+	calls    [][]string
+	openOut  string
+	openErr  error
+	setErrs  []error // consumed in order, one per browser.cookies.set call
+	setCalls int
+}
+
+func (f *fakeCmux) run(args ...string) (string, error) {
+	f.calls = append(f.calls, args)
+	if len(args) >= 2 && args[0] == "browser" && args[1] == "open" {
+		if f.openErr != nil {
+			return "", f.openErr
+		}
+		out := f.openOut
+		if out == "" {
+			out = "OK surface=surface:9 pane=pane:1 placement=split"
+		}
+		return out, nil
+	}
+	if len(args) >= 2 && args[0] == "rpc" && args[1] == "browser.cookies.set" {
+		i := f.setCalls
+		f.setCalls++
+		if i < len(f.setErrs) && f.setErrs[i] != nil {
+			return "", f.setErrs[i]
+		}
+		return `{"set":1}`, nil
+	}
+	return "", nil
+}
+
+func newTestCmux(f *fakeCmux, filter []string) *CmuxAdapter {
+	a := &CmuxAdapter{binary: "/fake/cmux", domainFilter: filter}
+	a.run = f.run
+	return a
+}
+
+func TestCmuxAdapter_Identity(t *testing.T) {
+	a := newTestCmux(&fakeCmux{}, []string{"%github.com"})
+	if a.Name() != "cmux" {
+		t.Errorf("Name: got %q, want cmux", a.Name())
+	}
+	if got := a.CookieHostPatterns(); len(got) != 1 || got[0] != "%github.com" {
+		t.Errorf("CookieHostPatterns: got %v", got)
+	}
+}
+
+func TestCmuxCookieJSON_FieldMapping(t *testing.T) {
+	c := chrome.Cookie{
+		HostKey:    ".github.com", // leading dot preserved (WebKit accepts it)
+		Name:       "session",
+		Value:      "abc123",
+		Path:       "/api",
+		IsSecure:   1,
+		IsHTTPOnly: 1,
+		SameSite:   2,                 // strict
+		ExpiresUTC: 13390000000000000, // micros since 1601
+	}
+	raw, err := cmuxCookieJSON("surface:9", c)
+	if err != nil {
+		t.Fatalf("cmuxCookieJSON: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(raw), &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if m["surface_id"] != "surface:9" {
+		t.Errorf("surface_id: got %v", m["surface_id"])
+	}
+	if m["domain"] != ".github.com" {
+		t.Errorf("domain should be verbatim with leading dot, got %v", m["domain"])
+	}
+	if m["name"] != "session" || m["value"] != "abc123" {
+		t.Errorf("name/value: got %v / %v", m["name"], m["value"])
+	}
+	if m["path"] != "/api" {
+		t.Errorf("path: got %v", m["path"])
+	}
+	if m["secure"] != true || m["http_only"] != true {
+		t.Errorf("secure/http_only: got %v / %v", m["secure"], m["http_only"])
+	}
+	if m["same_site"] != "strict" {
+		t.Errorf("same_site: got %v, want strict", m["same_site"])
+	}
+	if _, ok := m["expires"]; !ok {
+		t.Errorf("expires should be present for a persistent cookie")
+	}
+}
+
+func TestCmuxCookieJSON_SessionCookieOmitsExpires(t *testing.T) {
+	c := chrome.Cookie{HostKey: "example.com", Name: "s", Value: "v", ExpiresUTC: 0}
+	raw, _ := cmuxCookieJSON("surface:1", c)
+	var m map[string]any
+	_ = json.Unmarshal([]byte(raw), &m)
+	if _, ok := m["expires"]; ok {
+		t.Errorf("session cookie (ExpiresUTC==0) must omit expires, got %v", m["expires"])
+	}
+	if m["path"] != "/" {
+		t.Errorf("empty path should default to /, got %v", m["path"])
+	}
+}
+
+func TestCmuxCookieJSON_ValuePassthroughNoSecondStrip(t *testing.T) {
+	// Regression guard: the App-Bound prefix is stripped once on the
+	// source side. A second strip here lopped 32 bytes off every cookie
+	// longer than the prefix (the v0.12.0-beta.3 64% drop). The value
+	// must arrive byte-identical.
+	val := strings.Repeat("A", 32) + "REAL_SESSION_PAYLOAD"
+	c := chrome.Cookie{HostKey: ".x.com", Name: "k", Value: val}
+	raw, _ := cmuxCookieJSON("surface:1", c)
+	var m map[string]any
+	_ = json.Unmarshal([]byte(raw), &m)
+	if m["value"] != val {
+		t.Errorf("value was altered.\n got: %q\nwant: %q", m["value"], val)
+	}
+}
+
+func TestCmuxSameSite(t *testing.T) {
+	cases := []struct {
+		in   int
+		want string
+	}{
+		{0, "none"},
+		{1, "lax"},
+		{2, "strict"},
+		{-1, ""}, // unspecified -> omitted
+		{99, ""}, // unknown -> omitted
+	}
+	for _, tc := range cases {
+		if got := cmuxSameSite(tc.in); got != tc.want {
+			t.Errorf("cmuxSameSite(%d): got %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestChromeMicrosToUnixSec(t *testing.T) {
+	// 13390000000000000 micros / 1e6 = 13390000000 sec since 1601;
+	// minus the 11644473600 offset = 1745526400 unix sec.
+	if got := chromeMicrosToUnixSec(13390000000000000); got != 1745526400 {
+		t.Errorf("chromeMicrosToUnixSec: got %d, want 1745526400", got)
+	}
+}
+
+func TestCmuxPush_OpensSurfaceThenSetsEach(t *testing.T) {
+	f := &fakeCmux{}
+	a := newTestCmux(f, nil)
+	cookies := []chrome.Cookie{
+		{HostKey: ".github.com", Name: "a", Value: "1"},
+		{HostKey: ".github.com", Name: "b", Value: "2"},
+	}
+	if err := a.Push(cookies); err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	// One open, two sets.
+	if f.calls[0][0] != "browser" || f.calls[0][1] != "open" {
+		t.Errorf("first call should open a surface, got %v", f.calls[0])
+	}
+	if f.setCalls != 2 {
+		t.Errorf("expected 2 cookies.set calls, got %d", f.setCalls)
+	}
+	// Surface is cached: a second Push reuses it (no new open).
+	opensBefore := countOpens(f.calls)
+	if err := a.Push(cookies[:1]); err != nil {
+		t.Fatalf("second Push: %v", err)
+	}
+	if countOpens(f.calls) != opensBefore {
+		t.Errorf("second Push should reuse cached surface, opened again")
+	}
+}
+
+func TestCmuxPush_ReopensOnSurfaceError(t *testing.T) {
+	f := &fakeCmux{
+		// First set fails with a surface error; after reopen the retry
+		// (and subsequent sets) succeed.
+		setErrs: []error{errors.New("invalid_params: Surface is not a browser")},
+	}
+	a := newTestCmux(f, nil)
+	// Prime a stale cached surface so Push starts with one and the first
+	// set hits the stale-surface path.
+	a.surfaceID = "surface:stale"
+	cookies := []chrome.Cookie{{HostKey: ".x.com", Name: "a", Value: "1"}}
+	if err := a.Push(cookies); err != nil {
+		t.Fatalf("Push should recover by reopening, got %v", err)
+	}
+	if countOpens(f.calls) != 1 {
+		t.Errorf("expected exactly one reopen, got %d", countOpens(f.calls))
+	}
+}
+
+func TestCmuxPush_NonSurfaceErrorFailsSoft(t *testing.T) {
+	// A cmuxOnly access-denied (or any non-surface error that does not
+	// match the reopen heuristic) propagates so RunAll records FAIL.
+	f := &fakeCmux{setErrs: []error{errors.New("connection refused")}}
+	a := newTestCmux(f, nil)
+	err := a.Push([]chrome.Cookie{{HostKey: ".x.com", Name: "a", Value: "1"}})
+	if err == nil {
+		t.Fatal("expected Push to return the underlying error")
+	}
+	if !strings.Contains(err.Error(), "connection refused") {
+		t.Errorf("error should carry the cause, got %v", err)
+	}
+}
+
+func TestCmuxPush_EmptyIsNoop(t *testing.T) {
+	f := &fakeCmux{}
+	a := newTestCmux(f, nil)
+	if err := a.Push(nil); err != nil {
+		t.Fatalf("Push(nil): %v", err)
+	}
+	if len(f.calls) != 0 {
+		t.Errorf("empty Push should not open a surface or set cookies, got %v", f.calls)
+	}
+}
+
+func TestCmuxIsInstalled(t *testing.T) {
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "cmux")
+	a := &CmuxAdapter{binary: bin}
+	if a.IsInstalled() {
+		t.Error("IsInstalled should be false before the binary exists")
+	}
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if !a.IsInstalled() {
+		t.Error("IsInstalled should be true once the binary exists")
+	}
+}
+
+func TestNewCmux_DefaultBinaryFallback(t *testing.T) {
+	a := NewCmux("", nil)
+	if a.binary == "" {
+		t.Error("NewCmux with empty path should resolve a binary")
+	}
+	a2 := NewCmux("/custom/cmux", []string{"%x"})
+	if a2.binary != "/custom/cmux" {
+		t.Errorf("NewCmux should honor explicit path, got %q", a2.binary)
+	}
+}
+
+func countOpens(calls [][]string) int {
+	n := 0
+	for _, c := range calls {
+		if len(c) >= 2 && c[0] == "browser" && c[1] == "open" {
+			n++
+		}
+	}
+	return n
+}

--- a/internal/sinkpush/adapter_cmux_test.go
+++ b/internal/sinkpush/adapter_cmux_test.go
@@ -253,6 +253,21 @@ func TestNewCmux_DefaultBinaryFallback(t *testing.T) {
 	}
 }
 
+func TestFilterByHostPatterns(t *testing.T) {
+	cookies := []chrome.Cookie{
+		{HostKey: ".github.com", Name: "a"},
+		{HostKey: ".openai.com", Name: "b"},
+		{HostKey: "www.example.com", Name: "c"},
+	}
+	if got := FilterByHostPatterns(cookies, nil); len(got) != 3 {
+		t.Errorf("nil patterns should pass all, got %d", len(got))
+	}
+	got := FilterByHostPatterns(cookies, []string{"%github.com"})
+	if len(got) != 1 || got[0].HostKey != ".github.com" {
+		t.Errorf("expected only github, got %+v", got)
+	}
+}
+
 func countOpens(calls [][]string) int {
 	n := 0
 	for _, c := range calls {

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -52,6 +52,18 @@ type Config struct {
 	// BaselineTick: even with no fs events, run a push every BaselineTick.
 	// Defends against fsnotify event loss on macOS. Defaults to 30s.
 	BaselineTick time.Duration
+
+	// LogLabel prefixes the watcher's stderr lines so they name the command
+	// that owns the loop. Defaults to "agentcookie source --watch". The
+	// cmux-sync local loop passes its own label so logs aren't mislabeled.
+	LogLabel string
+}
+
+func (c Config) logLabel() string {
+	if c.LogLabel != "" {
+		return c.LogLabel
+	}
+	return "agentcookie source --watch"
 }
 
 func (c Config) debounce() time.Duration {
@@ -120,14 +132,14 @@ func (w *Watcher) Run(ctx context.Context) error {
 	if w.cfg.LocalStorageDir != "" {
 		if _, err := os.Stat(w.cfg.LocalStorageDir); err == nil {
 			if err := fsw.Add(w.cfg.LocalStorageDir); err != nil {
-				fmt.Fprintf(os.Stderr, "agentcookie source --watch: localStorage watch failed (%v); continuing without it\n", err)
+				fmt.Fprintf(os.Stderr, w.cfg.logLabel()+": localStorage watch failed (%v); continuing without it\n", err)
 			}
 		}
 	}
 	if w.cfg.IndexedDBDir != "" {
 		if _, err := os.Stat(w.cfg.IndexedDBDir); err == nil {
 			if err := fsw.Add(w.cfg.IndexedDBDir); err != nil {
-				fmt.Fprintf(os.Stderr, "agentcookie source --watch: indexedDB watch failed (%v); continuing without it\n", err)
+				fmt.Fprintf(os.Stderr, w.cfg.logLabel()+": indexedDB watch failed (%v); continuing without it\n", err)
 			}
 		}
 	}
@@ -174,7 +186,7 @@ func (w *Watcher) Run(ctx context.Context) error {
 			if !ok {
 				return nil
 			}
-			fmt.Fprintf(os.Stderr, "agentcookie source --watch: fsnotify error: %v\n", err)
+			fmt.Fprintf(os.Stderr, w.cfg.logLabel()+": fsnotify error: %v\n", err)
 
 		case <-debounceTimer.C:
 			pendingEvent = false
@@ -237,12 +249,12 @@ func (w *Watcher) runOne(ctx context.Context, reason string) {
 	if err != nil {
 		w.lastErr = fmt.Errorf("%s: %w", reason, err)
 		w.errorCount++
-		fmt.Fprintf(os.Stderr, "agentcookie source --watch: push (%s) failed: %v\n", reason, err)
+		fmt.Fprintf(os.Stderr, w.cfg.logLabel()+": push (%s) failed: %v\n", reason, err)
 		return
 	}
 	w.pushCount++
 	if n > 0 {
-		fmt.Fprintf(os.Stderr, "agentcookie source --watch: pushed %d cookies (%s)\n", n, reason)
+		fmt.Fprintf(os.Stderr, w.cfg.logLabel()+": pushed %d cookies (%s)\n", n, reason)
 	}
 }
 

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -209,6 +209,15 @@ func TestWatcherIgnoresUnrelatedFiles(t *testing.T) {
 	}
 }
 
+func TestConfigLogLabel(t *testing.T) {
+	if got := (Config{}).logLabel(); got != "agentcookie source --watch" {
+		t.Errorf("default logLabel = %q, want source --watch default", got)
+	}
+	if got := (Config{LogLabel: "agentcookie cmux-sync --watch"}).logLabel(); got != "agentcookie cmux-sync --watch" {
+		t.Errorf("override logLabel = %q", got)
+	}
+}
+
 func TestIsInterestingCoversWALCompanions(t *testing.T) {
 	w := &Watcher{cfg: Config{CookiesPath: "/tmp/Cookies"}}
 	cases := map[string]bool{


### PR DESCRIPTION
Gets your Chrome logins into cmux's browser so an agent driving cmux wakes up authenticated. cmux ships its own Apple WebKit browser with a cookie jar separate from Chrome's, so it needs its own delivery path.

Two ways in, sharing one injection adapter:

## Local loop (the common case) — `agentcookie cmux-sync`
Same machine: this Mac's Chrome -> this Mac's cmux. No sink, no peer, no Tailscale.
- `cmux-sync --once` (one read+inject) / `--watch` (re-inject on every Chrome cookie change, fsnotify).
- Reuses `source.yaml`'s Chrome path + blocklist and the shared decrypt+DBSC read pipeline; `cmux:` config block + `--domain`/`--cmux-path`/`--browser` flags.
- Run it from inside cmux and it passes the default `cmuxOnly` socket gate with **no cmux change**.

## Sink surface (two-machine model)
A fourth sink delivery surface (`sinkpush.Adapter`) that injects the synced session into the sink's cmux after every sync, alongside Chrome SQLite / sidecar / per-CLI adapters. Opt-in via `cmux.enabled` in `sink.yaml`.

## Shared internals
- `CmuxAdapter` over `cmux rpc browser.cookies.set`. WebKit semantics confirmed live: domain stored verbatim (keep the leading dot, unlike CDP); cookie value passthrough (no second App-Bound strip — regression-guards the old 64% drop); `browser.cookies.set` needs a surface, so the adapter opens/reuses one unfocused `about:blank` pane, and injected cookies persist profile-wide.
- `agentcookie doctor` reports both the sink surface and the source-side local loop, and prints the exact `socketControlMode` + restart remediation for the `cmuxOnly` gate.

## Verified live
`cmux-sync --once` read 8131 Chrome cookies, injected the Amazon session into cmux, and the pane rendered "Hello, Matt". Opt-in live integration test included (`AGENTCOOKIE_LIVE_CMUX=1`).

## Notes
- Cookies only; DBSC/fingerprint sessions (Google/Workspace) and WebKit ITP may still need a one-time in-pane sign-in.
- Run the installed signed binary so reading Chrome's Safe Storage key doesn't prompt (the grant is per-binary; `go run` prompts each build).

Design docs: `docs/plans/2026-06-03-001-...` (delivery surface) and `docs/plans/2026-06-03-002-feat-cmux-local-loop-plan.md` (local loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)