### PR TITLE
feat(orca): orca-sync - log orca's embedded browser into your sites via live CDP injection

### DIFF
--- a/internal/cli/orca_sync.go
+++ b/internal/cli/orca_sync.go
@@ -1,0 +1,253 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mvanhorn/agentcookie/internal/chrome"
+	"github.com/mvanhorn/agentcookie/internal/config"
+	"github.com/mvanhorn/agentcookie/internal/livecdp"
+	"github.com/mvanhorn/agentcookie/internal/sinkpush"
+	"github.com/mvanhorn/agentcookie/internal/watcher"
+)
+
+var (
+	orcaSyncOnce     bool
+	orcaSyncWatch    bool
+	orcaSyncVerbose  bool
+	orcaSyncDryRun   bool
+	orcaSyncSkipDBSC bool
+	orcaSyncDomains  []string
+	orcaSyncCDP      string
+	orcaSyncBrowser  string
+)
+
+// orcaSyncPollInterval is how often --watch re-injects the current cookie set
+// into orca's open panes, independent of Chrome cookie changes. It catches a
+// browser pane the user opens after the watcher started: the fsnotify watch
+// only fires on a Chrome cookie write, so without a poll a freshly-opened pane
+// would read logged-out until the next login change.
+const orcaSyncPollInterval = 5 * time.Second
+
+var orcaSyncCmd = &cobra.Command{
+	Use:   "orca-sync",
+	Short: "Local loop: read this machine's Chrome and inject the session into orca's browser over CDP",
+	Long: `orca-sync is the Electron counterpart to cmux-sync and agent-sync. It
+reads this Mac's Chrome cookies (decrypt + blocklist + DBSC filter, the same
+pipeline source uses) and injects them -- as plaintext, over the DevTools
+Protocol -- into orca's embedded browser panes, so a browser pane in orca
+wakes up logged into your sites. No orca change: orca is Electron, so it
+exposes CDP when launched with --remote-debugging-port.
+
+  agentcookie orca-sync --once    one read+inject cycle, then exit.
+  agentcookie orca-sync --watch   long-running; fsnotify watches Chrome's
+                                  Cookies SQLite and re-injects on change, and
+                                  re-injects open panes periodically so a pane
+                                  opened later also wakes up logged in.
+
+Setup: launch orca with a loopback debug port, e.g.
+  open -a Orca --args --remote-debugging-port=9222
+and open a browser pane in orca (orca-sync injects into open panes). Note the
+real tradeoff: while that port is open, any local process can drive orca's
+browser, so prefer launching it intentionally.
+
+Device-bound (DBSC) cookies -- Google/Workspace account cookies -- cannot
+transfer to another browser and are reported, not faked. Non-DBSC sites
+(GitHub-class, the large majority) work.`,
+	RunE: runOrcaSync,
+}
+
+func init() {
+	orcaSyncCmd.Flags().BoolVar(&orcaSyncOnce, "once", false, "single read+inject cycle, then exit")
+	orcaSyncCmd.Flags().BoolVar(&orcaSyncWatch, "watch", false, "long-running fsnotify watcher; re-injects on every Chrome cookie write (debounced) and polls open panes")
+	orcaSyncCmd.Flags().BoolVar(&orcaSyncVerbose, "verbose", false, "log per-cycle counts to stderr")
+	orcaSyncCmd.Flags().BoolVar(&orcaSyncDryRun, "dry-run", false, "read + filter but do not inject into orca")
+	orcaSyncCmd.Flags().BoolVar(&orcaSyncSkipDBSC, "skip-dbsc-suspect", false, "drop cookies that look device-bound (DBSC); also honored via AGENTCOOKIE_SKIP_DBSC_SUSPECT=1")
+	orcaSyncCmd.Flags().StringSliceVar(&orcaSyncDomains, "domain", nil, "limit to these host_key LIKE patterns (repeatable), e.g. --domain %github.com")
+	orcaSyncCmd.Flags().StringVar(&orcaSyncCDP, "cdp", livecdp.DefaultOrcaCDP, "orca CDP endpoint (orca must run with --remote-debugging-port)")
+	orcaSyncCmd.Flags().StringVar(&orcaSyncBrowser, "browser", "", "source browser name (default: source.yaml browser, then Chrome)")
+}
+
+func runOrcaSync(cmd *cobra.Command, args []string) error {
+	if !orcaSyncOnce && !orcaSyncWatch {
+		return fmt.Errorf("pass either --once for a single pass or --watch for the long-running watcher")
+	}
+	if orcaSyncOnce && orcaSyncWatch {
+		return fmt.Errorf("--once and --watch are mutually exclusive")
+	}
+
+	// LoadSourceLocal, not LoadSource: the local loop has no push target, so it
+	// must not require sink.url or a peer/secret. A missing source.yaml is fine
+	// (defaults: default Chrome path, no blocklist).
+	cfg, err := config.LoadSourceLocal(common.ConfigDir)
+	if err != nil {
+		return err
+	}
+	if _, err := loadFreshBlocklist(); err != nil {
+		return err
+	}
+
+	browserName := orcaSyncBrowser
+	if browserName == "" {
+		browserName = cfg.Browser.Name
+	}
+	sourceBrowser, err := chrome.LookupBrowser(browserName)
+	if err != nil {
+		return err
+	}
+	password, err := chrome.SafeStoragePasswordFor(sourceBrowser)
+	if err != nil {
+		return err
+	}
+	key, err := chrome.DeriveAESKey(password)
+	if err != nil {
+		return err
+	}
+
+	skipDBSC := orcaSyncSkipDBSC || os.Getenv("AGENTCOOKIE_SKIP_DBSC_SUSPECT") == "1"
+
+	cdp := orcaSyncCDP
+	if cdp == "" {
+		cdp = livecdp.DefaultOrcaCDP
+	}
+
+	// lastCookies caches the most recent read so the --watch poll can re-inject
+	// newly-opened panes without re-decrypting Chrome every tick; the fsnotify
+	// watch refreshes it on each Chrome cookie change. lastDBSCSkipped carries
+	// the most recent DBSC-skipped count out for the --once summary.
+	var (
+		mu              sync.Mutex
+		lastCookies     []chrome.Cookie
+		lastDBSCSkipped int
+	)
+
+	readFresh := func() ([]chrome.Cookie, error) {
+		blocklist, err := loadFreshBlocklist()
+		if err != nil {
+			return nil, err
+		}
+		cookies, st, err := readFilteredCookies(cfg.Chrome.DBPath, blocklist, key, skipDBSC, time.Now().UTC())
+		if err != nil {
+			return nil, err
+		}
+		cookies = sinkpush.FilterByHostPatterns(cookies, orcaSyncDomains)
+		mu.Lock()
+		lastCookies = cookies
+		lastDBSCSkipped = st.dbsc.skipped
+		mu.Unlock()
+		if orcaSyncVerbose {
+			fmt.Fprintf(os.Stderr, "agentcookie orca-sync: read %d, blocked %d, dbsc(warn=%d skip=%d), injecting %d\n",
+				st.totalRead, st.totalDropped, st.dbsc.warned, st.dbsc.skipped, len(cookies))
+		}
+		return cookies, nil
+	}
+
+	// syncOnce reads fresh, then injects into every open orca pane. Returns the
+	// number of panes injected (0 = no pane open, which is a soft outcome).
+	syncOnce := func(ctx context.Context) (int, error) {
+		cookies, err := readFresh()
+		if err != nil {
+			return 0, err
+		}
+		if orcaSyncDryRun {
+			fmt.Fprintf(os.Stderr, "agentcookie orca-sync: dry-run; not injecting %d cookies\n", len(cookies))
+			return 0, nil
+		}
+		if len(cookies) == 0 {
+			return 0, nil
+		}
+		return livecdp.InjectIntoOrca(cdp, cookies)
+	}
+
+	// injectCached re-injects the last read set into open panes without
+	// re-reading Chrome. Used by the --watch poll to catch newly-opened panes.
+	injectCached := func() (int, error) {
+		mu.Lock()
+		cookies := lastCookies
+		mu.Unlock()
+		if orcaSyncDryRun || len(cookies) == 0 {
+			return 0, nil
+		}
+		return livecdp.InjectIntoOrca(cdp, cookies)
+	}
+
+	if orcaSyncOnce {
+		ctx, cancel := context.WithTimeout(cmd.Context(), 60*time.Second)
+		defer cancel()
+		panes, err := syncOnce(ctx)
+		if err != nil {
+			// Fail soft with remediation: the usual cause is orca not running
+			// with the debug port, or no browser pane open.
+			return fmt.Errorf("orca-sync: %w (launch orca with --remote-debugging-port and open a browser pane -- `agentcookie orca-sync --help`)", err)
+		}
+		mu.Lock()
+		dbsc := lastDBSCSkipped
+		count := len(lastCookies)
+		mu.Unlock()
+		fmt.Fprint(os.Stderr, orcaSyncSummary(panes, count, dbsc))
+		return nil
+	}
+
+	// --watch: re-inject on every debounced Chrome Cookies change, and also on
+	// a slow poll so a pane opened after start gets seeded. A failed cycle
+	// (orca down / no pane) is logged and the loop keeps running.
+	w, err := watcher.New(watcher.Config{
+		CookiesPath: cfg.Chrome.DBPath,
+		LogLabel:    "agentcookie orca-sync --watch",
+		Push:        syncOnce,
+		OnEvent: func(ev watcher.Event) {
+			if orcaSyncVerbose {
+				fmt.Fprintf(os.Stderr, "agentcookie orca-sync --watch: %s\n", ev.String())
+			}
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("init watcher: %w", err)
+	}
+
+	// Seed once up front so an already-open pane logs in immediately, then poll
+	// for newly-opened panes alongside the fsnotify watch.
+	if _, err := syncOnce(cmd.Context()); err != nil && orcaSyncVerbose {
+		fmt.Fprintf(os.Stderr, "agentcookie orca-sync --watch: initial sync: %v\n", err)
+	}
+	go func() {
+		t := time.NewTicker(orcaSyncPollInterval)
+		defer t.Stop()
+		for {
+			select {
+			case <-cmd.Context().Done():
+				return
+			case <-t.C:
+				if n, err := injectCached(); err != nil && orcaSyncVerbose {
+					fmt.Fprintf(os.Stderr, "agentcookie orca-sync --watch: poll: %v\n", err)
+				} else if orcaSyncVerbose && n > 0 {
+					fmt.Fprintf(os.Stderr, "agentcookie orca-sync --watch: poll injected into %d pane(s)\n", n)
+				}
+			}
+		}
+	}()
+
+	fmt.Fprintf(os.Stderr, "agentcookie orca-sync --watch: watching %s, injecting into orca at %s\n", cfg.Chrome.DBPath, cdp)
+	return w.Run(cmd.Context())
+}
+
+// orcaSyncSummary renders the --once completion line(s): how many panes were
+// injected with how many cookies, an actionable note when no pane is open, and
+// a DBSC note when device-bound cookies were skipped.
+func orcaSyncSummary(panes, cookies, dbscSkipped int) string {
+	var s string
+	if panes == 0 {
+		s = "agentcookie orca-sync: no orca browser pane is open -- open one in orca (it injects into open panes)\n"
+	} else {
+		s = fmt.Sprintf("agentcookie orca-sync: injected %d cookies into %d orca pane(s)\n", cookies, panes)
+	}
+	if dbscSkipped > 0 {
+		s += fmt.Sprintf("agentcookie orca-sync: skipped %d device-bound (DBSC) cookies -- those sessions cannot transfer and may read as logged-out in orca\n", dbscSkipped)
+	}
+	return s
+}

--- a/internal/cli/orca_sync_test.go
+++ b/internal/cli/orca_sync_test.go
@@ -1,0 +1,58 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// runOrcaSync validates the mode flags before any Chrome/keychain/orca I/O,
+// mirroring cmux-sync. These cases exercise that gate without touching the
+// system.
+func TestOrcaSyncFlagValidation(t *testing.T) {
+	reset := func(once, watch bool) {
+		orcaSyncOnce = once
+		orcaSyncWatch = watch
+	}
+	t.Cleanup(func() { reset(false, false) })
+
+	t.Run("neither --once nor --watch errors", func(t *testing.T) {
+		reset(false, false)
+		err := runOrcaSync(&cobra.Command{}, nil)
+		if err == nil || !strings.Contains(err.Error(), "either --once") {
+			t.Fatalf("expected mode-required error, got %v", err)
+		}
+	})
+
+	t.Run("both --once and --watch errors", func(t *testing.T) {
+		reset(true, true)
+		err := runOrcaSync(&cobra.Command{}, nil)
+		if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+			t.Fatalf("expected mutual-exclusion error, got %v", err)
+		}
+	})
+}
+
+func TestOrcaSyncSummary(t *testing.T) {
+	t.Run("no pane open", func(t *testing.T) {
+		s := orcaSyncSummary(0, 0, 0)
+		if !strings.Contains(s, "no orca browser pane is open") {
+			t.Fatalf("expected open-a-pane note, got %q", s)
+		}
+	})
+
+	t.Run("injected", func(t *testing.T) {
+		s := orcaSyncSummary(2, 17, 0)
+		if !strings.Contains(s, "injected 17 cookies into 2 orca pane(s)") {
+			t.Fatalf("expected injected summary, got %q", s)
+		}
+	})
+
+	t.Run("dbsc note appended", func(t *testing.T) {
+		s := orcaSyncSummary(1, 10, 3)
+		if !strings.Contains(s, "skipped 3 device-bound") {
+			t.Fatalf("expected DBSC note, got %q", s)
+		}
+	})
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -46,7 +46,7 @@ func Execute() {
 	rootCmd.PersistentFlags().StringVar(&common.ConfigDir, "config-dir", defaultConfigDir(), "directory holding source.yaml, sink.yaml, blocklist.yaml")
 	rootCmd.PersistentFlags().BoolVar(&common.JSON, "json", false, "emit machine-readable JSON output where the subcommand supports it")
 
-	rootCmd.AddCommand(sourceCmd, sinkCmd, pairCmd, statusCmd, versionCmd, wizardCmd, doctorCmd, secretCmd, discoverCmd, cookiesCmd, accountsCmd, cmuxSyncCmd, agentSyncCmd)
+	rootCmd.AddCommand(sourceCmd, sinkCmd, pairCmd, statusCmd, versionCmd, wizardCmd, doctorCmd, secretCmd, discoverCmd, cookiesCmd, accountsCmd, cmuxSyncCmd, agentSyncCmd, orcaSyncCmd)
 
 	if err := rootCmd.Execute(); err != nil {
 		// Cobra already prints usage on flag errors; surface RunE errors here.

--- a/internal/livecdp/orca.go
+++ b/internal/livecdp/orca.go
@@ -1,0 +1,108 @@
+package livecdp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/chromedp/cdproto/target"
+	"github.com/chromedp/chromedp"
+
+	"github.com/mvanhorn/agentcookie/internal/chrome"
+)
+
+// DefaultOrcaCDP is the loopback CDP endpoint orca exposes when launched with
+// --remote-debugging-port=9222. orca is Electron, so it speaks the same
+// DevTools Protocol this package already uses for cmux's Chromium sibling and
+// the agent browsers; orca-sync points the injector at orca's own webview.
+const DefaultOrcaCDP = "http://127.0.0.1:9222"
+
+// orcaAttachTimeout bounds a single attach+inject against one orca webview.
+const orcaAttachTimeout = 30 * time.Second
+
+// cdpTarget is the subset of a CDP /json/list entry orca-sync needs.
+type cdpTarget struct {
+	ID   string `json:"id"`
+	Type string `json:"type"`
+	URL  string `json:"url"`
+}
+
+// FindOrcaWebviewTargets returns the target IDs of orca's open browser panes.
+// orca renders each browser pane as a CDP "webview" target on the
+// persist:orca-browser partition; orca-sync attaches to those. It deliberately
+// does NOT create a target: Electron rejects Target.createTarget with
+// "-32000 Not supported", so the only way in is to attach to a pane the user
+// already has open.
+func FindOrcaWebviewTargets(base string) ([]string, error) {
+	req, err := http.NewRequest(http.MethodGet, strings.TrimRight(base, "/")+"/json/list", nil)
+	if err != nil {
+		return nil, fmt.Errorf("orca cdp: build request: %w", err)
+	}
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("orca cdp: GET /json/list (%s) -- is orca running with --remote-debugging-port? %w", base, err)
+	}
+	defer resp.Body.Close()
+
+	var targets []cdpTarget
+	if err := json.NewDecoder(resp.Body).Decode(&targets); err != nil {
+		return nil, fmt.Errorf("orca cdp: decode /json/list: %w", err)
+	}
+	ids := make([]string, 0, len(targets))
+	for _, t := range targets {
+		if t.Type == "webview" {
+			ids = append(ids, t.ID)
+		}
+	}
+	return ids, nil
+}
+
+// InjectIntoOrca injects cookies into every open orca browser pane reachable
+// at base, and returns the number of panes injected. A failure on one pane
+// (e.g. it closed mid-sync) does not abort the others. Zero open panes is not
+// an error -- it returns (0, nil) and the caller decides how to report "open a
+// browser pane in orca". An empty cookie slice is a no-op.
+//
+// Injection lands in the persist:orca-browser partition, so a single open pane
+// authenticates the partition for the panes the user opens next.
+func InjectIntoOrca(base string, cookies []chrome.Cookie) (int, error) {
+	if len(cookies) == 0 {
+		return 0, nil
+	}
+	ids, err := FindOrcaWebviewTargets(base)
+	if err != nil {
+		return 0, err
+	}
+	n := 0
+	var firstErr error
+	for _, id := range ids {
+		if err := injectIntoOrcaTarget(base, id, cookies); err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		n++
+	}
+	return n, firstErr
+}
+
+// injectIntoOrcaTarget attaches to one existing orca webview target and sets
+// the cookies on it via Network.setCookies (the proven shaping in Inject).
+func injectIntoOrcaTarget(base, id string, cookies []chrome.Cookie) error {
+	allocCtx, allocCancel := chromedp.NewRemoteAllocator(context.Background(), base)
+	defer allocCancel()
+	ctx, cancel := chromedp.NewContext(allocCtx, chromedp.WithTargetID(target.ID(id)))
+	defer cancel()
+	ctx, tcancel := context.WithTimeout(ctx, orcaAttachTimeout)
+	defer tcancel()
+
+	if err := chromedp.Run(ctx); err != nil {
+		return fmt.Errorf("attach to orca webview %s: %w", id, err)
+	}
+	return Inject(ctx, cookies)
+}

--- a/internal/livecdp/orca_test.go
+++ b/internal/livecdp/orca_test.go
@@ -1,0 +1,79 @@
+package livecdp
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mvanhorn/agentcookie/internal/chrome"
+)
+
+func TestFindOrcaWebviewTargets(t *testing.T) {
+	// /json/list with a mix of orca's own UI (page) and two browser panes
+	// (webview). Only the webviews are injectable browser panes.
+	body := `[
+		{"id":"ui1","type":"page","url":"file:///Applications/Orca.app/.../renderer"},
+		{"id":"pane1","type":"webview","url":"https://github.com/"},
+		{"id":"pane2","type":"webview","url":"https://example.com/"}
+	]`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/json/list" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	ids, err := FindOrcaWebviewTargets(srv.URL)
+	if err != nil {
+		t.Fatalf("FindOrcaWebviewTargets: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != "pane1" || ids[1] != "pane2" {
+		t.Fatalf("expected [pane1 pane2], got %v", ids)
+	}
+}
+
+func TestFindOrcaWebviewTargetsNoPanes(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`[{"id":"ui1","type":"page","url":"file:///renderer"}]`))
+	}))
+	defer srv.Close()
+
+	ids, err := FindOrcaWebviewTargets(srv.URL)
+	if err != nil {
+		t.Fatalf("FindOrcaWebviewTargets: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("expected no webview targets, got %v", ids)
+	}
+}
+
+func TestFindOrcaWebviewTargetsUnreachable(t *testing.T) {
+	// A closed endpoint should surface an actionable error, not panic.
+	_, err := FindOrcaWebviewTargets("http://127.0.0.1:0")
+	if err == nil {
+		t.Fatal("expected an error connecting to a closed CDP endpoint")
+	}
+}
+
+func TestInjectIntoOrcaEmptyCookies(t *testing.T) {
+	// No cookies is a no-op and must not even touch the endpoint.
+	n, err := InjectIntoOrca("http://127.0.0.1:0", nil)
+	if err != nil || n != 0 {
+		t.Fatalf("expected (0, nil) for empty cookies, got (%d, %v)", n, err)
+	}
+}
+
+func TestInjectIntoOrcaNoPanes(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`[{"id":"ui1","type":"page","url":"file:///renderer"}]`))
+	}))
+	defer srv.Close()
+
+	// Cookies present but no open pane: returns (0, nil), a soft outcome.
+	n, err := InjectIntoOrca(srv.URL, []chrome.Cookie{{HostKey: "github.com", Name: "a", Value: "1", Path: "/"}})
+	if err != nil || n != 0 {
+		t.Fatalf("expected (0, nil) when no panes are open, got (%d, %v)", n, err)
+	}
+}


