### PR TITLE
feat(cmux): local loop on by default when cmux is installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## [Unreleased]
 
+### cmux local loop on by default
+
+When cmux is installed, `agentcookie wizard install` now wires the local
+loop automatically: it sets cmux's `automation.socketControlMode` to
+`allowAll` (backing up `~/.config/cmux/cmux.json` first), installs a
+`dev.agentcookie.cmux-sync` LaunchAgent running `cmux-sync --watch` over
+the full cookie set, and prints the one-time "restart cmux" step (the mode
+is read only at app launch). After that single restart, this Mac's Chrome
+session stays mirrored into cmux's browser hands-free.
+
+New `agentcookie cmux-sync enable` / `disable` manage it directly;
+`wizard install --no-cmux` opts out; `agentcookie doctor` reports loop
+liveness (not-enabled / enabled-but-needs-restart / live). Absent cmux,
+all of this is a clean no-op. Manual `cmux-sync --once/--watch` run inside
+cmux still works with no socket change (a cmux child passes `cmuxOnly`).
+
 ### cmux local loop: `agentcookie cmux-sync`
 
 Same-machine loop so this Mac's Chrome logins flow into this Mac's cmux

--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ Caveats: the surface delivers cookies only, so sites whose session also lives in
 
 The sink surface above is for the two-machine model. If you just want *this* Mac's Chrome logins to flow into *this* Mac's cmux browser, use the local loop instead. No second machine, no Tailscale, no pairing.
 
