### PR TITLE
fix(cmux): keep the sync loop invisible (background workspace + delta pushes)

### DIFF
--- a/internal/cli/cmux_sync.go
+++ b/internal/cli/cmux_sync.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"hash/fnv"
 	"os"
 	"time"
 
@@ -111,6 +112,17 @@ func runCmuxSync(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("cmux CLI not found at %s (install cmux, or set --cmux-path / cmux.cmux_path in source.yaml)", adapter.CLIBinary())
 	}
 
+	// lastPushed tracks the per-cookie content hash of the last successful
+	// injection (watch mode only; nil in --once). Injected cookies persist
+	// at cmux's WKWebsiteDataStore profile level, so a cookie only needs
+	// re-pushing when its content actually changes -- without this, every
+	// debounced Chrome fs-event re-injected the full multi-thousand-cookie
+	// set (~every 30s, forever).
+	var lastPushed map[string]uint64
+	if cmuxSyncWatch {
+		lastPushed = map[string]uint64{}
+	}
+
 	syncOnce := func(ctx context.Context) (int, error) {
 		blocklist, err := loadFreshBlocklist()
 		if err != nil {
@@ -122,21 +134,31 @@ func runCmuxSync(cmd *cobra.Command, args []string) error {
 		}
 		// Apply the cmux domain filter the same way RunAll would before Push.
 		cookies = sinkpush.FilterByHostPatterns(cookies, domainFilter)
+		push := cookies
+		if lastPushed != nil {
+			push = deltaCookies(cookies, lastPushed)
+		}
 		if cmuxSyncVerbose {
-			fmt.Fprintf(os.Stderr, "agentcookie cmux-sync: read %d, blocked %d, dbsc(warn=%d skip=%d), injecting %d\n",
-				st.totalRead, st.totalDropped, st.dbsc.warned, st.dbsc.skipped, len(cookies))
+			fmt.Fprintf(os.Stderr, "agentcookie cmux-sync: read %d, blocked %d, dbsc(warn=%d skip=%d), injecting %d (of %d)\n",
+				st.totalRead, st.totalDropped, st.dbsc.warned, st.dbsc.skipped, len(push), len(cookies))
 		}
 		if cmuxSyncDryRun {
-			fmt.Fprintf(os.Stderr, "agentcookie cmux-sync: dry-run; not injecting %d cookies\n", len(cookies))
+			fmt.Fprintf(os.Stderr, "agentcookie cmux-sync: dry-run; not injecting %d cookies\n", len(push))
 			return 0, nil
 		}
-		if len(cookies) == 0 {
+		if len(push) == 0 {
 			return 0, nil
 		}
-		if err := adapter.Push(cookies); err != nil {
+		if err := adapter.Push(push); err != nil {
 			return 0, err
 		}
-		return len(cookies), nil
+		if lastPushed != nil {
+			// Rebuild from the full current set, not just the delta: every
+			// cookie in it is either unchanged-since-pushed or just pushed,
+			// and rebuilding prunes entries for cookies Chrome deleted.
+			lastPushed = hashCookieSet(cookies)
+		}
+		return len(push), nil
 	}
 
 	if cmuxSyncOnce {
@@ -170,4 +192,40 @@ func runCmuxSync(cmd *cobra.Command, args []string) error {
 	}
 	fmt.Fprintf(os.Stderr, "agentcookie cmux-sync --watch: watching %s, injecting into cmux\n", cfg.Chrome.DBPath)
 	return w.Run(cmd.Context())
+}
+
+// cmuxCookieKey identifies a cookie across sync cycles. Host+name+path is
+// the same identity WebKit upserts on, so a changed value under the same
+// key is an update, not a new cookie.
+func cmuxCookieKey(c chrome.Cookie) string {
+	return c.HostKey + "\x00" + c.Name + "\x00" + c.Path
+}
+
+// cmuxCookieHash digests the fields that matter to injection. Any change
+// flips the hash and re-queues the cookie for push.
+func cmuxCookieHash(c chrome.Cookie) uint64 {
+	h := fnv.New64a()
+	fmt.Fprintf(h, "%s\x00%d\x00%d\x00%d\x00%d", c.Value, c.ExpiresUTC, c.IsSecure, c.IsHTTPOnly, c.SameSite)
+	return h.Sum64()
+}
+
+// deltaCookies returns the cookies that are new or changed relative to
+// the last successfully pushed set.
+func deltaCookies(cookies []chrome.Cookie, lastPushed map[string]uint64) []chrome.Cookie {
+	var out []chrome.Cookie
+	for _, c := range cookies {
+		if h, ok := lastPushed[cmuxCookieKey(c)]; !ok || h != cmuxCookieHash(c) {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// hashCookieSet builds the lastPushed map for a full cookie set.
+func hashCookieSet(cookies []chrome.Cookie) map[string]uint64 {
+	m := make(map[string]uint64, len(cookies))
+	for _, c := range cookies {
+		m[cmuxCookieKey(c)] = cmuxCookieHash(c)
+	}
+	return m
 }

--- a/internal/cli/cmux_sync_test.go
+++ b/internal/cli/cmux_sync_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+
+	"github.com/mvanhorn/agentcookie/internal/chrome"
 )
 
 // runCmuxSync validates the mode flags before any Chrome/keychain/cmux I/O,
@@ -32,4 +34,56 @@ func TestCmuxSyncFlagValidation(t *testing.T) {
 			t.Fatalf("expected mutual-exclusion error, got %v", err)
 		}
 	})
+}
+
+func TestDeltaCookies(t *testing.T) {
+	a := chrome.Cookie{HostKey: ".x.com", Name: "a", Path: "/", Value: "1"}
+	b := chrome.Cookie{HostKey: ".x.com", Name: "b", Path: "/", Value: "2", ExpiresUTC: 100}
+	full := []chrome.Cookie{a, b}
+
+	// Empty state: everything is new (the startup full push).
+	if got := deltaCookies(full, map[string]uint64{}); len(got) != 2 {
+		t.Fatalf("empty state should push all, got %d", len(got))
+	}
+
+	state := hashCookieSet(full)
+
+	// Unchanged set: nothing to push.
+	if got := deltaCookies(full, state); len(got) != 0 {
+		t.Fatalf("unchanged set should be empty delta, got %d", len(got))
+	}
+
+	// Value change re-queues only that cookie.
+	a2 := a
+	a2.Value = "rotated"
+	if got := deltaCookies([]chrome.Cookie{a2, b}, state); len(got) != 1 || got[0].Name != "a" {
+		t.Fatalf("expected only the changed cookie, got %+v", got)
+	}
+
+	// Expiry change alone re-queues too.
+	b2 := b
+	b2.ExpiresUTC = 200
+	if got := deltaCookies([]chrome.Cookie{a, b2}, state); len(got) != 1 || got[0].Name != "b" {
+		t.Fatalf("expected only the expiry-changed cookie, got %+v", got)
+	}
+
+	// A new cookie under a different path is a distinct identity.
+	c := chrome.Cookie{HostKey: ".x.com", Name: "a", Path: "/api", Value: "1"}
+	if got := deltaCookies([]chrome.Cookie{a, b, c}, state); len(got) != 1 || got[0].Path != "/api" {
+		t.Fatalf("expected only the new path-scoped cookie, got %+v", got)
+	}
+}
+
+func TestHashCookieSet_PrunesDeleted(t *testing.T) {
+	a := chrome.Cookie{HostKey: ".x.com", Name: "a", Path: "/", Value: "1"}
+	b := chrome.Cookie{HostKey: ".x.com", Name: "b", Path: "/", Value: "2"}
+	state := hashCookieSet([]chrome.Cookie{a, b})
+	if len(state) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(state))
+	}
+	// Rebuilding from the current (smaller) set drops the deleted cookie.
+	state = hashCookieSet([]chrome.Cookie{a})
+	if len(state) != 1 {
+		t.Fatalf("rebuild should prune deletions, got %d entries", len(state))
+	}
 }