### PR DESCRIPTION
orca is an Electron coding IDE with an embedded browser pane (on the `persist:orca-browser` partition). Because it is Electron, it exposes the DevTools Protocol when launched with `--remote-debugging-port`. `orca-sync` reads this machine's Chrome cookies (decrypt + blocklist + DBSC filter, the same `readFilteredCookies` pipeline `source`/`cmux-sync`/`agent-sync` use) and injects them into orca's open browser panes over CDP, so a pane wakes up logged into your sites.

This is the Electron sibling of `cmux-sync` (WebKit) and `agent-sync` (Chromium agent browsers), with no change to orca.

## Usage

```
open -a Orca --args --remote-debugging-port=9222   # launch orca with the port
agentcookie orca-sync --once                        # one read+inject
agentcookie orca-sync --watch                        # fsnotify on Chrome + poll for new panes
```

`--watch` re-injects on every Chrome cookie change and polls so a pane opened after start also gets seeded. `--domain` limits to matching hosts.

## How it works

- `internal/livecdp/orca.go`: `FindOrcaWebviewTargets` + `InjectIntoOrca`. Electron rejects `Target.createTarget` (`-32000`), so it attaches to orca's existing webview targets (from `/json/list`) and sets cookies with the existing `livecdp.Inject` shaping; it never opens a tab.
- `internal/cli/orca_sync.go`: the command, reusing `readFilteredCookies` and `internal/watcher`.
- Device-bound (DBSC) cookies cannot transfer and are excluded and reported.

## Tradeoff

orca has to run with a loopback debug port. On an editor (vs a throwaway automation browser), an open debug port lets any local process drive orca's browser while it is open. Prefer launching orca with the flag intentionally.

Verified end to end: `orca-sync --once --domain %github.com` logs an open orca browser pane into github.com as the user.