### PR TITLE
fix(cdp): faithful host-only/__Host- cookie injection on the sink path

### DIFF
--- a/internal/cdp/setcookies.go
+++ b/internal/cdp/setcookies.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/chromedp/cdproto/cdp"
@@ -77,6 +78,20 @@ func InjectCookies(ctx context.Context, profileDir string, cookies []chrome.Cook
 	if err := chromedp.Run(chromeCtx, network.SetCookies(params)); err != nil {
 		return fmt.Errorf("cdp.InjectCookies: Network.SetCookies (%d cookies, profile=%s): %w", len(params), profileDir, err)
 	}
+
+	// Gracefully close the browser and WAIT for it to exit before
+	// returning. Cookies set via Network.setCookies live in Chrome's
+	// in-memory cookie store and are only flushed to the profile's SQLite
+	// on a clean shutdown. The deferred context cancels below SIGKILL the
+	// process, which loses un-flushed writes nondeterministically and
+	// leaves the profile's SingletonLock held -- which corrupts the seed
+	// when a persistent Chrome is then launched on the same dir (the
+	// debug-profile fallback) and can silently drop cookies on the sink.
+	// chromedp.Cancel performs the graceful Browser.close and waits for
+	// the process to exit, guaranteeing the flush and lock release.
+	if err := chromedp.Cancel(chromeCtx); err != nil {
+		return fmt.Errorf("cdp.InjectCookies: graceful close (flush): %w", err)
+	}
 	return nil
 }
 