--- a/internal/sinkpush/adapter_cmux.go
+++ b/internal/sinkpush/adapter_cmux.go
@@ -261,8 +261,9 @@ func (a *CmuxAdapter) ensureWorkspaceLocked() (string, error) {
 
 // findWorkspaceRef scans `workspace list --json` output for a workspace
 // whose title is name. cmux prefixes active-workspace titles with a
-// status glyph ("✳ agentcookie"), so a trailing-word match is accepted
-// alongside the exact one.
+// single status glyph ("✳ agentcookie"), so a glyph-plus-name title is
+// accepted alongside the exact one -- but not arbitrary leading words
+// ("dev agentcookie" is someone else's workspace).
 func findWorkspaceRef(listJSON, name string) string {
 	var parsed struct {
 		Workspaces []struct {
@@ -274,7 +275,10 @@ func findWorkspaceRef(listJSON, name string) string {
 		return ""
 	}
 	for _, w := range parsed.Workspaces {
-		if w.Title == name || strings.HasSuffix(w.Title, " "+name) {
+		if w.Title == name {
+			return w.Ref
+		}
+		if fields := strings.Fields(w.Title); len(fields) == 2 && fields[1] == name && len([]rune(fields[0])) == 1 {
 			return w.Ref
 		}
 	}
@@ -377,15 +381,18 @@ func isSurfaceError(err error) bool {
 		strings.Contains(msg, "not a browser")
 }
 
-// isWorkspaceError reports whether err looks like a stale/missing
+// isWorkspaceError reports whether err is specifically a stale/missing
 // workspace (e.g. the user closed the background workspace), which
 // warrants one recreate. cmux answers "not_found: Workspace not found"
-// for a closed workspace ref.
+// for a closed workspace ref. Deliberately NOT any error mentioning
+// "workspace" -- a quota or permission failure would recur on the
+// recreated workspace too, so recreating for those is a spurious
+// workspace per failed sync.
 func isWorkspaceError(err error) bool {
 	if err == nil {
 		return false
 	}
-	return strings.Contains(strings.ToLower(err.Error()), "workspace")
+	return strings.Contains(strings.ToLower(err.Error()), "workspace not found")
 }
 
 // isCmuxUnavailable reports whether err means cmux itself can't be

--- a/internal/sinkpush/adapter_cmux.go
+++ b/internal/sinkpush/adapter_cmux.go
@@ -27,6 +27,19 @@ const chromeEpochOffsetSec = 11644473600
 // output, e.g. "OK surface=surface:45 pane=pane:32 placement=split".
 var surfaceRefRE = regexp.MustCompile(`surface:\d+`)
 
+// workspaceRefRE extracts the `workspace:N` ref from `cmux workspace
+// create` output, e.g. "OK workspace:9".
+var workspaceRefRE = regexp.MustCompile(`workspace:\d+`)
+
+// cmuxWorkspaceName is the dedicated background workspace the adapter
+// parks its injection surface in. The cmux-sync LaunchAgent runs outside
+// cmux, so $CMUX_WORKSPACE_ID is unset and a bare `browser open` lands
+// the pane in whatever workspace the user has focused -- right in their
+// face, and reopened on every sync if they close it. A named, unfocused
+// workspace keeps the surface alive without ever entering the user's
+// view.
+const cmuxWorkspaceName = "agentcookie"
+
 // CmuxAdapter delivers synced cookies into cmux's embedded WebKit
 // browser via the cmux control socket, so an agent driving cmux's
 // browser pane wakes up authenticated. It is the fourth delivery
@@ -45,9 +58,12 @@ var surfaceRefRE = regexp.MustCompile(`surface:\d+`)
 //   - browser.cookies.set REQUIRES a browser surface_id; there is no
 //     profile-level set, and browser surfaces are not listed by
 //     surface.list. So the adapter opens its own about:blank surface
-//     (unfocused) and caches it for reuse. Injected cookies persist at
+//     (unfocused, inside the dedicated cmuxWorkspaceName background
+//     workspace) and caches it for reuse. Injected cookies persist at
 //     the WKWebsiteDataStore (profile) level, surviving pane close, so
 //     a single injection authenticates the agent's future panes.
+//   - Surface refs are workspace-scoped: any command that targets the
+//     cached surface by ref must carry the cached workspace ref too.
 //   - expires is Unix seconds; omit it for session cookies. WebKit
 //     clamps far-future expiries to its ~400-day max (expected).
 //   - Cookie values are passed through VERBATIM. The App-Bound (Chrome
@@ -58,8 +74,9 @@ type CmuxAdapter struct {
 	binary       string
 	domainFilter []string
 
-	mu        sync.Mutex
-	surfaceID string // cached browser surface ref, opened lazily, reused
+	mu           sync.Mutex
+	surfaceID    string // cached browser surface ref, opened lazily, reused
+	workspaceRef string // cached background workspace ref hosting the surface
 
 	// run executes a cmux subcommand and returns stdout. Swappable in
 	// tests; defaults to execCmux.
@@ -182,12 +199,27 @@ func (a *CmuxAdapter) Push(cookies []chrome.Cookie) error {
 }
 
 // ensureSurfaceLocked returns the cached browser surface ref, opening an
-// unfocused about:blank pane if none is cached. Caller must hold a.mu.
+// unfocused about:blank pane inside the dedicated background workspace
+// if none is cached. If the cached workspace has been closed by the user
+// since, it is recreated once. Caller must hold a.mu.
 func (a *CmuxAdapter) ensureSurfaceLocked() (string, error) {
 	if a.surfaceID != "" {
 		return a.surfaceID, nil
 	}
-	out, err := a.run("browser", "open", "about:blank", "--focus", "false")
+	ws, err := a.ensureWorkspaceLocked()
+	if err != nil {
+		return "", fmt.Errorf("background workspace: %w", err)
+	}
+	out, err := a.run("browser", "open", "about:blank", "--workspace", ws, "--focus", "false")
+	if err != nil && isWorkspaceError(err) {
+		// The cached workspace went away (user closed it). Recreate once.
+		a.workspaceRef = ""
+		ws, werr := a.ensureWorkspaceLocked()
+		if werr != nil {
+			return "", fmt.Errorf("recreate background workspace after %v: %w", err, werr)
+		}
+		out, err = a.run("browser", "open", "about:blank", "--workspace", ws, "--focus", "false")
+	}
 	if err != nil {
 		return "", err
 	}
@@ -197,6 +229,56 @@ func (a *CmuxAdapter) ensureSurfaceLocked() (string, error) {
 	}
 	a.surfaceID = sid
 	return sid, nil
+}
+
+// ensureWorkspaceLocked returns the cached background workspace ref,
+// finding an existing workspace named cmuxWorkspaceName or creating an
+// unfocused one. Caller must hold a.mu.
+func (a *CmuxAdapter) ensureWorkspaceLocked() (string, error) {
+	if a.workspaceRef != "" {
+		return a.workspaceRef, nil
+	}
+	// Reuse an existing workspace from a previous run so restarts don't
+	// accumulate one workspace each. A list failure is non-fatal: fall
+	// through to create.
+	if out, err := a.run("workspace", "list", "--json"); err == nil {
+		if ref := findWorkspaceRef(out, cmuxWorkspaceName); ref != "" {
+			a.workspaceRef = ref
+			return ref, nil
+		}
+	}
+	out, err := a.run("workspace", "create", "--name", cmuxWorkspaceName, "--focus", "false")
+	if err != nil {
+		return "", err
+	}
+	ref := workspaceRefRE.FindString(out)
+	if ref == "" {
+		return "", fmt.Errorf("could not parse workspace ref from %q", strings.TrimSpace(out))
+	}
+	a.workspaceRef = ref
+	return ref, nil
+}
+
+// findWorkspaceRef scans `workspace list --json` output for a workspace
+// whose title is name. cmux prefixes active-workspace titles with a
+// status glyph ("✳ agentcookie"), so a trailing-word match is accepted
+// alongside the exact one.
+func findWorkspaceRef(listJSON, name string) string {
+	var parsed struct {
+		Workspaces []struct {
+			Ref   string `json:"ref"`
+			Title string `json:"title"`
+		} `json:"workspaces"`
+	}
+	if err := json.Unmarshal([]byte(listJSON), &parsed); err != nil {
+		return ""
+	}
+	for _, w := range parsed.Workspaces {
+		if w.Title == name || strings.HasSuffix(w.Title, " "+name) {
+			return w.Ref
+		}
+	}
+	return ""
 }
 
 // cmuxCookieBatch caps how many cookies ride one browser.cookies.set
@@ -293,6 +375,17 @@ func isSurfaceError(err error) bool {
 	// "not found" (Go's exec.LookPath error contains it).
 	return strings.Contains(msg, "surface") ||
 		strings.Contains(msg, "not a browser")
+}
+
+// isWorkspaceError reports whether err looks like a stale/missing
+// workspace (e.g. the user closed the background workspace), which
+// warrants one recreate. cmux answers "not_found: Workspace not found"
+// for a closed workspace ref.
+func isWorkspaceError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "workspace")
 }
 
 // isCmuxUnavailable reports whether err means cmux itself can't be

--- a/internal/sinkpush/adapter_cmux_test.go
+++ b/internal/sinkpush/adapter_cmux_test.go
@@ -16,16 +16,43 @@ import (
 type fakeCmux struct {
 	calls    [][]string
 	openOut  string
-	openErr  error
+	openErrs []error // consumed in order, one per browser open call
+	openIdx  int
+	listOut  string // workspace list --json response ("" = empty list)
+	listErr  error
+	wsOut    string // workspace create response
+	wsErr    error
 	setErrs  []error // consumed in order, one per browser.cookies.set call
 	setCalls int
 }
 
 func (f *fakeCmux) run(args ...string) (string, error) {
 	f.calls = append(f.calls, args)
+	if len(args) >= 2 && args[0] == "workspace" && args[1] == "list" {
+		if f.listErr != nil {
+			return "", f.listErr
+		}
+		out := f.listOut
+		if out == "" {
+			out = `{"workspaces":[]}`
+		}
+		return out, nil
+	}
+	if len(args) >= 2 && args[0] == "workspace" && args[1] == "create" {
+		if f.wsErr != nil {
+			return "", f.wsErr
+		}
+		out := f.wsOut
+		if out == "" {
+			out = "OK workspace:7"
+		}
+		return out, nil
+	}
 	if len(args) >= 2 && args[0] == "browser" && args[1] == "open" {
-		if f.openErr != nil {
-			return "", f.openErr
+		i := f.openIdx
+		f.openIdx++
+		if i < len(f.openErrs) && f.openErrs[i] != nil {
+			return "", f.openErrs[i]
 		}
 		out := f.openOut
 		if out == "" {
@@ -168,9 +195,17 @@ func TestCmuxPush_OpensSurfaceThenBatchSets(t *testing.T) {
 	if err := a.Push(cookies); err != nil {
 		t.Fatalf("Push: %v", err)
 	}
-	// One open, and both cookies in a single batched set call.
-	if f.calls[0][0] != "browser" || f.calls[0][1] != "open" {
-		t.Errorf("first call should open a surface, got %v", f.calls[0])
+	// One open (inside the background workspace), and both cookies in a
+	// single batched set call.
+	open := findCall(f.calls, "browser", "open")
+	if open == nil {
+		t.Fatalf("no browser open call, got %v", f.calls)
+	}
+	if !hasFlag(open, "--workspace", "workspace:7") {
+		t.Errorf("open must target the background workspace, got %v", open)
+	}
+	if !hasFlag(open, "--focus", "false") {
+		t.Errorf("open must be unfocused, got %v", open)
 	}
 	if f.setCalls != 1 {
 		t.Errorf("expected 1 batched cookies.set call for 2 cookies, got %d", f.setCalls)
@@ -342,6 +377,99 @@ func countOpens(calls [][]string) int {
 		}
 	}
 	return n
+}
+
+// findCall returns the first recorded call whose leading args match.
+func findCall(calls [][]string, prefix ...string) []string {
+	for _, c := range calls {
+		if len(c) < len(prefix) {
+			continue
+		}
+		match := true
+		for i, p := range prefix {
+			if c[i] != p {
+				match = false
+				break
+			}
+		}
+		if match {
+			return c
+		}
+	}
+	return nil
+}
+
+// hasFlag reports whether args contains the flag followed by value.
+func hasFlag(args []string, flag, value string) bool {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == flag && args[i+1] == value {
+			return true
+		}
+	}
+	return false
+}
+
+func TestCmuxPush_ReusesExistingNamedWorkspace(t *testing.T) {
+	// A workspace named "agentcookie" from a previous run is reused (cmux
+	// prefixes active titles with a status glyph), so restarts don't
+	// accumulate one background workspace each.
+	f := &fakeCmux{listOut: `{"workspaces":[
+		{"ref":"workspace:2","title":"✳ Claude Code"},
+		{"ref":"workspace:5","title":"⠂ agentcookie"}
+	]}`}
+	a := newTestCmux(f, nil)
+	if err := a.Push([]chrome.Cookie{{HostKey: ".x.com", Name: "a", Value: "1"}}); err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	if c := findCall(f.calls, "workspace", "create"); c != nil {
+		t.Errorf("existing workspace must be reused, but create was called: %v", c)
+	}
+	open := findCall(f.calls, "browser", "open")
+	if open == nil || !hasFlag(open, "--workspace", "workspace:5") {
+		t.Errorf("open should target the existing workspace:5, got %v", open)
+	}
+}
+
+func TestCmuxPush_RecreatesClosedWorkspace(t *testing.T) {
+	// The cached background workspace was closed by the user between
+	// syncs: browser open fails with a workspace error, and the adapter
+	// recreates the workspace once and retries the open.
+	f := &fakeCmux{openErrs: []error{errors.New("not_found: Workspace not found")}}
+	a := newTestCmux(f, nil)
+	a.workspaceRef = "workspace:stale"
+	if err := a.Push([]chrome.Cookie{{HostKey: ".x.com", Name: "a", Value: "1"}}); err != nil {
+		t.Fatalf("Push should recover by recreating the workspace, got %v", err)
+	}
+	if findCall(f.calls, "workspace", "create") == nil {
+		t.Errorf("expected a workspace create after the stale-workspace open failure, calls: %v", f.calls)
+	}
+	if countOpens(f.calls) != 2 {
+		t.Errorf("expected 2 opens (stale fail + retry), got %d", countOpens(f.calls))
+	}
+	if a.workspaceRef != "workspace:7" {
+		t.Errorf("workspaceRef should be the recreated workspace, got %q", a.workspaceRef)
+	}
+}
+
+func TestFindWorkspaceRef(t *testing.T) {
+	list := `{"workspaces":[
+		{"ref":"workspace:1","title":"✳ Claude Code"},
+		{"ref":"workspace:3","title":"agentcookie"},
+		{"ref":"workspace:4","title":"not-agentcookie"}
+	]}`
+	if got := findWorkspaceRef(list, "agentcookie"); got != "workspace:3" {
+		t.Errorf("exact title: got %q, want workspace:3", got)
+	}
+	glyph := `{"workspaces":[{"ref":"workspace:9","title":"⠐ agentcookie"}]}`
+	if got := findWorkspaceRef(glyph, "agentcookie"); got != "workspace:9" {
+		t.Errorf("glyph-prefixed title: got %q, want workspace:9", got)
+	}
+	if got := findWorkspaceRef(list, "missing"); got != "" {
+		t.Errorf("missing name should return empty, got %q", got)
+	}
+	if got := findWorkspaceRef("not json", "agentcookie"); got != "" {
+		t.Errorf("bad json should return empty, got %q", got)
+	}
 }
 
 func TestCmuxPush_SurfaceErrorAfterReopenHardFails(t *testing.T) {

--- a/internal/sinkpush/adapter_cmux_test.go
+++ b/internal/sinkpush/adapter_cmux_test.go
@@ -464,11 +464,41 @@ func TestFindWorkspaceRef(t *testing.T) {
 	if got := findWorkspaceRef(glyph, "agentcookie"); got != "workspace:9" {
 		t.Errorf("glyph-prefixed title: got %q, want workspace:9", got)
 	}
+	// Greptile P2: only a single leading glyph is accepted -- a user
+	// workspace that merely ends with the name must not be hijacked.
+	words := `{"workspaces":[
+		{"ref":"workspace:2","title":"dev agentcookie"},
+		{"ref":"workspace:6","title":"my old agentcookie"}
+	]}`
+	if got := findWorkspaceRef(words, "agentcookie"); got != "" {
+		t.Errorf("word-prefixed titles must not match, got %q", got)
+	}
 	if got := findWorkspaceRef(list, "missing"); got != "" {
 		t.Errorf("missing name should return empty, got %q", got)
 	}
 	if got := findWorkspaceRef("not json", "agentcookie"); got != "" {
 		t.Errorf("bad json should return empty, got %q", got)
+	}
+}
+
+func TestIsWorkspaceError_OnlyMissingWorkspace(t *testing.T) {
+	// Greptile P1: only the closed/missing-ref signature triggers the
+	// one-shot recreate. Quota or permission failures would recur on a
+	// fresh workspace, so recreating for them just leaks workspaces.
+	if !isWorkspaceError(errors.New("not_found: Workspace not found")) {
+		t.Error("missing-workspace error must trigger recreate")
+	}
+	for _, msg := range []string{
+		"workspace quota exceeded",
+		"workspace permission denied",
+		"connection refused",
+	} {
+		if isWorkspaceError(errors.New(msg)) {
+			t.Errorf("%q must not trigger a workspace recreate", msg)
+		}
+	}
+	if isWorkspaceError(nil) {
+		t.Error("nil error must not trigger recreate")
 	}
 }
 


### PR DESCRIPTION
## Problem

The cmux-sync LaunchAgent runs outside cmux, so `$CMUX_WORKSPACE_ID` is unset and the adapter's bare `browser open` landed the about:blank injection pane in whatever workspace the user had focused. Closing the pane was a losing battle: the next debounced Chrome fs-event hit the reopen path and put it right back, roughly every 30s, forever. The same loop also re-injected the full ~8.5k-cookie set on every cycle.

## Fix

- The adapter parks its injection surface in a dedicated unfocused `agentcookie` workspace: found by name across restarts, recreated once if the user closes it. The pane never enters the user's view.
- `cmux-sync --watch` keeps a per-cookie content hash (FNV-1a over value, expiry, flags) of the last successful injection and pushes only new or changed cookies. Injected cookies persist at the WKWebsiteDataStore profile level, so full-set re-pushes were pure churn; a quiet cycle now skips the RPC entirely. State rebuilds from the full current set after each successful push, pruning deletions. `--once` keeps full-set semantics.

One cmux detail worth recording: surface refs are workspace-scoped, so the adapter caches the workspace ref alongside the surface ref.

## Verification

- `go test ./internal/sinkpush ./internal/cli`: 318 passed, including new coverage for background-workspace targeting, named-workspace reuse, stale-workspace recreation, and delta computation
- golangci-lint: no issues
- Live against a running cmux: surface opens in the background workspace with focus unchanged, cookies inject, a second run reuses the workspace (exactly one `agentcookie` workspace after repeated runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)