+**On by default when cmux is installed.** `agentcookie wizard install` detects cmux and turns the loop on automatically: it sets cmux's `socketControlMode` to `allowAll`, installs a launch agent that runs `cmux-sync --watch` over your full cookie set, and tells you to **restart cmux once** to activate (the mode is read only at app launch). After that single restart it stays in sync hands-free. Opt out with `agentcookie wizard install --no-cmux`. Turn it on/off later with `agentcookie cmux-sync enable` / `disable`. `agentcookie doctor` reports the loop's liveness (enabled / needs-restart / live).
+
+For manual or one-shot use:
+
 ```bash
 # one-shot: read Chrome now, inject into cmux
 agentcookie cmux-sync --once

--- a/docs/plans/2026-06-03-003-feat-cmux-default-on-plan.md
+++ b/docs/plans/2026-06-03-003-feat-cmux-default-on-plan.md
@@ -1,0 +1,256 @@
+---
+title: "feat: cmux local loop on by default when cmux is installed"
+status: active
+date: 2026-06-03
+type: feat
+---
+
+# feat: cmux local loop on by default when cmux is installed
+
+Builds on the local loop (`agentcookie cmux-sync`, PR #86) and batched injection (PR #88). This plan makes that loop **automatic**: if cmux and agentcookie are both installed, your Chrome session continuously flows into cmux's browser with no flags, no manual command, and no per-use setup.
+
+## Summary
+
+Today the local loop exists but is opt-in and manual: you run `cmux-sync --watch` yourself, in a cmux pane, for it to work. The goal is "both installed -> it just works." This adds a re-runnable `agentcookie cmux-sync enable` that (1) sets cmux's `socketControlMode` so a background daemon can reach the socket, (2) installs a launchd agent running `cmux-sync --watch` over the full cookie set, and (3) prints the one-time "restart cmux" step; `wizard install` calls it automatically when cmux is detected. A `disable` tears it down, and `doctor` reports whether the loop is actually live.
+
+The one unavoidable cost, surfaced honestly: the launchd agent is not a cmux child, so cmux's default `socketControlMode: cmuxOnly` blocks it. Turning the loop on therefore requires setting `allowAll` (or `password`) in `~/.config/cmux/cmux.json` and **one** cmux restart (the mode is read only at app launch). After that single restart it is permanent and hands-free. There is no cmux-native "auto-run a daemon" hook (`resumeCommands` is cmux-managed signed surface-resume approvals, not a startup hook), so launchd is the mechanism.
+
+---
+
+## Problem Frame
+
+The local loop's value is "my agent's cmux browser is always logged in like my Chrome." That promise only lands if it is on by default. Right now a user must know the command exists, run it in a cmux pane, and keep that pane alive. The moment they close it or reboot, sync stops. "Both installed -> automatic" requires: a persistent runner (launchd), the socket opened to a non-cmux-child caller (the `cmuxOnly` gate), and install-time wiring that detects cmux and sets this up without the user asking.
+
+Constraints discovered this session:
+- The launchd agent is not a cmux child, so `cmuxOnly` rejects it. The mode must be `allowAll`/`password`, applied via `~/.config/cmux/cmux.json`, and cmux must be restarted once for it to take effect (no live RPC sets the mode; `reload-config` does not apply it).
+- cmux has no startup-daemon config hook, so "run it as a cmux child to avoid the gate" is not available for the automatic case. (A user can still run `cmux-sync --watch` by hand inside cmux with no mode change; that stays supported, just not the default mechanism.)
+- The injection adapter already batches and is resilient (PR #88), so full-cookie continuous sync is practical.
+
+---
+
+## Requirements
+
+- R1. `agentcookie cmux-sync enable` makes the local loop persistent and automatic: it configures cmux's socket mode, installs a launchd agent running `cmux-sync --watch` (full cookie set), and is idempotent (safe to re-run).
+- R2. `agentcookie wizard install` auto-runs the enable path when cmux is detected, so a fresh install with cmux present yields a working loop with no extra commands. When cmux is absent, it is a no-op (no error, no nag).
+- R3. `agentcookie cmux-sync disable` cleanly removes the launchd agent; reverting the cmux socket mode is offered but not forced (other tools may rely on it).
+- R4. Enabling writes `~/.config/cmux/cmux.json` (`automation.socketControlMode`) itself, backing up the file first, and clearly tells the user a one-time cmux restart is required for it to take effect.
+- R5. `agentcookie doctor` reports the local-loop state end to end: launchd agent loaded, cmux reachable, socket mode not `cmuxOnly`, with the exact remediation when any piece is missing.
+- R6. Nothing here changes the source->sink transport, pairing, or the injection adapter internals.
+- R7. The manual path (`cmux-sync --once/--watch` run by hand, no mode change needed when run inside cmux) keeps working unchanged.
+
+---
+
+## Key Technical Decisions
+
+- KTD1. Mechanism is a **launchd agent**, not a cmux startup hook. cmux exposes no "run a background command on launch" config; `terminal.resumeCommands` is cmux-managed signed surface-resume approvals, not a hook. launchd is also the established agentcookie pattern (`internal/launchd`).
+- KTD2. Add a `cmux-sync` role to `internal/launchd` (`RoleCmuxSync`), so the agent is `dev.agentcookie.cmux-sync` running `agentcookie cmux-sync --watch`. Mirrors the existing source/sink roles; no new launchd machinery.
+- KTD3. The enable/disable logic lives in a dedicated `agentcookie cmux-sync enable|disable` subcommand, and `wizard install` calls it. Re-runnable and testable on its own, rather than burying the logic in the wizard.
+- KTD4. Enabling sets `automation.socketControlMode` to `allowAll` by default (the socket is user-only, so the marginal risk is low and it needs no secret). `--password` selects password mode (writes `socketPassword` + sets `CMUX_SOCKET_PASSWORD` in the agent env). One-time cmux restart required either way; the command states this prominently.
+- KTD5. cmux.json is edited with a JSONC-aware, targeted writer (set/insert only `automation.socketControlMode`/`socketPassword`), backing up to a timestamped `.bak` first, preserving comments and other settings. Go has no JSONC round-trip, so this is a careful regex/structured edit, not `json.Marshal`. (A Python reference for this exact edit exists in the sibling agentmail-to-claude-code repo's `setup_cmux.py`; port the case logic.)
+- KTD6. Default cookie scope for the agent is the full set (no `--domain`) -- "all my cookies" is the intent. The agent honors `source.yaml`'s `cmux.domain_filter` if the user set one.
+- KTD7. Detection = cmux CLI present (`sinkpush.ResolveCmuxBinary` + stat) AND `~/.config/cmux/cmux.json` reachable. Absent cmux -> enable is a clean no-op so `wizard install` never errors on non-cmux machines.
+
+---
+
+## High-Level Technical Design
+
+What `cmux-sync enable` wires up and how the pieces relate:
+
+```mermaid
+flowchart TD
+  WI["agentcookie wizard install"] -->|cmux detected| EN["cmux-sync enable (NEW)"]
+  ENM["agentcookie cmux-sync enable (manual)"] --> EN
+  EN --> DET{"cmux installed\n+ cmux.json present?"}
+  DET -- no --> NOOP["no-op (clean skip)"]
+  DET -- yes --> CFG["write cmux.json:\nautomation.socketControlMode=allowAll\n(backup first)"]
+  CFG --> LA["launchd.Install(RoleCmuxSync)\n-> dev.agentcookie.cmux-sync\nruns: agentcookie cmux-sync --watch"]
+  LA --> MSG["print: restart cmux once\n(mode read at launch)"]
+  MSG --> RUN["after restart: agent watches Chrome,\nbatched-injects all cookies into cmux"]
+  DOC["agentcookie doctor"] -.checks.-> LA
+  DOC -.checks.-> CFG
+  DOC -.checks.-> RUN
+```
+
+The runtime sync path itself (Chrome -> read pipeline -> CmuxAdapter -> cmux) is unchanged from the local-loop PRs; this plan only adds the always-on wiring around it.
+
+---
+
+## Implementation Units
+
+### U1. launchd `cmux-sync` role
+
+**Goal:** Let `internal/launchd` install/uninstall/detect a `cmux-sync` agent.
+
+**Requirements:** R1, R3
+
+**Dependencies:** none
+
+**Files:**
+- `internal/launchd/plist.go` (add `RoleCmuxSync`; allow it in `Build` validation; args become `["cmux-sync", "--watch"]` via Role + ExtraArgs)
+- `internal/launchd/plist_test.go`
+
+**Approach:** Add `RoleCmuxSync Role = "cmux-sync"`. Permit it in the role validation alongside source/sink. `Label()` yields `dev.agentcookie.cmux-sync`; `ProgramArguments` becomes the binary + `cmux-sync` + `ExtraArgs` (`--watch`). No other launchd changes.
+
+**Test scenarios:**
+- `Spec{Role: RoleCmuxSync, ExtraArgs: ["--watch"]}.Build()` yields Label `dev.agentcookie.cmux-sync` and ProgramArguments ending `cmux-sync --watch`.
+- `Build` still rejects an unknown role.
+- Plist path/log paths derive from the role name.
+
+**Verification:** `go test ./internal/launchd/...` passes; a built plist loads under launchd in manual testing.
+
+### U2. cmux.json socket-mode writer
+
+**Goal:** Set `automation.socketControlMode` (and optional `socketPassword`) in `~/.config/cmux/cmux.json`, safely and idempotently.
+
+**Requirements:** R4
+
+**Dependencies:** none
+
+**Files:**
+- `internal/cmuxconfig/cmuxconfig.go` (new small package: locate cmux.json, set mode with backup, JSONC-preserving)
+- `internal/cmuxconfig/cmuxconfig_test.go`
+
+**Approach:** Locate `~/.config/cmux/cmux.json`. Back up to `cmux.json.<timestamp>.bak`. Set `automation.socketControlMode` via targeted edit across three shapes (existing uncommented key -> replace value; existing uncommented `automation` block -> inject key; no automation block -> insert one), preserving comments and unrelated settings. Idempotent: setting the same value is a no-op-equivalent. Optionally validate via `cmux config check` when the cmux binary is available.
+
+**Execution note:** Test-first on the three JSONC shapes -- this is the bug-prone part (Go has no JSONC round-trip).
+
+**Patterns to follow:** the sibling `agentmail-to-claude-code` repo's `setup_cmux.py` (the same three-case targeted edit, in Python) as the reference for the case logic; `internal/config` for path/backup conventions.
+
+**Test scenarios:**
+- Fresh template (all-commented automation) -> a real `automation.socketControlMode` is inserted; result parses as JSONC and keeps the schema/comments.
+- Existing uncommented `socketControlMode` -> value replaced, file otherwise unchanged.
+- Existing uncommented `automation` block without the key -> key injected inside it.
+- Password mode -> both `socketControlMode: "password"` and `socketPassword` set.
+- A backup `.bak` is created before write; re-running is safe (no duplicate blocks).
+- Missing cmux.json -> clear typed error the caller can treat as "cmux not set up".
+
+**Verification:** `go test ./internal/cmuxconfig/...`; `cmux config check` reports valid after a write.
+
+### U3. `agentcookie cmux-sync enable|disable`
+
+**Goal:** One command to make the loop persistent/automatic, and one to remove it.
+
+**Requirements:** R1, R3, R4, R7
+
+**Dependencies:** U1, U2
+
+**Files:**
+- `internal/cli/cmux_sync.go` (add `enable`/`disable` subcommands under the existing `cmux-sync` command; flags `--password`, `--no-restart-hint`)
+- `internal/cli/cmux_sync_test.go`
+
+**Approach:** `enable`: detect cmux (KTD7); if absent, print a clean "cmux not found, skipping" and exit 0 (so wizard can call it unconditionally). If present: write the socket mode via `internal/cmuxconfig` (U2), install the launchd agent via `internal/launchd` (U1) pointing at the resolved agentcookie binary with `cmux-sync --watch`, then print the one-time restart instruction and how to verify (`agentcookie doctor`). `disable`: uninstall the launchd agent; print how to revert the socket mode (do not force-revert -- other tools may use it). Both idempotent.
+
+**Execution note:** Implement the cmux-absent no-op path test-first (it gates wizard safety).
+
+**Patterns to follow:** `internal/cli/wizard.go` (launchd install + user messaging), `internal/cli/cmux_sync.go` (existing command + config resolution), `internal/launchd` Install/Uninstall.
+
+**Test scenarios:**
+- cmux absent -> `enable` is a no-op, exit 0, prints a skip line, installs nothing.
+- cmux present -> writes socket mode (via a faked cmuxconfig writer), installs the launchd agent (faked launchd), prints the restart instruction.
+- `enable` twice -> idempotent (no duplicate agent, single backup per change).
+- `disable` -> uninstalls the agent; prints the revert hint; does not error if nothing was installed.
+- `--password` -> writes password mode and sets the agent's `CMUX_SOCKET_PASSWORD`.
+
+**Verification:** `agentcookie cmux-sync enable` on a cmux machine installs `dev.agentcookie.cmux-sync` and, after a cmux restart, cmux stays logged in hands-free; `disable` removes it.
+
+### U4. Wizard auto-enable on cmux detection
+
+**Goal:** Make it the default: `wizard install` sets up the loop when cmux is present.
+
+**Requirements:** R2
+
+**Dependencies:** U3
+
+**Files:**
+- `internal/cli/wizard.go` (call the enable path near the end of install, after the binary/log dir are resolved)
+- `internal/cli/wizard_test.go`
+
+**Approach:** At the tail of `runWizardInstall` (both source and sink installs), call the same enable routine U3 exposes. cmux-absent -> silent no-op (KTD7). Surface a concise line in the install summary ("cmux detected -- local loop enabled; restart cmux once to activate") so the one-time restart is visible. Gate behind a `--no-cmux` flag for users who want to opt out.
+
+**Test scenarios:**
+- Install with cmux present -> enable routine invoked; summary mentions the loop + restart.
+- Install with cmux absent -> enable routine no-ops; no error, no cmux mention.
+- `--no-cmux` -> enable skipped even when cmux present.
+
+**Verification:** A fresh `wizard install` on a cmux machine yields a loaded `dev.agentcookie.cmux-sync` agent and the restart hint, with no extra commands.
+
+### U5. Doctor: local-loop liveness
+
+**Goal:** `doctor` tells the user whether the automatic loop is actually working.
+
+**Requirements:** R5
+
+**Dependencies:** U1, U3
+
+**Files:**
+- `internal/cli/doctor.go` (extend the existing `cmux local loop` check: also report whether `dev.agentcookie.cmux-sync` is loaded via `launchd.IsInstalled`, in addition to cmux reachability + socket mode)
+- `internal/cli/doctor_test.go`
+
+**Approach:** Build on the `checkCmuxDelivery` introduced for the source-side loop. When the local loop is configured/enabled, additionally check the launchd agent is loaded and the socket mode is not `cmuxOnly`; WARN with the precise next step when the agent is missing, the mode is still `cmuxOnly` (needs restart), or cmux is unreachable. OK only when agent loaded + mode open + cmux reachable.
+
+**Test scenarios:**
+- Agent loaded + mode allowAll + cmux reachable -> OK.
+- Agent loaded + mode still `cmuxOnly` -> WARN "restart cmux to apply socketControlMode".
+- Agent not loaded but cmux present -> WARN "run `agentcookie cmux-sync enable`".
+- Source-only / loop disabled -> SKIPPED (regression of current behavior).
+
+**Verification:** `agentcookie doctor` distinguishes "enabled but needs restart" from "not enabled" from "live".
+
+### U6. Docs
+
+**Goal:** Document the default-on behavior and the one-time restart.
+
+**Requirements:** R2, R4, R5
+
+**Files:**
+- `README.md` (local loop section: it's automatic when cmux is installed; the one-time restart; enable/disable; doctor)
+- `docs/quickstart.md` (note the auto-enable in the install flow)
+- `CHANGELOG.md`
+
+**Approach:** State that installing agentcookie with cmux present turns the loop on automatically (all cookies, continuous), requiring one cmux restart to activate; document `cmux-sync enable|disable`, the `--no-cmux` opt-out, and the doctor line. Carry the DBSC/ITP and signed-binary-no-prompt notes forward.
+
+**Test scenarios:** Test expectation: none -- documentation only.
+
+**Verification:** A reader understands that with both installed it just works after one restart, and how to turn it off.
+
+---
+
+## Scope Boundaries
+
+In scope: the `cmux-sync enable|disable` command, the launchd role, the cmux.json socket-mode writer, wizard auto-enable, the doctor liveness check, and docs.
+
+Outside this product's identity: changes to the source->sink transport or pairing; the injection adapter internals (PR #88); defeating DBSC.
+
+### Deferred to Follow-Up Work
+- localStorage/sessionStorage sync (carried from the local-loop deferred list).
+- A live socket-mode apply that avoids the cmux restart (no cmux API exists today; revisit if cmux adds one).
+- Auto-revert of `socketControlMode` on `disable` (today: print the revert hint, don't force it).
+
+---
+
+## Risk Analysis & Mitigation
+
+- Editing the user's `cmux.json` automatically. Mitigation: timestamped backup before any write; targeted edit preserving comments/settings; `cmux config check` validation; idempotent.
+- The one-time cmux restart is a real friction and easy to forget. Mitigation: prominent restart instruction at enable + install; `doctor` explicitly reports "enabled but needs restart" vs "live".
+- `allowAll` opens the cmux socket to any local process running as the user. Mitigation: documented; `--password` available for a tighter posture; socket is already user-only.
+- Wizard auto-enable on machines without cmux. Mitigation: detection no-ops cleanly (KTD7); `--no-cmux` opt-out.
+- Full-cookie continuous injection load. Mitigation: batched + min-interval rate cap from the watcher (PRs #86/#88).
+- Greptile review: resolve all findings before merge.
+
+---
+
+## Alternatives Considered
+
+- **cmux `resumeCommands` to auto-launch the loop as a cmux child** (no restart, no mode change). Rejected: `resumeCommands` is cmux-managed signed surface-resume approvals, not a startup-command hook; there is no cmux-native way to auto-run a background daemon. The manual "run `cmux-sync --watch` inside cmux" path remains available for users who prefer no mode change, but it can't be the automatic default.
+- **A login item / shell-profile launch instead of launchd.** Rejected: launchd is the established agentcookie agent pattern, integrates with `doctor`/uninstall, and is more robust than profile hacks.
+- **Bury enable logic directly in the wizard.** Rejected (KTD3): a standalone `cmux-sync enable` is re-runnable and unit-testable; the wizard just calls it.
+
+---
+
+## Sources & Research
+
+- launchd extension point: `internal/launchd/plist.go` (`Role`, `Spec`, `Build`, `Install`/`Uninstall`/`IsInstalled`; roles currently source/sink, `Label() = dev.agentcookie.<role>`).
+- Wizard install flow to hook: `internal/cli/wizard.go` (`runWizardInstall`, `wizardInstallSource`/`Sink`, launchd install + summary messaging).
+- The local loop + adapter this builds on: `internal/cli/cmux_sync.go`, `internal/sinkpush` (`CmuxAdapter`, `ResolveCmuxBinary`), and `docs/plans/2026-06-03-002-feat-cmux-local-loop-plan.md`.
+- cmux socket-mode facts (verified this session): `socketControlMode` read only at app launch; no live RPC to set it; `reload-config` doesn't apply it; `cmuxOnly` rejects non-cmux-child callers. `terminal.resumeCommands` is signed surface-resume approvals (cmux schema), not a startup hook.
+- cmux.json edit reference: the sibling `agentmail-to-claude-code` repo's `setup_cmux.py` (same three-case targeted JSONC edit, in Python).

--- a/internal/cli/cmux_sync_enable.go
+++ b/internal/cli/cmux_sync_enable.go
@@ -110,7 +110,10 @@ func enableCmuxLoop(cmuxPath string, quiet bool) error {
 		return err
 	}
 	binPath, _ = filepath.Abs(binPath)
-	home, _ := os.UserHomeDir()
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("locate home dir: %w", err)
+	}
 	logDir := filepath.Join(home, ".agentcookie", "logs")
 	if err := os.MkdirAll(logDir, 0o755); err != nil {
 		return err

--- a/internal/cli/cmux_sync_enable.go
+++ b/internal/cli/cmux_sync_enable.go
@@ -1,0 +1,129 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mvanhorn/agentcookie/internal/cmuxconfig"
+	"github.com/mvanhorn/agentcookie/internal/launchd"
+	"github.com/mvanhorn/agentcookie/internal/sinkpush"
+)
+
+// Seams so tests can exercise enable/disable without touching the real
+// cmux.json or launchd.
+var (
+	cmuxSyncSetMode        = cmuxconfig.SetSocketControlMode
+	cmuxSyncInstallAgent   = installLaunchAgent
+	cmuxSyncUninstallAgent = launchd.Uninstall
+)
+
+var cmuxSyncEnableCmuxPath string
+
+var cmuxSyncEnableCmd = &cobra.Command{
+	Use:   "enable",
+	Short: "Make the cmux local loop persistent: install a launch agent and open cmux's socket",
+	Long: `enable sets up the local loop to run automatically: it points cmux's
+socketControlMode at allowAll (so the launchd agent, which is not a cmux
+child, can reach the control socket), installs a LaunchAgent that runs
+` + "`cmux-sync --watch`" + ` over your full cookie set, and tells you to restart
+cmux once (the mode is read only at app launch).
+
+If cmux is not installed, enable is a clean no-op. Idempotent.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return enableCmuxLoop(cmuxSyncEnableCmuxPath, false)
+	},
+}
+
+var cmuxSyncDisableCmd = &cobra.Command{
+	Use:   "disable",
+	Short: "Remove the cmux local-loop launch agent",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := cmuxSyncUninstallAgent(launchd.Spec{Role: launchd.RoleCmuxSync}); err != nil {
+			return fmt.Errorf("remove cmux-sync agent: %w", err)
+		}
+		fmt.Fprintln(os.Stderr, "agentcookie cmux-sync: removed launch agent dev.agentcookie.cmux-sync")
+		fmt.Fprintln(os.Stderr, "agentcookie cmux-sync: to revert cmux's socket, set automation.socketControlMode back to \"cmuxOnly\" in ~/.config/cmux/cmux.json and restart cmux")
+		return nil
+	},
+}
+
+func init() {
+	cmuxSyncEnableCmd.Flags().StringVar(&cmuxSyncEnableCmuxPath, "cmux-path", "", "override the cmux CLI path (default: the app bundle, then PATH)")
+	cmuxSyncCmd.AddCommand(cmuxSyncEnableCmd)
+	cmuxSyncCmd.AddCommand(cmuxSyncDisableCmd)
+}
+
+// cmuxAutoEnable is the function the wizard calls to wire the loop. A
+// package var so tests can spy on it.
+var cmuxAutoEnable = enableCmuxLoop
+
+// maybeAutoEnableCmux runs the default-on wiring at the tail of
+// `wizard install`, unless --no-cmux was passed. Non-fatal: a wiring
+// hiccup logs and is swallowed so it never fails the install.
+func maybeAutoEnableCmux() {
+	if wizardNoCmux {
+		return
+	}
+	if err := cmuxAutoEnable("", false); err != nil {
+		fmt.Fprintf(os.Stderr, "agentcookie wizard: cmux local-loop setup failed (non-fatal): %v\n", err)
+	}
+}
+
+// enableCmuxLoop configures cmux's socket and installs the cmux-sync launch
+// agent. It is a clean no-op when cmux (or its config) is absent, so the
+// wizard can call it unconditionally. quiet suppresses the per-step lines
+// (the wizard prints its own summary).
+func enableCmuxLoop(cmuxPath string, quiet bool) error {
+	logf := func(format string, a ...any) {
+		if !quiet {
+			fmt.Fprintf(os.Stderr, format+"\n", a...)
+		}
+	}
+
+	binary := sinkpush.ResolveCmuxBinary(cmuxPath)
+	if info, err := os.Stat(binary); err != nil || info.IsDir() {
+		logf("agentcookie cmux-sync: cmux not found at %s; skipping local-loop setup", binary)
+		return nil
+	}
+
+	cfgPath, err := cmuxconfig.DefaultConfigPath()
+	if err != nil {
+		return err
+	}
+	bak, err := cmuxSyncSetMode(cfgPath, "allowAll", "", time.Now())
+	if errors.Is(err, cmuxconfig.ErrNotFound) {
+		logf("agentcookie cmux-sync: cmux is installed but %s is missing; launch cmux once, then re-run `agentcookie cmux-sync enable`", cfgPath)
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("set cmux socketControlMode: %w", err)
+	}
+	logf("agentcookie cmux-sync: set socketControlMode=allowAll in %s (backup: %s)", cfgPath, bak)
+
+	binPath, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	binPath, _ = filepath.Abs(binPath)
+	home, _ := os.UserHomeDir()
+	logDir := filepath.Join(home, ".agentcookie", "logs")
+	if err := os.MkdirAll(logDir, 0o755); err != nil {
+		return err
+	}
+	if err := cmuxSyncInstallAgent(launchd.Spec{
+		Role:       launchd.RoleCmuxSync,
+		BinaryPath: binPath,
+		LogDir:     logDir,
+		ExtraArgs:  []string{"--watch"},
+	}); err != nil {
+		return fmt.Errorf("install cmux-sync launch agent: %w", err)
+	}
+	logf("agentcookie cmux-sync: installed launch agent dev.agentcookie.cmux-sync (runs cmux-sync --watch over all cookies)")
+	logf("agentcookie cmux-sync: RESTART cmux once to apply socketControlMode (read only at app launch). Verify with: agentcookie doctor")
+	return nil
+}

