### PR TITLE
chore: require go 1.26.4 for stdlib security fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mvanhorn/agentcookie
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/chromedp/cdproto v0.0.0-20260321001828-e3e3800016bc


### PR DESCRIPTION
Bumps the `go` directive from 1.26.3 to 1.26.4.

go1.26.4 patches two standard-library vulnerabilities govulncheck currently flags on every PR:
- GO-2026-5039 — net/textproto (unescaped input in errors)
- GO-2026-5037 — crypto/x509 (inefficient hostname parsing)

CI installs Go from `go-version-file: go.mod`, so this one-line change makes the build use the patched stdlib and clears govulncheck. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)