### PR TITLE
fix(cmux): serialize sync cycles so the startup push can't double-fire

### DIFF
--- a/internal/cli/cmux_sync.go
+++ b/internal/cli/cmux_sync.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -123,7 +124,16 @@ func runCmuxSync(cmd *cobra.Command, args []string) error {
 		lastPushed = map[string]uint64{}
 	}
 
+	// The watcher fires pushes as goroutines (the startup push in
+	// particular bypasses the rate cap), so two cycles can overlap. They
+	// would both read the same lastPushed snapshot, compute the same
+	// "everything is new" delta, and double-push the full set -- and race
+	// on the map. Serialize whole cycles.
+	var cycleMu sync.Mutex
+
 	syncOnce := func(ctx context.Context) (int, error) {
+		cycleMu.Lock()
+		defer cycleMu.Unlock()
 		blocklist, err := loadFreshBlocklist()
 		if err != nil {
 			return 0, err


### PR DESCRIPTION
Follow-up to #91, caught watching the redeployed loop's first minutes live.

## Problem

`watcher.Run` kicks the startup push as a goroutine without the rate cap, so it can overlap the first debounced fs-event cycle. Both cycles read the same empty `lastPushed` snapshot, compute the same "everything is new" delta, and double-push the full ~8.5k-cookie set, racing on the map itself. Observed in the live log: `pushed 8510 cookies (startup)` immediately followed by `pushed 8510 cookies (fs-event)`.

## Fix

A cycle mutex around `syncOnce`: the overlapping cycle waits and then sees the first cycle's updated state, so its delta collapses to just what actually changed.

## Verification

- `go test -race ./internal/cli ./internal/sinkpush`: 319 passed
- golangci-lint: no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)