--- a/internal/cli/cmux_sync_enable_test.go
+++ b/internal/cli/cmux_sync_enable_test.go
@@ -1,0 +1,126 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/mvanhorn/agentcookie/internal/cmuxconfig"
+	"github.com/mvanhorn/agentcookie/internal/launchd"
+)
+
+func fakeCmuxBinary(t *testing.T) string {
+	t.Helper()
+	bin := filepath.Join(t.TempDir(), "cmux")
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return bin
+}
+
+func stubEnableSeams(t *testing.T) (setCalls *[]string, installed *[]launchd.Spec) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir()) // keep logDir + os.Executable side effects in tmp
+	sc := []string{}
+	ins := []launchd.Spec{}
+	origSet, origInstall := cmuxSyncSetMode, cmuxSyncInstallAgent
+	cmuxSyncSetMode = func(path, mode, password string, now time.Time) (string, error) {
+		sc = append(sc, mode)
+		return path + ".bak", nil
+	}
+	cmuxSyncInstallAgent = func(spec launchd.Spec) error {
+		ins = append(ins, spec)
+		return nil
+	}
+	t.Cleanup(func() { cmuxSyncSetMode, cmuxSyncInstallAgent = origSet, origInstall })
+	return &sc, &ins
+}
+
+func TestEnableCmuxLoop_NoOpWhenCmuxAbsent(t *testing.T) {
+	setCalls, installed := stubEnableSeams(t)
+	missing := filepath.Join(t.TempDir(), "no-cmux")
+	if err := enableCmuxLoop(missing, true); err != nil {
+		t.Fatalf("enable should be a clean no-op, got %v", err)
+	}
+	if len(*setCalls) != 0 || len(*installed) != 0 {
+		t.Errorf("cmux absent should touch nothing: set=%v install=%v", *setCalls, *installed)
+	}
+}
+
+func TestEnableCmuxLoop_WiresModeAndAgent(t *testing.T) {
+	setCalls, installed := stubEnableSeams(t)
+	if err := enableCmuxLoop(fakeCmuxBinary(t), true); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	if len(*setCalls) != 1 || (*setCalls)[0] != "allowAll" {
+		t.Errorf("expected socketControlMode=allowAll set once, got %v", *setCalls)
+	}
+	if len(*installed) != 1 {
+		t.Fatalf("expected one agent install, got %d", len(*installed))
+	}
+	spec := (*installed)[0]
+	if spec.Role != launchd.RoleCmuxSync {
+		t.Errorf("agent role = %q, want cmux-sync", spec.Role)
+	}
+	if len(spec.ExtraArgs) != 1 || spec.ExtraArgs[0] != "--watch" {
+		t.Errorf("agent args = %v, want [--watch]", spec.ExtraArgs)
+	}
+}
+
+func TestEnableCmuxLoop_NoAgentWhenCmuxConfigMissing(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	installed := []launchd.Spec{}
+	origSet, origInstall := cmuxSyncSetMode, cmuxSyncInstallAgent
+	cmuxSyncSetMode = func(string, string, string, time.Time) (string, error) {
+		return "", cmuxconfig.ErrNotFound
+	}
+	cmuxSyncInstallAgent = func(spec launchd.Spec) error {
+		installed = append(installed, spec)
+		return nil
+	}
+	t.Cleanup(func() { cmuxSyncSetMode, cmuxSyncInstallAgent = origSet, origInstall })
+
+	if err := enableCmuxLoop(fakeCmuxBinary(t), true); err != nil {
+		t.Fatalf("missing cmux.json should be a clean no-op, got %v", err)
+	}
+	if len(installed) != 0 {
+		t.Errorf("no agent should be installed when cmux.json is missing, got %d", len(installed))
+	}
+}
+
+func TestCmuxSyncDisable_UninstallsAgent(t *testing.T) {
+	var got launchd.Spec
+	orig := cmuxSyncUninstallAgent
+	cmuxSyncUninstallAgent = func(spec launchd.Spec) error { got = spec; return nil }
+	t.Cleanup(func() { cmuxSyncUninstallAgent = orig })
+
+	if err := cmuxSyncDisableCmd.RunE(cmuxSyncDisableCmd, nil); err != nil {
+		t.Fatalf("disable: %v", err)
+	}
+	if got.Role != launchd.RoleCmuxSync {
+		t.Errorf("disable should uninstall the cmux-sync agent, got role %q", got.Role)
+	}
+}
+
+func TestMaybeAutoEnableCmux_GatedByNoCmuxFlag(t *testing.T) {
+	calls := 0
+	orig := cmuxAutoEnable
+	cmuxAutoEnable = func(cmuxPath string, quiet bool) error { calls++; return nil }
+	t.Cleanup(func() { cmuxAutoEnable = orig })
+
+	origFlag := wizardNoCmux
+	t.Cleanup(func() { wizardNoCmux = origFlag })
+
+	wizardNoCmux = false
+	maybeAutoEnableCmux()
+	if calls != 1 {
+		t.Errorf("expected auto-enable to fire when --no-cmux is off, got %d calls", calls)
+	}
+
+	wizardNoCmux = true
+	maybeAutoEnableCmux()
+	if calls != 1 {
+		t.Errorf("--no-cmux should skip auto-enable; calls went to %d", calls)
+	}
+}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -20,6 +20,7 @@ import (
 	"github.com/mvanhorn/agentcookie/internal/chromepaths"
 	"github.com/mvanhorn/agentcookie/internal/config"
 	"github.com/mvanhorn/agentcookie/internal/keystore"
+	"github.com/mvanhorn/agentcookie/internal/launchd"
 	"github.com/mvanhorn/agentcookie/internal/secretsbus"
 	"github.com/mvanhorn/agentcookie/internal/sinkpush"
 	"github.com/mvanhorn/agentcookie/internal/state"
@@ -258,11 +259,11 @@ func buildReport(d doctorDeps) DoctorReport {
 		})
 	}
 