@@ -98,17 +113,41 @@ func InjectCookies(ctx context.Context, profileDir string, cookies []chrome.Cook
 //     Chrome would derive from the same Set-Cookie header sent by the
 //     server, so the semantics round-trip correctly.
 func buildCookieParam(c chrome.Cookie, value string) *network.CookieParam {
-	return &network.CookieParam{
+	p := &network.CookieParam{
 		Name:     c.Name,
 		Value:    value,
 		URL:      synthesizeCookieURL(c),
-		Domain:   normalizeDomain(c.HostKey),
 		Path:     c.Path,
 		Secure:   c.IsSecure == 1,
 		HTTPOnly: c.IsHTTPOnly == 1,
 		SameSite: chromeSameSiteToCDP(c.SameSite),
 		Expires:  cookieExpiresEpoch(c.ExpiresUTC),
 	}
+
+	// Domain attribute: only set it for cookies Chrome stored as
+	// domain-scoped (host_key WITH a leading dot, valid for subdomains).
+	// Host-only cookies must carry NO Domain -- Chrome scopes them to the
+	// exact host via the URL. Two cases are host-only:
+	//   1. host_key without a leading dot (Chrome's host-only form).
+	//   2. __Host--prefixed cookies, which Network.setCookies HARD-REJECTS
+	//      when a Domain is present. Modern host-bound session cookies
+	//      (e.g. GitHub's __Host-user_session_same_site) only land when
+	//      Domain is omitted.
+	// Setting both URL and a Domain on a host-only cookie is also what
+	// silently dropped host-bound login cookies before this fix.
+	isHostPrefixed := strings.HasPrefix(c.Name, "__Host-")
+	if strings.HasPrefix(c.HostKey, ".") && !isHostPrefixed {
+		p.Domain = normalizeDomain(c.HostKey)
+	}
+
+	// __Host- cookies have mandatory attributes (Secure, Path "/"); enforce
+	// them so a slightly-off source row is not rejected wholesale.
+	if isHostPrefixed {
+		p.Secure = true
+		p.Path = "/"
+	}
+
+	return p
 }
 
 // normalizeDomain converts Chrome's host_key form to the CDP-acceptable

--- a/internal/cdp/setcookies_test.go
+++ b/internal/cdp/setcookies_test.go
@@ -147,3 +147,48 @@ func TestBuildCookieParam_SessionCookie(t *testing.T) {
 		t.Errorf("session cookie should have nil Expires, got non-nil")
 	}
 }
+
+// TestBuildCookieParam_HostOnlyOmitsDomain confirms a host-only cookie
+// (host_key without a leading dot) is injected with NO Domain attribute,
+// so Chrome scopes it to the exact host via the URL rather than widening
+// it to subdomains (and so host-bound login cookies actually land).
+func TestBuildCookieParam_HostOnlyOmitsDomain(t *testing.T) {
+	c := chrome.Cookie{HostKey: "github.com", Name: "user_session", Value: "v", Path: "/", IsSecure: 1, IsHTTPOnly: 1, SameSite: 1}
+	got := buildCookieParam(c, "v")
+	if got.Domain != "" {
+		t.Errorf("host-only cookie must have empty Domain, got %q", got.Domain)
+	}
+	if got.URL != "https://github.com/" {
+		t.Errorf("URL: got %q", got.URL)
+	}
+}
+
+// TestBuildCookieParam_HostPrefixRejectionGuard confirms a __Host- cookie
+// is injected with no Domain and the mandatory Secure + Path "/" so Chrome
+// does not hard-reject it.
+func TestBuildCookieParam_HostPrefixRejectionGuard(t *testing.T) {
+	// Deliberately pass a leading-dot host_key and a non-root path to prove
+	// the __Host- handling overrides both.
+	c := chrome.Cookie{HostKey: ".github.com", Name: "__Host-user_session_same_site", Value: "v", Path: "/app", IsSecure: 0, SameSite: 2}
+	got := buildCookieParam(c, "v")
+	if got.Domain != "" {
+		t.Errorf("__Host- cookie must have empty Domain, got %q", got.Domain)
+	}
+	if !got.Secure {
+		t.Errorf("__Host- cookie must be Secure")
+	}
+	if got.Path != "/" {
+		t.Errorf("__Host- cookie must have Path /, got %q", got.Path)
+	}
+}
+
+// TestBuildCookieParam_DomainCookieKeepsDomain confirms a genuinely
+// domain-scoped cookie (leading dot, not __Host-) still carries its
+// dot-stripped Domain so its subdomain scope round-trips.
+func TestBuildCookieParam_DomainCookieKeepsDomain(t *testing.T) {
+	c := chrome.Cookie{HostKey: ".example.com", Name: "sess", Value: "v", Path: "/", IsSecure: 1}
+	got := buildCookieParam(c, "v")
+	if got.Domain != "example.com" {
+		t.Errorf("domain cookie must keep dot-stripped Domain, got %q", got.Domain)
+	}
+}


### PR DESCRIPTION
## What

Salvages the verified injector fix from #90 as a slim PR, dropping the superseded agent-browser attach scaffolding.

Two bugs in `internal/cdp/setcookies.go` silently dropped modern host-bound login cookies on the sink delivery path (`internal/cli/sink.go` -> `cdp.InjectCookies`):

1. `buildCookieParam` set a `Domain` on every cookie. Chrome hard-rejects `__Host-` cookies that carry a `Domain`, and host-only cookies (host_key without a leading dot) should stay host-only. Login cookies like GitHub `user_session` / `__Host-user_session_same_site` were dropped.
2. The headless Chrome was SIGKILLed by deferred context cancel, so cookies set over CDP never flushed from the in-memory store to the profile's SQLite (nondeterministic loss, plus a held SingletonLock that corrupts the seed for follow-on launches).

Fix: only set `Domain` for dot-prefixed (domain-scoped) host_keys, enforce `Secure` + `Path "/"` on `__Host-` cookies, and gracefully close Chrome via `chromedp.Cancel` so the flush and lock release are guaranteed.

This mirrors the same fix class already shipped for the live-injection path in #92 (`internal/livecdp`); this PR covers the cold path #92 did not touch.

## Testing

- Full suite: 728 tests pass across 28 packages; `go vet` clean.
- Fix verified live on the #90 branch: GitHub host-bound login cookies go from dropped to persisted in a seeded profile (6 -> 13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)