### PR TITLE
feat(cmux): batched, resilient cookie injection for full-set sync

### DIFF
--- a/internal/sinkpush/adapter_cmux.go
+++ b/internal/sinkpush/adapter_cmux.go
@@ -138,10 +138,7 @@ func (a *CmuxAdapter) Push(cookies []chrome.Cookie) error {
 	// ARG_MAX (~1MB); cmuxCookieBatch keeps each call well under that.
 	reopened := false
 	for start := 0; start < len(cookies); start += cmuxCookieBatch {
-		end := start + cmuxCookieBatch
-		if end > len(cookies) {
-			end = len(cookies)
-		}
+		end := min(start+cmuxCookieBatch, len(cookies))
 		chunk := cookies[start:end]
 		err := a.setCookiesLocked(chunk)
 		if err == nil {
@@ -161,24 +158,25 @@ func (a *CmuxAdapter) Push(cookies []chrome.Cookie) error {
 				err = rerr
 			}
 		}
-		// cmux unreachable (down / cmuxOnly-gated) is a hard failure -- the
-		// whole loop can't deliver, so surface it.
-		if isCmuxUnavailable(err) {
+		// Hard-fail (do not silently drop the chunk) when cmux is unreachable
+		// (down / cmuxOnly-gated) OR the error is still surface-related after
+		// the one reopen attempt -- a reopen that didn't fix it won't be fixed
+		// per-cookie either, and silently skipping would lose the whole chunk.
+		if isCmuxUnavailable(err) || isSurfaceError(err) {
 			return fmt.Errorf("cmux: set cookies [%d:%d] of %d: %w", start, end, len(cookies), err)
 		}
 		// Otherwise one cookie in the chunk is rejected by cmux (e.g. a
 		// payload WebKit won't accept). Fall back to per-cookie so the rest
-		// of the chunk still lands; skip the individual rejects. A
-		// cmux-unavailable error mid-fallback still hard-fails.
+		// of the chunk still lands; skip only the genuine individual rejects.
+		// A cmux-unavailable or surface error mid-fallback still hard-fails.
 		for _, c := range chunk {
 			if e := a.setCookiesLocked([]chrome.Cookie{c}); e != nil {
-				if isCmuxUnavailable(e) {
+				if isCmuxUnavailable(e) || isSurfaceError(e) {
 					return fmt.Errorf("cmux: set cookie %q: %w", c.Name, e)
 				}
-				// individual reject: skip it, keep going
+				// individual payload reject: skip it, keep going
 			}
 		}
-		continue
 	}
 	return nil
 }
@@ -309,6 +307,7 @@ func isCmuxUnavailable(err error) bool {
 	return strings.Contains(msg, "broken pipe") ||
 		strings.Contains(msg, "connection refused") ||
 		strings.Contains(msg, "access denied") ||
+		strings.Contains(msg, "permission denied") || // EACCES (unexecutable cmux mid-run)
 		strings.Contains(msg, "only processes started inside cmux") ||
 		strings.Contains(msg, "cmuxonly")
 }

--- a/internal/sinkpush/adapter_cmux.go
+++ b/internal/sinkpush/adapter_cmux.go
@@ -111,6 +111,20 @@ func (a *CmuxAdapter) Push(cookies []chrome.Cookie) error {
 		return nil
 	}
 
+	// Drop RFC-invalid cookies up front (the same gate RunAll applies before
+	// an adapter's Push). cmux-sync calls Push directly, bypassing RunAll, so
+	// without this a malformed cookie would fail a whole batch.
+	valid := make([]chrome.Cookie, 0, len(cookies))
+	for _, c := range cookies {
+		if Validate(c) == nil {
+			valid = append(valid, c)
+		}
+	}
+	cookies = valid
+	if len(cookies) == 0 {
+		return nil
+	}
+
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
@@ -118,26 +132,53 @@ func (a *CmuxAdapter) Push(cookies []chrome.Cookie) error {
 		return fmt.Errorf("cmux: open browser surface: %w", err)
 	}
 
+	// Inject in batches: browser.cookies.set accepts a cookies array, so a
+	// full Chrome cookie set lands in a handful of RPC calls instead of one
+	// per cookie. Chunked because the JSON params ride a CLI arg bounded by
+	// ARG_MAX (~1MB); cmuxCookieBatch keeps each call well under that.
 	reopened := false
-	for i, c := range cookies {
-		err := a.setCookieLocked(c)
+	for start := 0; start < len(cookies); start += cmuxCookieBatch {
+		end := start + cmuxCookieBatch
+		if end > len(cookies) {
+			end = len(cookies)
+		}
+		chunk := cookies[start:end]
+		err := a.setCookiesLocked(chunk)
 		if err == nil {
 			continue
 		}
-		// The cached surface may have been closed by the user between
-		// syncs. Reopen once and retry this cookie before giving up.
+		// The cached surface may have been closed between syncs. Reopen
+		// once and retry this chunk before giving up.
 		if !reopened && isSurfaceError(err) {
 			reopened = true
 			a.surfaceID = ""
 			if _, oerr := a.ensureSurfaceLocked(); oerr != nil {
 				return fmt.Errorf("cmux: reopen surface after %v: %w", err, oerr)
 			}
-			if rerr := a.setCookieLocked(c); rerr != nil {
-				return fmt.Errorf("cmux: set cookie %q after reopen: %w", c.Name, rerr)
+			if rerr := a.setCookiesLocked(chunk); rerr == nil {
+				continue
+			} else {
+				err = rerr
 			}
-			continue
 		}
-		return fmt.Errorf("cmux: set cookie %q (%d/%d): %w", c.Name, i+1, len(cookies), err)
+		// cmux unreachable (down / cmuxOnly-gated) is a hard failure -- the
+		// whole loop can't deliver, so surface it.
+		if isCmuxUnavailable(err) {
+			return fmt.Errorf("cmux: set cookies [%d:%d] of %d: %w", start, end, len(cookies), err)
+		}
+		// Otherwise one cookie in the chunk is rejected by cmux (e.g. a
+		// payload WebKit won't accept). Fall back to per-cookie so the rest
+		// of the chunk still lands; skip the individual rejects. A
+		// cmux-unavailable error mid-fallback still hard-fails.
+		for _, c := range chunk {
+			if e := a.setCookiesLocked([]chrome.Cookie{c}); e != nil {
+				if isCmuxUnavailable(e) {
+					return fmt.Errorf("cmux: set cookie %q: %w", c.Name, e)
+				}
+				// individual reject: skip it, keep going
+			}
+		}
+		continue
 	}
 	return nil
 }
@@ -160,34 +201,55 @@ func (a *CmuxAdapter) ensureSurfaceLocked() (string, error) {
 	return sid, nil
 }
 
-// setCookieLocked sends one cookie to the cached surface. Caller must
-// hold a.mu and have a non-empty a.surfaceID.
-func (a *CmuxAdapter) setCookieLocked(c chrome.Cookie) error {
-	payload, err := cmuxCookieJSON(a.surfaceID, c)
+// cmuxCookieBatch caps how many cookies ride one browser.cookies.set
+// call. The params travel as a CLI arg bounded by ARG_MAX (~1MB on
+// macOS); at a few hundred bytes per cookie, 200 keeps each call well
+// under that with comfortable headroom.
+const cmuxCookieBatch = 200
+
+// setCookiesLocked sends a batch of cookies to the cached surface in one
+// browser.cookies.set call. Caller must hold a.mu and have a non-empty
+// a.surfaceID.
+func (a *CmuxAdapter) setCookiesLocked(cookies []chrome.Cookie) error {
+	payload, err := cmuxCookiesJSON(a.surfaceID, cookies)
 	if err != nil {
-		return fmt.Errorf("marshal cookie %q: %w", c.Name, err)
+		return fmt.Errorf("marshal %d cookies: %w", len(cookies), err)
 	}
 	_, err = a.run("rpc", "browser.cookies.set", payload)
 	return err
 }
 
-// cmuxCookieJSON builds the browser.cookies.set params for one cookie.
-// Value and domain pass through verbatim (see the CmuxAdapter doc on why
-// no App-Bound re-strip and no leading-dot strip). expires is omitted
-// for session cookies (ExpiresUTC == 0).
-func cmuxCookieJSON(surfaceID string, c chrome.Cookie) (string, error) {
+// cmuxCookiesJSON builds browser.cookies.set params for a batch of
+// cookies: {"surface_id":..., "cookies":[...]}.
+func cmuxCookiesJSON(surfaceID string, cookies []chrome.Cookie) (string, error) {
+	params := make([]map[string]any, 0, len(cookies))
+	for _, c := range cookies {
+		params = append(params, cmuxCookieParam(c))
+	}
+	m := map[string]any{
+		"surface_id": surfaceID,
+		"cookies":    params,
+	}
+	b, err := json.Marshal(m)
+	return string(b), err
+}
+
+// cmuxCookieParam builds one cookie's params. Value and domain pass
+// through verbatim (see the CmuxAdapter doc on why no App-Bound re-strip
+// and no leading-dot strip). expires is omitted for session cookies
+// (ExpiresUTC == 0).
+func cmuxCookieParam(c chrome.Cookie) map[string]any {
 	path := c.Path
 	if path == "" {
 		path = "/"
 	}
 	m := map[string]any{
-		"surface_id": surfaceID,
-		"name":       c.Name,
-		"value":      c.Value,   // verbatim -- already App-Bound-stripped on the source
-		"domain":     c.HostKey, // verbatim -- WebKit accepts the leading dot
-		"path":       path,
-		"secure":     c.IsSecure == 1,
-		"http_only":  c.IsHTTPOnly == 1,
+		"name":      c.Name,
+		"value":     c.Value,   // verbatim -- already App-Bound-stripped on the source
+		"domain":    c.HostKey, // verbatim -- WebKit accepts the leading dot
+		"path":      path,
+		"secure":    c.IsSecure == 1,
+		"http_only": c.IsHTTPOnly == 1,
 	}
 	if ss := cmuxSameSite(c.SameSite); ss != "" {
 		m["same_site"] = ss
@@ -195,8 +257,7 @@ func cmuxCookieJSON(surfaceID string, c chrome.Cookie) (string, error) {
 	if c.ExpiresUTC != 0 {
 		m["expires"] = chromeMicrosToUnixSec(c.ExpiresUTC)
 	}
-	b, err := json.Marshal(m)
-	return string(b), err
+	return m
 }
 
 // cmuxSameSite maps Chrome's numeric SameSite (cookies.samesite) to the
@@ -229,12 +290,27 @@ func isSurfaceError(err error) bool {
 	}
 	msg := strings.ToLower(err.Error())
 	// Match only stale/invalid-surface signatures. Deliberately NOT
-	// "not found": Go's exec.LookPath error ("executable file not found
-	// in $PATH") and unrelated OS errors contain that phrase, and would
-	// wrongly trigger the one-time reopen on a genuinely missing cmux.
+	// "invalid_params" (cmux returns "invalid_params: Invalid cookie
+	// payload" for a bad cookie, which is not a surface problem) and NOT
+	// "not found" (Go's exec.LookPath error contains it).
 	return strings.Contains(msg, "surface") ||
-		strings.Contains(msg, "invalid_params") ||
 		strings.Contains(msg, "not a browser")
+}
+
+// isCmuxUnavailable reports whether err means cmux itself can't be
+// reached (down, or socketControlMode gating a non-cmux-child caller) --
+// a hard failure for the whole push, as opposed to a single rejected
+// cookie which can be skipped.
+func isCmuxUnavailable(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "broken pipe") ||
+		strings.Contains(msg, "connection refused") ||
+		strings.Contains(msg, "access denied") ||
+		strings.Contains(msg, "only processes started inside cmux") ||
+		strings.Contains(msg, "cmuxonly")
 }
 
 // execCmux runs a cmux subcommand, returning stdout. A non-zero exit

--- a/internal/sinkpush/adapter_cmux_test.go
+++ b/internal/sinkpush/adapter_cmux_test.go
@@ -71,17 +71,7 @@ func TestCmuxCookieJSON_FieldMapping(t *testing.T) {
 		SameSite:   2,                 // strict
 		ExpiresUTC: 13390000000000000, // micros since 1601
 	}
-	raw, err := cmuxCookieJSON("surface:9", c)
-	if err != nil {
-		t.Fatalf("cmuxCookieJSON: %v", err)
-	}
-	var m map[string]any
-	if err := json.Unmarshal([]byte(raw), &m); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	if m["surface_id"] != "surface:9" {
-		t.Errorf("surface_id: got %v", m["surface_id"])
-	}
+	m := cmuxCookieParam(c)
 	if m["domain"] != ".github.com" {
 		t.Errorf("domain should be verbatim with leading dot, got %v", m["domain"])
 	}
@@ -100,13 +90,27 @@ func TestCmuxCookieJSON_FieldMapping(t *testing.T) {
 	if _, ok := m["expires"]; !ok {
 		t.Errorf("expires should be present for a persistent cookie")
 	}
+
+	// The batch envelope wraps per-cookie params with the surface id.
+	raw, err := cmuxCookiesJSON("surface:9", []chrome.Cookie{c, c})
+	if err != nil {
+		t.Fatalf("cmuxCookiesJSON: %v", err)
+	}
+	var env struct {
+		SurfaceID string           `json:"surface_id"`
+		Cookies   []map[string]any `json:"cookies"`
+	}
+	if err := json.Unmarshal([]byte(raw), &env); err != nil {
+		t.Fatalf("unmarshal envelope: %v", err)
+	}
+	if env.SurfaceID != "surface:9" || len(env.Cookies) != 2 {
+		t.Errorf("envelope: surface_id=%q cookies=%d, want surface:9 / 2", env.SurfaceID, len(env.Cookies))
+	}
 }
 
-func TestCmuxCookieJSON_SessionCookieOmitsExpires(t *testing.T) {
+func TestCmuxCookieParam_SessionCookieOmitsExpires(t *testing.T) {
 	c := chrome.Cookie{HostKey: "example.com", Name: "s", Value: "v", ExpiresUTC: 0}
-	raw, _ := cmuxCookieJSON("surface:1", c)
-	var m map[string]any
-	_ = json.Unmarshal([]byte(raw), &m)
+	m := cmuxCookieParam(c)
 	if _, ok := m["expires"]; ok {
 		t.Errorf("session cookie (ExpiresUTC==0) must omit expires, got %v", m["expires"])
 	}
@@ -115,16 +119,14 @@ func TestCmuxCookieJSON_SessionCookieOmitsExpires(t *testing.T) {
 	}
 }
 
-func TestCmuxCookieJSON_ValuePassthroughNoSecondStrip(t *testing.T) {
+func TestCmuxCookieParam_ValuePassthroughNoSecondStrip(t *testing.T) {
 	// Regression guard: the App-Bound prefix is stripped once on the
 	// source side. A second strip here lopped 32 bytes off every cookie
 	// longer than the prefix (the v0.12.0-beta.3 64% drop). The value
 	// must arrive byte-identical.
 	val := strings.Repeat("A", 32) + "REAL_SESSION_PAYLOAD"
 	c := chrome.Cookie{HostKey: ".x.com", Name: "k", Value: val}
-	raw, _ := cmuxCookieJSON("surface:1", c)
-	var m map[string]any
-	_ = json.Unmarshal([]byte(raw), &m)
+	m := cmuxCookieParam(c)
 	if m["value"] != val {
 		t.Errorf("value was altered.\n got: %q\nwant: %q", m["value"], val)
 	}
@@ -156,7 +158,7 @@ func TestChromeMicrosToUnixSec(t *testing.T) {
 	}
 }
 
-func TestCmuxPush_OpensSurfaceThenSetsEach(t *testing.T) {
+func TestCmuxPush_OpensSurfaceThenBatchSets(t *testing.T) {
 	f := &fakeCmux{}
 	a := newTestCmux(f, nil)
 	cookies := []chrome.Cookie{
@@ -166,12 +168,12 @@ func TestCmuxPush_OpensSurfaceThenSetsEach(t *testing.T) {
 	if err := a.Push(cookies); err != nil {
 		t.Fatalf("Push: %v", err)
 	}
-	// One open, two sets.
+	// One open, and both cookies in a single batched set call.
 	if f.calls[0][0] != "browser" || f.calls[0][1] != "open" {
 		t.Errorf("first call should open a surface, got %v", f.calls[0])
 	}
-	if f.setCalls != 2 {
-		t.Errorf("expected 2 cookies.set calls, got %d", f.setCalls)
+	if f.setCalls != 1 {
+		t.Errorf("expected 1 batched cookies.set call for 2 cookies, got %d", f.setCalls)
 	}
 	// Surface is cached: a second Push reuses it (no new open).
 	opensBefore := countOpens(f.calls)
@@ -180,6 +182,70 @@ func TestCmuxPush_OpensSurfaceThenSetsEach(t *testing.T) {
 	}
 	if countOpens(f.calls) != opensBefore {
 		t.Errorf("second Push should reuse cached surface, opened again")
+	}
+}
+
+func TestCmuxPush_ChunksLargeSets(t *testing.T) {
+	f := &fakeCmux{}
+	a := newTestCmux(f, nil)
+	n := cmuxCookieBatch*2 + 5 // spans 3 chunks
+	cookies := make([]chrome.Cookie, n)
+	for i := range cookies {
+		cookies[i] = chrome.Cookie{HostKey: ".x.com", Name: "c", Value: "v"}
+	}
+	if err := a.Push(cookies); err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	if f.setCalls != 3 {
+		t.Errorf("expected 3 batched set calls for %d cookies (batch=%d), got %d", n, cmuxCookieBatch, f.setCalls)
+	}
+}
+
+func TestCmuxPush_BatchRejectFallsBackPerCookie(t *testing.T) {
+	// The batch call rejects with a payload error (one bad cookie in the
+	// chunk); the per-cookie fallback then lands the good one and skips the
+	// reject. Push succeeds best-effort.
+	f := &fakeCmux{setErrs: []error{
+		errors.New("invalid_params: Invalid cookie payload"), // batch call
+		nil, // cookie a, per-cookie
+		errors.New("invalid_params: Invalid cookie payload"), // cookie b rejected -> skipped
+	}}
+	a := newTestCmux(f, nil)
+	cookies := []chrome.Cookie{
+		{HostKey: ".x.com", Name: "a", Value: "1"},
+		{HostKey: ".x.com", Name: "b", Value: "2"},
+	}
+	if err := a.Push(cookies); err != nil {
+		t.Fatalf("Push should be best-effort (skip rejected cookie), got %v", err)
+	}
+	if f.setCalls != 3 { // 1 batch + 2 per-cookie
+		t.Errorf("expected 3 set calls (batch + per-cookie fallback), got %d", f.setCalls)
+	}
+}
+
+func TestCmuxPush_HardFailsWhenCmuxUnavailable(t *testing.T) {
+	f := &fakeCmux{setErrs: []error{errors.New("broken pipe, errno 32")}}
+	a := newTestCmux(f, nil)
+	err := a.Push([]chrome.Cookie{{HostKey: ".x.com", Name: "a", Value: "1"}})
+	if err == nil || !strings.Contains(err.Error(), "broken pipe") {
+		t.Fatalf("cmux-unavailable must hard-fail (not silently skip), got %v", err)
+	}
+}
+
+func TestCmuxPush_DropsInvalidCookies(t *testing.T) {
+	// An RFC-invalid cookie (control char in value) is dropped before any
+	// RPC, so it can't poison a batch. A valid one still lands.
+	f := &fakeCmux{}
+	a := newTestCmux(f, nil)
+	cookies := []chrome.Cookie{
+		{HostKey: ".x.com", Name: "ok", Value: "good"},
+		{HostKey: ".x.com", Name: "bad", Value: "has\x00null"},
+	}
+	if err := a.Push(cookies); err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	if f.setCalls != 1 {
+		t.Errorf("expected 1 batch call, got %d", f.setCalls)
 	}
 }
 

--- a/internal/sinkpush/adapter_cmux_test.go
+++ b/internal/sinkpush/adapter_cmux_test.go
@@ -343,3 +343,30 @@ func countOpens(calls [][]string) int {
 	}
 	return n
 }
+
+func TestCmuxPush_SurfaceErrorAfterReopenHardFails(t *testing.T) {
+	// Greptile P1: a reopen happens but the retry still hits a surface error.
+	// That must hard-fail, not fall into per-cookie fallback and silently drop
+	// the whole chunk.
+	f := &fakeCmux{setErrs: []error{
+		errors.New("invalid_params: Surface is not a browser"), // batch
+		errors.New("invalid_params: Surface is not a browser"), // retry after reopen
+	}}
+	a := newTestCmux(f, nil)
+	a.surfaceID = "surface:stale"
+	err := a.Push([]chrome.Cookie{{HostKey: ".x.com", Name: "a", Value: "1"}})
+	if err == nil || !strings.Contains(err.Error(), "not a browser") {
+		t.Fatalf("a persistent surface error must hard-fail (no silent chunk loss), got %v", err)
+	}
+}
+
+func TestCmuxPush_PermissionDeniedHardFails(t *testing.T) {
+	// Greptile P2: EACCES ("permission denied") means cmux is unusable; it must
+	// hard-fail, not be mistaken for a per-cookie reject and silently skipped.
+	f := &fakeCmux{setErrs: []error{errors.New("fork/exec /x/cmux: permission denied")}}
+	a := newTestCmux(f, nil)
+	err := a.Push([]chrome.Cookie{{HostKey: ".x.com", Name: "a", Value: "1"}})
+	if err == nil || !strings.Contains(err.Error(), "permission denied") {
+		t.Fatalf("permission denied must hard-fail, got %v", err)
+	}
+}


### PR DESCRIPTION
Follow-up to #86. Syncing the *whole* Chrome cookie set (`cmux-sync` with no `--domain`) - which is what you want for "all my cookies, always" - exposed two problems the scoped tests never hit.

## Problems
- **One RPC per cookie** made a ~8000-cookie sync impractical (thousands of `cmux rpc` execs).
- **All-or-nothing batches**: one cookie cmux rejects (`Invalid cookie payload`) failed 200 good ones, and `isSurfaceError` matched `invalid_params`, so it mistook the reject for a stale surface and reopened pointlessly.

## Fix
- Batch via `browser.cookies.set`'s cookies array, chunked at 200 (kept under macOS `ARG_MAX` ~1MB). Full set now lands in ~40 calls / a few seconds.
- Drop RFC-invalid cookies up front (the same gate `RunAll` applies before `Push`).
- On a batch reject, fall back to per-cookie and skip only the bad ones (best-effort delivery).
- Hard-fail only when cmux is genuinely unavailable (broken pipe / cmuxOnly / access denied), not on a single rejected cookie.
- `isSurfaceError` tightened to surface-specific signatures.

## Verified live
Full **8096-cookie** sync in ~3.6s; Amazon and X both show logged in afterward. New tests cover batching, chunking, per-cookie fallback, hard-fail-on-unavailable, and invalid-cookie drop. 78 sinkpush tests pass; vet/lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)