-	// 10c. cmux local loop (source side) -- verifies `cmux-sync` can reach
-	// cmux when the local loop is configured in source.yaml. Same gate as
-	// the sink surface, surfaced from the machine that runs the loop.
+	// 10c. cmux local loop (source side) -- liveness of the always-on loop:
+	// is the launch agent loaded, is cmux reachable, and is the socket mode
+	// applied (not still cmuxOnly, which means a restart is pending).
 	if srcCfg != nil {
-		checks = append(checks, checkCmuxDelivery(srcCfg.Cmux, "cmux local loop"))
+		checks = append(checks, checkCmuxLocalLoop(srcCfg.Cmux))
 	} else {
 		checks = append(checks, Check{
 			Name:     "cmux local loop",
@@ -1000,6 +1001,65 @@ func checkCmuxDeliveryWith(cmux config.CmuxRef, label string, probe func(binary 
 		Severity: SeverityOK,
 		Detail:   "cmux installed, socketControlMode=" + mode + "; cookies can be injected",
 	}
+}
+
+// checkCmuxLocalLoop reports the liveness of the always-on local loop
+// (the `cmux-sync` launch agent), distinguishing "not enabled" from
+// "enabled but needs a cmux restart" from "live". The loop is considered
+// set up if the launch agent is loaded OR source.yaml opted in via
+// cmux.enabled.
+func checkCmuxLocalLoop(cmux config.CmuxRef) Check {
+	return checkCmuxLocalLoopWith(cmux, launchd.IsInstalled, probeCmuxAccessMode)
+}
+
+func checkCmuxLocalLoopWith(cmux config.CmuxRef, agentInstalled func(launchd.Spec) bool, probe func(string) (string, error)) Check {
+	const name = "cmux local loop"
+	agentUp := agentInstalled(launchd.Spec{Role: launchd.RoleCmuxSync})
+	binary := sinkpush.ResolveCmuxBinary(cmux.CmuxPath)
+	info, statErr := os.Stat(binary)
+	cmuxPresent := statErr == nil && !info.IsDir()
+
+	if !agentUp && !cmux.Enabled {
+		if !cmuxPresent {
+			return Check{Name: name, Severity: SeveritySkipped, Detail: "not set up (cmux not installed)"}
+		}
+		return Check{
+			Name:        name,
+			Severity:    SeverityWarn,
+			Detail:      "cmux is installed but the local loop is not enabled",
+			Remediation: "run `agentcookie cmux-sync enable`, then restart cmux once",
+		}
+	}
+	if !cmuxPresent {
+		return Check{
+			Name:        name,
+			Severity:    SeverityWarn,
+			Detail:      "local loop enabled but the cmux CLI was not found at " + binary,
+			Remediation: "install cmux (https://cmux.com) or set cmux.cmux_path",
+		}
+	}
+	mode, err := probe(binary)
+	if err != nil {
+		return Check{
+			Name:        name,
+			Severity:    SeverityWarn,
+			Detail:      "cmux installed but its control socket did not answer (is cmux running?): " + err.Error(),
+			Remediation: "start cmux; if it is already running, restart it once to apply socketControlMode",
+		}
+	}
+	if mode == "cmuxOnly" {
+		return Check{
+			Name:        name,
+			Severity:    SeverityWarn,
+			Detail:      "loop set up but socketControlMode is still \"cmuxOnly\" -- the change has not taken effect yet",
+			Remediation: "RESTART cmux once (socketControlMode is read only at app launch; `cmux reload-config` does not apply it)",
+		}
+	}
+	detail := "config-enabled; socketControlMode=" + mode
+	if agentUp {
+		detail = "launch agent loaded; socketControlMode=" + mode + "; loop active"
+	}
+	return Check{Name: name, Severity: SeverityOK, Detail: detail}
 }
 
 // probeCmuxAccessMode runs `cmux capabilities` and returns the server's

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -1055,11 +1055,22 @@ func checkCmuxLocalLoopWith(cmux config.CmuxRef, agentInstalled func(launchd.Spe
 			Remediation: "RESTART cmux once (socketControlMode is read only at app launch; `cmux reload-config` does not apply it)",
 		}
 	}
-	detail := "config-enabled; socketControlMode=" + mode
-	if agentUp {
-		detail = "launch agent loaded; socketControlMode=" + mode + "; loop active"
+	if !agentUp {
+		// Reached here via cmux.Enabled in config, but the launch agent that
+		// actually runs the loop is not loaded -- so nothing is syncing. Not
+		// OK (Greptile finding: avoid a false-positive "live").
+		return Check{
+			Name:        name,
+			Severity:    SeverityWarn,
+			Detail:      "cmux.enabled is set but the cmux-sync launch agent is not running; the loop is not active",
+			Remediation: "run `agentcookie cmux-sync enable` to install and start the agent",
+		}
 	}
-	return Check{Name: name, Severity: SeverityOK, Detail: detail}
+	return Check{
+		Name:     name,
+		Severity: SeverityOK,
+		Detail:   "launch agent loaded; socketControlMode=" + mode + "; loop active",
+	}
 }
 
 // probeCmuxAccessMode runs `cmux capabilities` and returns the server's

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -808,3 +808,18 @@ func TestCheckCmuxLocalLoop(t *testing.T) {
 		}
 	})
 }
+
+func TestCheckCmuxLocalLoop_ConfigEnabledButAgentDown(t *testing.T) {
+	// Greptile: cmux.enabled in config but the launch agent is not running
+	// means the loop is not actually syncing -> WARN, not OK.
+	agentDown := func(launchd.Spec) bool { return false }
+	okProbe := func(string) (string, error) { return "allowAll", nil }
+	cfg := config.CmuxRef{Enabled: true, CmuxPath: writeExecutable(t)}
+	c := checkCmuxLocalLoopWith(cfg, agentDown, okProbe)
+	if c.Severity != SeverityWarn {
+		t.Fatalf("config-enabled + agent down should WARN, got %q (%q)", c.Severity, c.Detail)
+	}
+	if !strings.Contains(c.Remediation, "enable") {
+		t.Errorf("remediation should point at enable: %q", c.Remediation)
+	}
+}

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mvanhorn/agentcookie/internal/chrome"
 	"github.com/mvanhorn/agentcookie/internal/config"
 	"github.com/mvanhorn/agentcookie/internal/keystore"
+	"github.com/mvanhorn/agentcookie/internal/launchd"
 	"github.com/mvanhorn/agentcookie/internal/sinkpush"
 	"github.com/mvanhorn/agentcookie/internal/state"
 )
@@ -767,4 +768,43 @@ func writeKey(t *testing.T, configDir, peer string, mode os.FileMode) {
 	if err := os.Chmod(path, mode); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestCheckCmuxLocalLoop(t *testing.T) {
+	agentUp := func(launchd.Spec) bool { return true }
+	agentDown := func(launchd.Spec) bool { return false }
+	okProbe := func(string) (string, error) { return "allowAll", nil }
+	cmuxOnlyProbe := func(string) (string, error) { return "cmuxOnly", nil }
+
+	t.Run("agent down + cmux absent = skipped (not set up)", func(t *testing.T) {
+		cfg := config.CmuxRef{CmuxPath: filepath.Join(t.TempDir(), "no-cmux")}
+		c := checkCmuxLocalLoopWith(cfg, agentDown, okProbe)
+		if c.Severity != SeveritySkipped {
+			t.Fatalf("got %q, want SKIPPED", c.Severity)
+		}
+	})
+
+	t.Run("agent down + cmux present = warn run enable", func(t *testing.T) {
+		cfg := config.CmuxRef{CmuxPath: writeExecutable(t)}
+		c := checkCmuxLocalLoopWith(cfg, agentDown, okProbe)
+		if c.Severity != SeverityWarn || !strings.Contains(c.Remediation, "enable") {
+			t.Fatalf("got %q / %q, want WARN + enable hint", c.Severity, c.Remediation)
+		}
+	})
+
+	t.Run("agent up + still cmuxOnly = warn restart", func(t *testing.T) {
+		cfg := config.CmuxRef{CmuxPath: writeExecutable(t)}
+		c := checkCmuxLocalLoopWith(cfg, agentUp, cmuxOnlyProbe)
+		if c.Severity != SeverityWarn || !strings.Contains(c.Remediation, "RESTART") {
+			t.Fatalf("got %q / %q, want WARN + restart hint", c.Severity, c.Remediation)
+		}
+	})
+
+	t.Run("agent up + allowAll = OK live", func(t *testing.T) {
+		cfg := config.CmuxRef{CmuxPath: writeExecutable(t)}
+		c := checkCmuxLocalLoopWith(cfg, agentUp, okProbe)
+		if c.Severity != SeverityOK || !strings.Contains(c.Detail, "loop active") {
+			t.Fatalf("got %q / %q, want OK + loop active", c.Severity, c.Detail)
+		}
+	})
 }

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -45,6 +45,7 @@ var (
 	wizardSkipChromeSQLite  bool
 	wizardWriteChromeSQLite bool
 	wizardNoCDP             bool
+	wizardNoCmux            bool
 )
 
 var wizardCmd = &cobra.Command{
@@ -106,6 +107,7 @@ func init() {
 	wizardInstallCmd.Flags().BoolVar(&wizardSkipChromeSQLite, "skip-chrome-sqlite", false, "[sink] opt OUT of universal delivery: the sink daemon never reads Chrome Safe Storage or writes Chrome SQLite/leveldb; sidecar + adapter push remain the cookie-delivery paths (degraded mode). The v0.13 default is universal regardless of TTY; pass this to force degraded. Overrides --write-chrome-sqlite when both passed.")
 	wizardInstallCmd.Flags().BoolVar(&wizardWriteChromeSQLite, "write-chrome-sqlite", false, "[sink] force universal delivery (write the real Default Chrome profile) and honor it even if the one-password keychain open cannot complete; does not silently downgrade to degraded")
 	wizardInstallCmd.Flags().BoolVar(&wizardNoCDP, "no-cdp", false, "[sink] do not enable CDP injection alongside skip_chrome_sqlite. By default, headless installs enable CDP injection so Chrome on the sink still sees synced cookies. Pass --no-cdp for sidecar+adapter-only mode.")
+	wizardInstallCmd.Flags().BoolVar(&wizardNoCmux, "no-cmux", false, "do not auto-enable the cmux local loop even if cmux is installed (by default, install wires Chrome->cmux delivery when cmux is present)")
 
 	wizardUninstallCmd.Flags().StringVar(&wizardRole, "as", "", "source | sink (required)")
 	wizardUninstallCmd.Flags().BoolVar(&wizardForce, "purge", false, "also delete configs and paired keys")
@@ -132,12 +134,21 @@ func runWizardInstall(cmd *cobra.Command, args []string) error {
 	home, _ := os.UserHomeDir()
 	logDir := filepath.Join(home, ".agentcookie", "logs")
 
+	var installErr error
 	switch role {
 	case "source":
-		return wizardInstallSource(cmd.Context(), binPath, logDir)
+		installErr = wizardInstallSource(cmd.Context(), binPath, logDir)
 	case "sink":
-		return wizardInstallSink(cmd.Context(), binPath, logDir)
+		installErr = wizardInstallSink(cmd.Context(), binPath, logDir)
 	}
+	if installErr != nil {
+		return installErr
+	}
+
+	// Default-on cmux local loop: when cmux is installed, wire this
+	// machine's Chrome -> cmux delivery automatically (no-op when cmux is
+	// absent, non-fatal, --no-cmux opts out).
+	maybeAutoEnableCmux()
 	return nil
 }
 

--- a/internal/cmuxconfig/cmuxconfig.go
+++ b/internal/cmuxconfig/cmuxconfig.go
@@ -1,0 +1,127 @@
+// Package cmuxconfig performs targeted, comment-preserving edits to a
+// user's cmux configuration (~/.config/cmux/cmux.json). cmux.json is JSONC
+// (JSON with comments), which Go's encoding/json cannot round-trip without
+// dropping comments and reordering keys, so edits are done as targeted
+// regex substitutions that touch only the keys we own and leave the rest
+// of the file -- comments, schema line, unrelated settings -- byte-stable.
+//
+// The only keys this package writes are automation.socketControlMode and
+// automation.socketPassword, which the cmux local loop needs so a launchd
+// agent (not a cmux child) can reach the control socket.
+package cmuxconfig
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"time"
+)
+
+// ErrNotFound means ~/.config/cmux/cmux.json does not exist -- cmux has
+// not written its config template yet (it does so on first launch).
+// Callers treat this as "cmux not set up", not a hard failure.
+var ErrNotFound = errors.New("cmuxconfig: cmux.json not found")
+
+// DefaultConfigPath returns ~/.config/cmux/cmux.json.
+func DefaultConfigPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".config", "cmux", "cmux.json"), nil
+}
+
+var (
+	// Uncommented (line does not start with //) automation keys.
+	scmRE  = regexp.MustCompile(`(?m)^(\s*"socketControlMode"\s*:\s*)"[^"]*"`)
+	spRE   = regexp.MustCompile(`(?m)^(\s*"socketPassword"\s*:\s*)("[^"]*"|null)`)
+	autoRE = regexp.MustCompile(`(?m)^(\s*"automation"\s*:\s*\{)`)
+)
+
+// SetSocketControlMode sets automation.socketControlMode (and, when
+// password is non-empty, automation.socketPassword) in the cmux config at
+// path. It backs the file up to "<path>.<timestamp>.bak" first and
+// preserves comments and all other settings. now is injected so callers
+// (and tests) control the backup timestamp. Returns the backup path.
+//
+// Idempotent: re-running with the same mode rewrites the same value.
+func SetSocketControlMode(path, mode, password string, now time.Time) (backupPath string, err error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", ErrNotFound
+		}
+		return "", err
+	}
+
+	backupPath = fmt.Sprintf("%s.%s.bak", path, now.Format("20060102-150405"))
+	if err := os.WriteFile(backupPath, data, 0o600); err != nil {
+		return "", fmt.Errorf("cmuxconfig: backup: %w", err)
+	}
+
+	out := applyMode(string(data), mode, password)
+	if err := os.WriteFile(path, []byte(out), 0o600); err != nil {
+		return "", fmt.Errorf("cmuxconfig: write: %w", err)
+	}
+	return backupPath, nil
+}
+
+// applyMode returns src with socketControlMode (and optionally
+// socketPassword) set, choosing among three shapes: an existing
+// uncommented key, an existing uncommented automation block, or no
+// automation block at all.
+func applyMode(src, mode, password string) string {
+	modeQ := strconv.Quote(mode)
+
+	// Case 1: an uncommented socketControlMode already exists -> replace it.
+	if scmRE.MatchString(src) {
+		src = scmRE.ReplaceAllString(src, "${1}"+modeQ)
+		if password != "" {
+			src = setPasswordInExisting(src, password)
+		}
+		return src
+	}
+
+	keys := `    "socketControlMode": ` + modeQ
+	if password != "" {
+		keys += ",\n    \"socketPassword\": " + strconv.Quote(password)
+	}
+
+	// Case 2: an uncommented automation block exists -> inject keys after `{`.
+	if autoRE.MatchString(src) {
+		return autoRE.ReplaceAllString(src, "${1}\n"+keys+",")
+	}
+
+	// Case 3: no automation block -> insert one after the root opening brace.
+	block := "\n  // Added by agentcookie: lets the launchd cmux-sync agent reach\n" +
+		"  // cmux's control socket. Restart cmux to apply.\n" +
+		"  \"automation\": {\n" + keys + "\n  },\n"
+	if i := indexOfFirstBrace(src); i >= 0 {
+		return src[:i+1] + block + src[i+1:]
+	}
+	return src
+}
+
+// setPasswordInExisting sets socketPassword when an automation block with a
+// socketControlMode already exists. Replaces an existing socketPassword, or
+// injects one on the line after socketControlMode (matching the cmux.json
+// 4-space inner indent).
+func setPasswordInExisting(src, password string) string {
+	pwQ := strconv.Quote(password)
+	if spRE.MatchString(src) {
+		return spRE.ReplaceAllString(src, "${1}"+pwQ)
+	}
+	return scmRE.ReplaceAllString(src, "${0},\n    \"socketPassword\": "+pwQ)
+}
+
+func indexOfFirstBrace(s string) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] == '{' {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/cmuxconfig/cmuxconfig.go
+++ b/internal/cmuxconfig/cmuxconfig.go
@@ -17,6 +17,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -74,7 +75,11 @@ func SetSocketControlMode(path, mode, password string, now time.Time) (backupPat
 // uncommented key, an existing uncommented automation block, or no
 // automation block at all.
 func applyMode(src, mode, password string) string {
-	modeQ := strconv.Quote(mode)
+	// strconv.Quote-d values can contain `$`, which regexp ReplaceAllString
+	// would interpret as a capture-group reference and corrupt the value
+	// (Greptile finding). escapeRepl doubles `$` so the value is inserted
+	// literally; group refs like ${1} are added separately and stay live.
+	modeQ := escapeRepl(strconv.Quote(mode))
 
 	// Case 1: an uncommented socketControlMode already exists -> replace it.
 	if scmRE.MatchString(src) {
@@ -85,20 +90,25 @@ func applyMode(src, mode, password string) string {
 		return src
 	}
 
-	keys := `    "socketControlMode": ` + modeQ
+	// keys is inserted via string concatenation (case 3) or ReplaceAllString
+	// (case 2); escape it for the ReplaceAllString path. Concatenation in
+	// case 3 is unaffected by escaping a `$$` because... it is NOT -- so build
+	// two forms: a literal (for case 3) and an escaped (for case 2).
+	keysLiteral := `    "socketControlMode": ` + strconv.Quote(mode)
 	if password != "" {
-		keys += ",\n    \"socketPassword\": " + strconv.Quote(password)
+		keysLiteral += ",\n    \"socketPassword\": " + strconv.Quote(password)
 	}
 
 	// Case 2: an uncommented automation block exists -> inject keys after `{`.
 	if autoRE.MatchString(src) {
-		return autoRE.ReplaceAllString(src, "${1}\n"+keys+",")
+		return autoRE.ReplaceAllString(src, "${1}\n"+escapeRepl(keysLiteral)+",")
 	}
 
 	// Case 3: no automation block -> insert one after the root opening brace.
+	// Plain string concatenation here, so no regexp escaping needed.
 	block := "\n  // Added by agentcookie: lets the launchd cmux-sync agent reach\n" +
 		"  // cmux's control socket. Restart cmux to apply.\n" +
-		"  \"automation\": {\n" + keys + "\n  },\n"
+		"  \"automation\": {\n" + keysLiteral + "\n  },\n"
 	if i := indexOfFirstBrace(src); i >= 0 {
 		return src[:i+1] + block + src[i+1:]
 	}
@@ -108,13 +118,19 @@ func applyMode(src, mode, password string) string {
 // setPasswordInExisting sets socketPassword when an automation block with a
 // socketControlMode already exists. Replaces an existing socketPassword, or
 // injects one on the line after socketControlMode (matching the cmux.json
-// 4-space inner indent).
+// 4-space inner indent). The password value is escaped for ReplaceAllString.
 func setPasswordInExisting(src, password string) string {
-	pwQ := strconv.Quote(password)
+	pwQ := escapeRepl(strconv.Quote(password))
 	if spRE.MatchString(src) {
 		return spRE.ReplaceAllString(src, "${1}"+pwQ)
 	}
 	return scmRE.ReplaceAllString(src, "${0},\n    \"socketPassword\": "+pwQ)
+}
+
+// escapeRepl doubles `$` so a value used as a regexp.ReplaceAllString
+// replacement is inserted literally rather than read as a $-group ref.
+func escapeRepl(s string) string {
+	return strings.ReplaceAll(s, "$", "$$")
 }
 
 func indexOfFirstBrace(s string) int {

--- a/internal/cmuxconfig/cmuxconfig_test.go
+++ b/internal/cmuxconfig/cmuxconfig_test.go
@@ -1,0 +1,147 @@
+package cmuxconfig
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+	"time"
+)
+
+var fixedTime = time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC)
+
+func writeCfg(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "cmux.json")
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func read(t *testing.T, p string) string {
+	t.Helper()
+	b, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
+// uncommentedMode finds an uncommented socketControlMode value.
+var uncommentedMode = regexp.MustCompile(`(?m)^\s*"socketControlMode"\s*:\s*"([^"]*)"`)
+
+func mustMode(t *testing.T, src string) string {
+	t.Helper()
+	m := uncommentedMode.FindStringSubmatch(src)
+	if m == nil {
+		t.Fatalf("no uncommented socketControlMode in:\n%s", src)
+	}
+	return m[1]
+}
+
+func TestSetSocketControlMode_FreshTemplate(t *testing.T) {
+	// Case 3: the shipped template has automation fully commented out.
+	p := writeCfg(t, `{
+  "$schema": "https://raw.githubusercontent.com/manaflow-ai/cmux/main/web/data/cmux.schema.json",
+  "schemaVersion": 1,
+  //   "automation" : {
+  //     "socketControlMode" : "cmuxOnly",
+  //   },
+}
+`)
+	bak, err := SetSocketControlMode(p, "allowAll", "", fixedTime)
+	if err != nil {
+		t.Fatalf("SetSocketControlMode: %v", err)
+	}
+	out := read(t, p)
+	if got := mustMode(t, out); got != "allowAll" {
+		t.Errorf("mode = %q, want allowAll", got)
+	}
+	// schema line + comments preserved.
+	if !regexp.MustCompile(`\$schema`).MatchString(out) {
+		t.Errorf("schema line dropped")
+	}
+	if _, err := os.Stat(bak); err != nil {
+		t.Errorf("backup not created: %v", err)
+	}
+}
+
+func TestSetSocketControlMode_ExistingKey(t *testing.T) {
+	// Case 1: an uncommented value gets replaced; file otherwise stable.
+	p := writeCfg(t, `{
+  "automation": {
+    "socketControlMode": "cmuxOnly",
+    "portBase": 9100
+  }
+}
+`)
+	if _, err := SetSocketControlMode(p, "allowAll", "", fixedTime); err != nil {
+		t.Fatalf("SetSocketControlMode: %v", err)
+	}
+	out := read(t, p)
+	if got := mustMode(t, out); got != "allowAll" {
+		t.Errorf("mode = %q, want allowAll", got)
+	}
+	if !regexp.MustCompile(`"portBase"\s*:\s*9100`).MatchString(out) {
+		t.Errorf("unrelated setting portBase was lost:\n%s", out)
+	}
+}
+
+func TestSetSocketControlMode_ExistingBlockNoKey(t *testing.T) {
+	// Case 2: automation block exists but lacks socketControlMode.
+	p := writeCfg(t, `{
+  "automation": {
+    "portBase": 9100
+  }
+}
+`)
+	if _, err := SetSocketControlMode(p, "allowAll", "", fixedTime); err != nil {
+		t.Fatalf("SetSocketControlMode: %v", err)
+	}
+	out := read(t, p)
+	if got := mustMode(t, out); got != "allowAll" {
+		t.Errorf("mode = %q, want allowAll", got)
+	}
+}
+
+func TestSetSocketControlMode_PasswordMode(t *testing.T) {
+	p := writeCfg(t, `{
+  "schemaVersion": 1
+}
+`)
+	if _, err := SetSocketControlMode(p, "password", "s3cr3t", fixedTime); err != nil {
+		t.Fatalf("SetSocketControlMode: %v", err)
+	}
+	out := read(t, p)
+	if got := mustMode(t, out); got != "password" {
+		t.Errorf("mode = %q, want password", got)
+	}
+	if !regexp.MustCompile(`"socketPassword"\s*:\s*"s3cr3t"`).MatchString(out) {
+		t.Errorf("socketPassword not set:\n%s", out)
+	}
+}
+
+func TestSetSocketControlMode_Idempotent(t *testing.T) {
+	p := writeCfg(t, `{
+  "automation": {
+    "socketControlMode": "allowAll"
+  }
+}
+`)
+	if _, err := SetSocketControlMode(p, "allowAll", "", fixedTime); err != nil {
+		t.Fatalf("SetSocketControlMode: %v", err)
+	}
+	// exactly one uncommented socketControlMode (no duplicate block)
+	if n := len(uncommentedMode.FindAllString(read(t, p), -1)); n != 1 {
+		t.Errorf("expected 1 socketControlMode, got %d (duplicate injected?)", n)
+	}
+}
+
+func TestSetSocketControlMode_MissingFile(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "nope", "cmux.json")
+	if _, err := SetSocketControlMode(p, "allowAll", "", fixedTime); err != ErrNotFound {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}

--- a/internal/cmuxconfig/cmuxconfig_test.go
+++ b/internal/cmuxconfig/cmuxconfig_test.go
@@ -145,3 +145,16 @@ func TestSetSocketControlMode_MissingFile(t *testing.T) {
 		t.Fatalf("expected ErrNotFound, got %v", err)
 	}
 }
+
+func TestSetSocketControlMode_PasswordWithDollarSign(t *testing.T) {
+	// Greptile: a `$` in the password must not be read as a regexp group ref.
+	p := writeCfg(t, "{\n  \"schemaVersion\": 1\n}\n")
+	pw := `a$1b$$c`
+	if _, err := SetSocketControlMode(p, "password", pw, fixedTime); err != nil {
+		t.Fatalf("SetSocketControlMode: %v", err)
+	}
+	out := read(t, p)
+	if !regexp.MustCompile(`"socketPassword"\s*:\s*"a\$1b\$\$c"`).MatchString(out) {
+		t.Errorf("password with $ was corrupted:\n%s", out)
+	}
+}

--- a/internal/launchd/plist.go
+++ b/internal/launchd/plist.go
@@ -18,8 +18,9 @@ import (
 type Role string
 
 const (
-	RoleSource Role = "source"
-	RoleSink   Role = "sink"
+	RoleSource   Role = "source"
+	RoleSink     Role = "sink"
+	RoleCmuxSync Role = "cmux-sync"
 )
 
 // Spec is the input to plist generation. All paths must be absolute.
@@ -45,7 +46,7 @@ func (s Spec) Render() ([]byte, error) {
 	if s.LogDir == "" {
 		return nil, fmt.Errorf("LogDir is required")
 	}
-	if s.Role != RoleSource && s.Role != RoleSink {
+	if s.Role != RoleSource && s.Role != RoleSink && s.Role != RoleCmuxSync {
 		return nil, fmt.Errorf("invalid Role %q", s.Role)
 	}
 

--- a/internal/launchd/plist_test.go
+++ b/internal/launchd/plist_test.go
@@ -36,6 +36,30 @@ func TestSpecRenderSourceRole(t *testing.T) {
 	}
 }
 
+func TestSpecRenderCmuxSyncRole(t *testing.T) {
+	s := Spec{
+		Role:       RoleCmuxSync,
+		BinaryPath: "/Users/test/bin/agentcookie",
+		LogDir:     "/Users/test/.agentcookie/logs",
+		ExtraArgs:  []string{"--watch"},
+	}
+	out, err := s.Render()
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	str := string(out)
+	for _, want := range []string{
+		"dev.agentcookie.cmux-sync",
+		"<string>cmux-sync</string>",
+		"<string>--watch</string>",
+		"/Users/test/.agentcookie/logs/cmux-sync.out.log",
+	} {
+		if !strings.Contains(str, want) {
+			t.Errorf("rendered plist missing %q\nFull output:\n%s", want, str)
+		}
+	}
+}
+
 func TestSpecRenderSinkRole(t *testing.T) {
 	s := Spec{
 		Role:       RoleSink,


### PR DESCRIPTION
Builds on #86 (local loop) and #88 (batched injection). Makes the loop **automatic** instead of a manual command: with cmux installed, your Chrome session flows into cmux's browser hands-free.

## What
- **`agentcookie cmux-sync enable | disable`** — `enable` sets cmux's `socketControlMode` to `allowAll` (backing up `~/.config/cmux/cmux.json` first), installs a `dev.agentcookie.cmux-sync` LaunchAgent running `cmux-sync --watch` over the full cookie set, and prints the one-time "restart cmux" step. Clean no-op when cmux (or its config) is absent. Idempotent.
- **`wizard install` auto-enables** when cmux is detected; `--no-cmux` opts out.
- **`doctor`** reports loop liveness: not-enabled / enabled-but-needs-restart / live.

## New internals
- `internal/launchd` gains a `cmux-sync` role.
- `internal/cmuxconfig` — a JSONC-safe, backup-first writer for `automation.socketControlMode` (Go can't round-trip JSONC, so targeted edits preserve comments/settings).

## The one honest cost
Turning it on needs **one cmux restart** to apply the socket mode (it's read only at app launch; there's no live RPC, and a LaunchAgent isn't a cmux child so the default `cmuxOnly` blocks it). After that single restart it's permanent and hands-free. `doctor` distinguishes "needs restart" from "live" so it's never a mystery. The manual `cmux-sync --once/--watch` run inside cmux still works with no socket change.

## Tests
688 pass; vet/lint clean. Coverage: launchd role, the cmux.json writer (3 JSONC shapes + password + idempotent + missing-file), enable/disable (no-op when cmux absent, wires mode+agent, no agent when cmux.json missing), wizard `--no-cmux` gate, and doctor's four liveness states.

Stacks on `main` independently of #88 (zero file overlap). Design doc: `docs/plans/2026-06-03-003-feat-cmux-default-on-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)