### PR TITLE
fix(cmux): inject cookies via a hidden background tab (no popup, no sidebar workspace)

### DIFF
--- a/internal/sinkpush/adapter_cmux.go
+++ b/internal/sinkpush/adapter_cmux.go
@@ -76,7 +76,7 @@ type CmuxAdapter struct {
 
 	mu           sync.Mutex
 	surfaceID    string // cached browser surface ref, opened lazily, reused
-	workspaceRef string // cached background workspace ref hosting the surface
+	workspaceRef string // last background workspace ref resolved by ensureWorkspaceLocked (informational: refs renumber across cmux restarts, so it is re-resolved by name, never reused)
 
 	// run executes a cmux subcommand and returns stdout. Swappable in
 	// tests; defaults to execCmux.
@@ -212,8 +212,8 @@ func (a *CmuxAdapter) ensureSurfaceLocked() (string, error) {
 	}
 	out, err := a.run("browser", "open", "about:blank", "--workspace", ws, "--focus", "false")
 	if err != nil && isWorkspaceError(err) {
-		// The cached workspace went away (user closed it). Recreate once.
-		a.workspaceRef = ""
+		// The workspace vanished between resolution and open (user closed
+		// it). Re-resolve by name / recreate once.
 		ws, werr := a.ensureWorkspaceLocked()
 		if werr != nil {
 			return "", fmt.Errorf("recreate background workspace after %v: %w", err, werr)
@@ -231,13 +231,20 @@ func (a *CmuxAdapter) ensureSurfaceLocked() (string, error) {
 	return sid, nil
 }
 
-// ensureWorkspaceLocked returns the cached background workspace ref,
-// finding an existing workspace named cmuxWorkspaceName or creating an
-// unfocused one. Caller must hold a.mu.
+// ensureWorkspaceLocked returns the background workspace ref, finding an
+// existing workspace named cmuxWorkspaceName or creating an unfocused
+// one. Caller must hold a.mu.
+//
+// The ref cached in a.workspaceRef is deliberately NOT trusted here:
+// short refs like `workspace:N` renumber when cmux restarts, and this
+// process outlives cmux (the cmux-sync LaunchAgent runs for days). A
+// stale cached ref can silently alias a live user workspace after a
+// restart -- `browser open --workspace` then succeeds without error, the
+// recreate path never fires, and the about:blank pane lands right in the
+// user's view. Resolving by name is the only stable identity, and it
+// only happens on surface (re)open, so the extra `workspace list` is
+// rare.
 func (a *CmuxAdapter) ensureWorkspaceLocked() (string, error) {
-	if a.workspaceRef != "" {
-		return a.workspaceRef, nil
-	}
 	// Reuse an existing workspace from a previous run so restarts don't
 	// accumulate one workspace each. A list failure is non-fatal: fall
 	// through to create.

--- a/internal/sinkpush/adapter_cmux.go
+++ b/internal/sinkpush/adapter_cmux.go
@@ -23,22 +23,9 @@ const cmuxAppCLI = "/Applications/cmux.app/Contents/Resources/bin/cmux"
 // microseconds since 1601; cmux's RPC wants Unix seconds.
 const chromeEpochOffsetSec = 11644473600
 
-// surfaceRefRE extracts the `surface:N` ref from `cmux browser open`
-// output, e.g. "OK surface=surface:45 pane=pane:32 placement=split".
+// surfaceRefRE extracts the `surface:N` ref from `cmux new-surface`
+// output, e.g. "OK surface:29 pane:7 workspace:5".
 var surfaceRefRE = regexp.MustCompile(`surface:\d+`)
-
-// workspaceRefRE extracts the `workspace:N` ref from `cmux workspace
-// create` output, e.g. "OK workspace:9".
-var workspaceRefRE = regexp.MustCompile(`workspace:\d+`)
-
-// cmuxWorkspaceName is the dedicated background workspace the adapter
-// parks its injection surface in. The cmux-sync LaunchAgent runs outside
-// cmux, so $CMUX_WORKSPACE_ID is unset and a bare `browser open` lands
-// the pane in whatever workspace the user has focused -- right in their
-// face, and reopened on every sync if they close it. A named, unfocused
-// workspace keeps the surface alive without ever entering the user's
-// view.
-const cmuxWorkspaceName = "agentcookie"
 
 // CmuxAdapter delivers synced cookies into cmux's embedded WebKit
 // browser via the cmux control socket, so an agent driving cmux's
@@ -51,19 +38,27 @@ const cmuxWorkspaceName = "agentcookie"
 // internal/cli/sink.go at sink startup rather than in init.go, because
 // it carries config (binary path, host filter) that init() cannot see.
 //
+// Injection surface (why a hidden background tab, not a workspace):
+// browser.cookies.set requires a browser surface_id -- there is no
+// profile-level set call. But WebKit cookies persist at the
+// WKWebsiteDataStore (profile) level, shared across every browser
+// surface and surviving pane close (confirmed empirically: a set on one
+// surface is visible to cookies.get on any other). So the surface only
+// has to exist; it never has to be seen. The adapter adds ONE unfocused
+// (`--focus false`) about:blank browser tab to an existing workspace's
+// active pane and caches it. A non-selected browser tab is a hidden
+// webview -- cookies.set still lands on it -- so the only UI artifact is
+// a small tab chip; nothing opens in the user's view and nothing appears
+// in the workspace sidebar. An earlier design parked the surface in a
+// dedicated "agentcookie" workspace, which showed in the sidebar and
+// (because cmux short refs renumber across restarts) could alias a live
+// user workspace and pop the pane into focus; the hidden-tab approach
+// removes the workspace entirely.
+//
 // WebKit cookie semantics (confirmed empirically, differ from Chrome's
 // CDP path):
 //   - Domain is stored VERBATIM. ".example.com" is accepted, so unlike
 //     the CDP injector we do NOT strip the leading dot from host_key.
-//   - browser.cookies.set REQUIRES a browser surface_id; there is no
-//     profile-level set, and browser surfaces are not listed by
-//     surface.list. So the adapter opens its own about:blank surface
-//     (unfocused, inside the dedicated cmuxWorkspaceName background
-//     workspace) and caches it for reuse. Injected cookies persist at
-//     the WKWebsiteDataStore (profile) level, surviving pane close, so
-//     a single injection authenticates the agent's future panes.
-//   - Surface refs are workspace-scoped: any command that targets the
-//     cached surface by ref must carry the cached workspace ref too.
 //   - expires is Unix seconds; omit it for session cookies. WebKit
 //     clamps far-future expiries to its ~400-day max (expected).
 //   - Cookie values are passed through VERBATIM. The App-Bound (Chrome
@@ -75,7 +70,7 @@ type CmuxAdapter struct {
 	domainFilter []string
 
 	mu        sync.Mutex
-	surfaceID string // cached browser surface ref, opened lazily, reused
+	surfaceID string // cached hidden background tab ref, added lazily, reused
 
 	// run executes a cmux subcommand and returns stdout. Swappable in
 	// tests; defaults to execCmux.
@@ -117,9 +112,9 @@ func (a *CmuxAdapter) IsInstalled() bool {
 func (a *CmuxAdapter) CookieHostPatterns() []string { return a.domainFilter }
 
 // Push injects each cookie into cmux's WebKit browser via
-// `cmux rpc browser.cookies.set`. It ensures a cached browser surface
-// exists (opening an unfocused about:blank pane on first use), and
-// reopens once if the cached surface has gone away. Errors are returned
+// `cmux rpc browser.cookies.set`. It ensures a cached hidden background
+// tab exists (adding one unfocused about:blank tab on first use), and
+// re-adds once if the cached surface has gone away. Errors are returned
 // for RunAll to log; a missing or cmuxOnly-gated cmux is a soft failure
 // that never aborts the sync or the other surfaces.
 func (a *CmuxAdapter) Push(cookies []chrome.Cookie) error {
@@ -197,28 +192,23 @@ func (a *CmuxAdapter) Push(cookies []chrome.Cookie) error {
 	return nil
 }
 
-// ensureSurfaceLocked returns the cached browser surface ref, opening an
-// unfocused about:blank pane inside the dedicated background workspace
-// if none is cached. If the cached workspace has been closed by the user
-// since, it is recreated once. Caller must hold a.mu.
+// ensureSurfaceLocked returns the cached injection surface ref, adding an
+// unfocused about:blank browser tab to an existing workspace if none is
+// cached. The tab is hidden (a non-selected webview) -- cookies.set lands
+// on it without it ever being shown, and it adds no sidebar entry.
+// Caller must hold a.mu.
 func (a *CmuxAdapter) ensureSurfaceLocked() (string, error) {
 	if a.surfaceID != "" {
 		return a.surfaceID, nil
 	}
-	ws, err := a.ensureWorkspaceLocked()
+	ws, err := a.hostWorkspaceLocked()
 	if err != nil {
-		return "", fmt.Errorf("background workspace: %w", err)
+		return "", fmt.Errorf("host workspace: %w", err)
 	}
-	out, err := a.run("browser", "open", "about:blank", "--workspace", ws, "--focus", "false")
-	if err != nil && isWorkspaceError(err) {
-		// The workspace vanished between resolution and open (user closed
-		// it). Re-resolve by name / recreate once.
-		ws, werr := a.ensureWorkspaceLocked()
-		if werr != nil {
-			return "", fmt.Errorf("recreate background workspace after %v: %w", err, werr)
-		}
-		out, err = a.run("browser", "open", "about:blank", "--workspace", ws, "--focus", "false")
-	}
+	// --focus false adds the about:blank as a non-selected background tab,
+	// so the user's selected surface stays put and nothing pops into view.
+	// cmux picks the workspace's active pane when --pane is omitted.
+	out, err := a.run("new-surface", "--type", "browser", "--workspace", ws, "--url", "about:blank", "--focus", "false")
 	if err != nil {
 		return "", err
 	}
@@ -230,59 +220,39 @@ func (a *CmuxAdapter) ensureSurfaceLocked() (string, error) {
 	return sid, nil
 }
 
-// ensureWorkspaceLocked returns the background workspace ref, finding an
-// existing workspace named cmuxWorkspaceName or creating an unfocused
-// one. Caller must hold a.mu.
-//
-// The workspace ref is deliberately re-resolved by NAME every call and
-// never cached on the adapter: short refs like `workspace:N` renumber
-// when cmux restarts, and this process outlives cmux (the cmux-sync
-// LaunchAgent runs for days). A stale cached ref can silently alias a
-// live user workspace after a restart -- `browser open --workspace` then
-// succeeds without error, the recreate path never fires, and the
-// about:blank pane lands right in the user's view. Name lookup is the
-// only stable identity, and this runs only on surface (re)open, so the
-// extra `workspace list` is rare.
-func (a *CmuxAdapter) ensureWorkspaceLocked() (string, error) {
-	// Reuse an existing workspace from a previous run so restarts don't
-	// accumulate one workspace each. A list failure is non-fatal: fall
-	// through to create.
-	if out, err := a.run("workspace", "list", "--json"); err == nil {
-		if ref := findWorkspaceRef(out, cmuxWorkspaceName); ref != "" {
-			return ref, nil
-		}
-	}
-	out, err := a.run("workspace", "create", "--name", cmuxWorkspaceName, "--focus", "false")
+// hostWorkspaceLocked returns a workspace to host the hidden injection
+// tab: the first workspace cmux reports. The cmux-sync LaunchAgent runs
+// outside cmux ($CMUX_WORKSPACE_ID unset), so there is no caller
+// workspace to default to; the first listed one is a stable, already-open
+// home that costs no new workspace and no sidebar entry. Resolved fresh
+// every time a surface must be (re)added -- never cached -- because short
+// refs renumber across cmux restarts and this process outlives cmux.
+// Caller must hold a.mu.
+func (a *CmuxAdapter) hostWorkspaceLocked() (string, error) {
+	out, err := a.run("workspace", "list", "--json")
 	if err != nil {
 		return "", err
 	}
-	ref := workspaceRefRE.FindString(out)
+	ref := firstWorkspaceRef(out)
 	if ref == "" {
-		return "", fmt.Errorf("could not parse workspace ref from %q", strings.TrimSpace(out))
+		return "", fmt.Errorf("no cmux workspace to host the injection tab in %q", strings.TrimSpace(out))
 	}
 	return ref, nil
 }
 
-// findWorkspaceRef scans `workspace list --json` output for a workspace
-// whose title is name. cmux prefixes active-workspace titles with a
-// single status glyph ("✳ agentcookie"), so a glyph-plus-name title is
-// accepted alongside the exact one -- but not arbitrary leading words
-// ("dev agentcookie" is someone else's workspace).
-func findWorkspaceRef(listJSON, name string) string {
+// firstWorkspaceRef returns the ref of the first workspace in `workspace
+// list --json` output, or "" if there are none / the JSON is unparseable.
+func firstWorkspaceRef(listJSON string) string {
 	var parsed struct {
 		Workspaces []struct {
-			Ref   string `json:"ref"`
-			Title string `json:"title"`
+			Ref string `json:"ref"`
 		} `json:"workspaces"`
 	}
 	if err := json.Unmarshal([]byte(listJSON), &parsed); err != nil {
 		return ""
 	}
 	for _, w := range parsed.Workspaces {
-		if w.Title == name {
-			return w.Ref
-		}
-		if fields := strings.Fields(w.Title); len(fields) == 2 && fields[1] == name && len([]rune(fields[0])) == 1 {
+		if w.Ref != "" {
 			return w.Ref
 		}
 	}
@@ -385,19 +355,6 @@ func isSurfaceError(err error) bool {
 		strings.Contains(msg, "not a browser")
 }
 
-// isWorkspaceError reports whether err is specifically a stale/missing
-// workspace (e.g. the user closed the background workspace), which
-// warrants one recreate. cmux answers "not_found: Workspace not found"
-// for a closed workspace ref. Deliberately NOT any error mentioning
-// "workspace" -- a quota or permission failure would recur on the
-// recreated workspace too, so recreating for those is a spurious
-// workspace per failed sync.
-func isWorkspaceError(err error) bool {
-	if err == nil {
-		return false
-	}
-	return strings.Contains(strings.ToLower(err.Error()), "workspace not found")
-}
 
 // isCmuxUnavailable reports whether err means cmux itself can't be
 // reached (down, or socketControlMode gating a non-cmux-child caller) --

--- a/internal/sinkpush/adapter_cmux.go
+++ b/internal/sinkpush/adapter_cmux.go
@@ -355,7 +355,6 @@ func isSurfaceError(err error) bool {
 		strings.Contains(msg, "not a browser")
 }
 
-
 // isCmuxUnavailable reports whether err means cmux itself can't be
 // reached (down, or socketControlMode gating a non-cmux-child caller) --
 // a hard failure for the whole push, as opposed to a single rejected

--- a/internal/sinkpush/adapter_cmux.go
+++ b/internal/sinkpush/adapter_cmux.go
@@ -74,9 +74,8 @@ type CmuxAdapter struct {
 	binary       string
 	domainFilter []string
 
-	mu           sync.Mutex
-	surfaceID    string // cached browser surface ref, opened lazily, reused
-	workspaceRef string // last background workspace ref resolved by ensureWorkspaceLocked (informational: refs renumber across cmux restarts, so it is re-resolved by name, never reused)
+	mu        sync.Mutex
+	surfaceID string // cached browser surface ref, opened lazily, reused
 
 	// run executes a cmux subcommand and returns stdout. Swappable in
 	// tests; defaults to execCmux.
@@ -235,22 +234,21 @@ func (a *CmuxAdapter) ensureSurfaceLocked() (string, error) {
 // existing workspace named cmuxWorkspaceName or creating an unfocused
 // one. Caller must hold a.mu.
 //
-// The ref cached in a.workspaceRef is deliberately NOT trusted here:
-// short refs like `workspace:N` renumber when cmux restarts, and this
-// process outlives cmux (the cmux-sync LaunchAgent runs for days). A
-// stale cached ref can silently alias a live user workspace after a
-// restart -- `browser open --workspace` then succeeds without error, the
-// recreate path never fires, and the about:blank pane lands right in the
-// user's view. Resolving by name is the only stable identity, and it
-// only happens on surface (re)open, so the extra `workspace list` is
-// rare.
+// The workspace ref is deliberately re-resolved by NAME every call and
+// never cached on the adapter: short refs like `workspace:N` renumber
+// when cmux restarts, and this process outlives cmux (the cmux-sync
+// LaunchAgent runs for days). A stale cached ref can silently alias a
+// live user workspace after a restart -- `browser open --workspace` then
+// succeeds without error, the recreate path never fires, and the
+// about:blank pane lands right in the user's view. Name lookup is the
+// only stable identity, and this runs only on surface (re)open, so the
+// extra `workspace list` is rare.
 func (a *CmuxAdapter) ensureWorkspaceLocked() (string, error) {
 	// Reuse an existing workspace from a previous run so restarts don't
 	// accumulate one workspace each. A list failure is non-fatal: fall
 	// through to create.
 	if out, err := a.run("workspace", "list", "--json"); err == nil {
 		if ref := findWorkspaceRef(out, cmuxWorkspaceName); ref != "" {
-			a.workspaceRef = ref
 			return ref, nil
 		}
 	}
@@ -262,7 +260,6 @@ func (a *CmuxAdapter) ensureWorkspaceLocked() (string, error) {
 	if ref == "" {
 		return "", fmt.Errorf("could not parse workspace ref from %q", strings.TrimSpace(out))
 	}
-	a.workspaceRef = ref
 	return ref, nil
 }
 

--- a/internal/sinkpush/adapter_cmux_test.go
+++ b/internal/sinkpush/adapter_cmux_test.go
@@ -451,6 +451,66 @@ func TestCmuxPush_RecreatesClosedWorkspace(t *testing.T) {
 	}
 }
 
+func TestCmuxPush_StaleWorkspaceRefNeverAliasesUserWorkspace(t *testing.T) {
+	// Regression (2026-06-06): cmux restarted underneath the long-lived
+	// cmux-sync daemon. Short refs renumber across restarts, so a
+	// workspace ref cached before the restart can alias a live USER
+	// workspace afterwards. Trusting it made `browser open` succeed
+	// silently -- no workspace error, no recreate -- and parked the
+	// about:blank pane right in the user's view. The adapter must
+	// re-resolve the background workspace by name instead.
+	f := &fakeCmux{listOut: `{"workspaces":[
+		{"ref":"workspace:2","title":"✳ Claude Code"},
+		{"ref":"workspace:5","title":"⠂ Process incoming email task"}
+	]}`}
+	a := newTestCmux(f, nil)
+	a.workspaceRef = "workspace:5" // pre-restart cache; now someone else's workspace
+	if err := a.Push([]chrome.Cookie{{HostKey: ".x.com", Name: "a", Value: "1"}}); err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	if findCall(f.calls, "workspace", "create") == nil {
+		t.Fatalf("no agentcookie workspace exists, so create is required; calls: %v", f.calls)
+	}
+	open := findCall(f.calls, "browser", "open")
+	if open == nil {
+		t.Fatalf("no browser open call, got %v", f.calls)
+	}
+	if hasFlag(open, "--workspace", "workspace:5") {
+		t.Errorf("open targeted the aliased user workspace:5: %v", open)
+	}
+	if !hasFlag(open, "--workspace", "workspace:7") {
+		t.Errorf("open should target the freshly created background workspace:7, got %v", open)
+	}
+}
+
+func TestCmuxPush_ReopenAfterCmuxRestartReResolvesWorkspaceByName(t *testing.T) {
+	// The exact incident path: a push against the pre-restart cached
+	// surface fails with a surface error, and the reopen must not reuse
+	// the pre-restart workspace ref (which now aliases a user workspace).
+	f := &fakeCmux{
+		listOut: `{"workspaces":[
+			{"ref":"workspace:5","title":"⠂ Process incoming email task"}
+		]}`,
+		setErrs: []error{errors.New("not_found: Surface not found")},
+	}
+	a := newTestCmux(f, nil)
+	a.surfaceID = "surface:12"     // pre-restart cache; surface is gone
+	a.workspaceRef = "workspace:5" // pre-restart cache; aliases a user workspace
+	if err := a.Push([]chrome.Cookie{{HostKey: ".x.com", Name: "a", Value: "1"}}); err != nil {
+		t.Fatalf("Push should recover via reopen, got %v", err)
+	}
+	open := findCall(f.calls, "browser", "open")
+	if open == nil {
+		t.Fatalf("expected a reopen, got %v", f.calls)
+	}
+	if hasFlag(open, "--workspace", "workspace:5") {
+		t.Errorf("reopen targeted the aliased user workspace:5: %v", open)
+	}
+	if !hasFlag(open, "--workspace", "workspace:7") {
+		t.Errorf("reopen should target the recreated background workspace, got %v", open)
+	}
+}
+
 func TestFindWorkspaceRef(t *testing.T) {
 	list := `{"workspaces":[
 		{"ref":"workspace:1","title":"✳ Claude Code"},

--- a/internal/sinkpush/adapter_cmux_test.go
+++ b/internal/sinkpush/adapter_cmux_test.go
@@ -14,13 +14,13 @@ import (
 // fakeCmux records the cmux subcommands invoked and returns scripted
 // responses, so adapter tests never shell out to a real cmux.
 type fakeCmux struct {
-	calls   [][]string
-	addOut  string  // new-surface response ("" = a default surface in the targeted workspace)
-	addErrs []error // consumed in order, one per new-surface call
-	addIdx  int
-	listOut string // workspace list --json response ("" = one default workspace)
-	listErr error
-	setErrs []error // consumed in order, one per browser.cookies.set call
+	calls    [][]string
+	addOut   string  // new-surface response ("" = a default surface in the targeted workspace)
+	addErrs  []error // consumed in order, one per new-surface call
+	addIdx   int
+	listOut  string // workspace list --json response ("" = one default workspace)
+	listErr  error
+	setErrs  []error // consumed in order, one per browser.cookies.set call
 	setCalls int
 }
 

--- a/internal/sinkpush/adapter_cmux_test.go
+++ b/internal/sinkpush/adapter_cmux_test.go
@@ -14,15 +14,13 @@ import (
 // fakeCmux records the cmux subcommands invoked and returns scripted
 // responses, so adapter tests never shell out to a real cmux.
 type fakeCmux struct {
-	calls    [][]string
-	openOut  string
-	openErrs []error // consumed in order, one per browser open call
-	openIdx  int
-	listOut  string // workspace list --json response ("" = empty list)
-	listErr  error
-	wsOut    string // workspace create response
-	wsErr    error
-	setErrs  []error // consumed in order, one per browser.cookies.set call
+	calls   [][]string
+	addOut  string  // new-surface response ("" = a default surface in the targeted workspace)
+	addErrs []error // consumed in order, one per new-surface call
+	addIdx  int
+	listOut string // workspace list --json response ("" = one default workspace)
+	listErr error
+	setErrs []error // consumed in order, one per browser.cookies.set call
 	setCalls int
 }
 
@@ -34,29 +32,21 @@ func (f *fakeCmux) run(args ...string) (string, error) {
 		}
 		out := f.listOut
 		if out == "" {
-			out = `{"workspaces":[]}`
+			out = `{"workspaces":[{"ref":"workspace:2","title":"✳ Claude Code"}]}`
 		}
 		return out, nil
 	}
-	if len(args) >= 2 && args[0] == "workspace" && args[1] == "create" {
-		if f.wsErr != nil {
-			return "", f.wsErr
+	if len(args) >= 1 && args[0] == "new-surface" {
+		i := f.addIdx
+		f.addIdx++
+		if i < len(f.addErrs) && f.addErrs[i] != nil {
+			return "", f.addErrs[i]
 		}
-		out := f.wsOut
+		out := f.addOut
 		if out == "" {
-			out = "OK workspace:7"
-		}
-		return out, nil
-	}
-	if len(args) >= 2 && args[0] == "browser" && args[1] == "open" {
-		i := f.openIdx
-		f.openIdx++
-		if i < len(f.openErrs) && f.openErrs[i] != nil {
-			return "", f.openErrs[i]
-		}
-		out := f.openOut
-		if out == "" {
-			out = "OK surface=surface:9 pane=pane:1 placement=split"
+			// Echo the targeted workspace so tests can assert placement.
+			ws := flagValue(args, "--workspace")
+			out = "OK surface:9 pane:1 " + ws
 		}
 		return out, nil
 	}
@@ -69,6 +59,16 @@ func (f *fakeCmux) run(args ...string) (string, error) {
 		return `{"set":1}`, nil
 	}
 	return "", nil
+}
+
+// flagValue returns the value following flag in args, or "".
+func flagValue(args []string, flag string) string {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == flag {
+			return args[i+1]
+		}
+	}
+	return ""
 }
 
 func newTestCmux(f *fakeCmux, filter []string) *CmuxAdapter {
@@ -185,7 +185,7 @@ func TestChromeMicrosToUnixSec(t *testing.T) {
 	}
 }
 
-func TestCmuxPush_OpensSurfaceThenBatchSets(t *testing.T) {
+func TestCmuxPush_AddsHiddenTabThenBatchSets(t *testing.T) {
 	f := &fakeCmux{}
 	a := newTestCmux(f, nil)
 	cookies := []chrome.Cookie{
@@ -195,28 +195,31 @@ func TestCmuxPush_OpensSurfaceThenBatchSets(t *testing.T) {
 	if err := a.Push(cookies); err != nil {
 		t.Fatalf("Push: %v", err)
 	}
-	// One open (inside the background workspace), and both cookies in a
-	// single batched set call.
-	open := findCall(f.calls, "browser", "open")
-	if open == nil {
-		t.Fatalf("no browser open call, got %v", f.calls)
+	// One hidden browser tab added to the host workspace, and both cookies
+	// in a single batched set call.
+	add := findCall(f.calls, "new-surface")
+	if add == nil {
+		t.Fatalf("no new-surface call, got %v", f.calls)
 	}
-	if !hasFlag(open, "--workspace", "workspace:7") {
-		t.Errorf("open must target the background workspace, got %v", open)
+	if !hasFlag(add, "--type", "browser") {
+		t.Errorf("must add a browser surface, got %v", add)
 	}
-	if !hasFlag(open, "--focus", "false") {
-		t.Errorf("open must be unfocused, got %v", open)
+	if !hasFlag(add, "--workspace", "workspace:2") {
+		t.Errorf("tab must target the host workspace (first listed), got %v", add)
+	}
+	if !hasFlag(add, "--focus", "false") {
+		t.Errorf("tab must be added unfocused (hidden), got %v", add)
 	}
 	if f.setCalls != 1 {
 		t.Errorf("expected 1 batched cookies.set call for 2 cookies, got %d", f.setCalls)
 	}
-	// Surface is cached: a second Push reuses it (no new open).
-	opensBefore := countOpens(f.calls)
+	// Surface is cached: a second Push reuses it (no new tab).
+	addsBefore := countAdds(f.calls)
 	if err := a.Push(cookies[:1]); err != nil {
 		t.Fatalf("second Push: %v", err)
 	}
-	if countOpens(f.calls) != opensBefore {
-		t.Errorf("second Push should reuse cached surface, opened again")
+	if countAdds(f.calls) != addsBefore {
+		t.Errorf("second Push should reuse cached surface, added another tab")
 	}
 }
 
@@ -284,10 +287,10 @@ func TestCmuxPush_DropsInvalidCookies(t *testing.T) {
 	}
 }
 
-func TestCmuxPush_ReopensOnSurfaceError(t *testing.T) {
+func TestCmuxPush_ReAddsTabOnSurfaceError(t *testing.T) {
 	f := &fakeCmux{
-		// First set fails with a surface error; after reopen the retry
-		// (and subsequent sets) succeed.
+		// First set fails with a surface error (the cached hidden tab was
+		// closed); after re-adding, the retry and subsequent sets succeed.
 		setErrs: []error{errors.New("invalid_params: Surface is not a browser")},
 	}
 	a := newTestCmux(f, nil)
@@ -296,10 +299,10 @@ func TestCmuxPush_ReopensOnSurfaceError(t *testing.T) {
 	a.surfaceID = "surface:stale"
 	cookies := []chrome.Cookie{{HostKey: ".x.com", Name: "a", Value: "1"}}
 	if err := a.Push(cookies); err != nil {
-		t.Fatalf("Push should recover by reopening, got %v", err)
+		t.Fatalf("Push should recover by re-adding the tab, got %v", err)
 	}
-	if countOpens(f.calls) != 1 {
-		t.Errorf("expected exactly one reopen, got %d", countOpens(f.calls))
+	if countAdds(f.calls) != 1 {
+		t.Errorf("expected exactly one re-add, got %d", countAdds(f.calls))
 	}
 }
 
@@ -369,10 +372,11 @@ func TestFilterByHostPatterns(t *testing.T) {
 	}
 }
 
-func countOpens(calls [][]string) int {
+// countAdds counts new-surface (hidden-tab add) calls.
+func countAdds(calls [][]string) int {
 	n := 0
 	for _, c := range calls {
-		if len(c) >= 2 && c[0] == "browser" && c[1] == "open" {
+		if len(c) >= 1 && c[0] == "new-surface" {
 			n++
 		}
 	}
@@ -399,28 +403,6 @@ func findCall(calls [][]string, prefix ...string) []string {
 	return nil
 }
 
-// lastCall is findCall scanning from the end -- the most recent matching
-// call, e.g. the retry open after a failed first open.
-func lastCall(calls [][]string, prefix ...string) []string {
-	for i := len(calls) - 1; i >= 0; i-- {
-		c := calls[i]
-		if len(c) < len(prefix) {
-			continue
-		}
-		match := true
-		for j, p := range prefix {
-			if c[j] != p {
-				match = false
-				break
-			}
-		}
-		if match {
-			return c
-		}
-	}
-	return nil
-}
-
 // hasFlag reports whether args contains the flag followed by value.
 func hasFlag(args []string, flag, value string) bool {
 	for i := 0; i+1 < len(args); i++ {
@@ -431,161 +413,88 @@ func hasFlag(args []string, flag, value string) bool {
 	return false
 }
 
-func TestCmuxPush_ReusesExistingNamedWorkspace(t *testing.T) {
-	// A workspace named "agentcookie" from a previous run is reused (cmux
-	// prefixes active titles with a status glyph), so restarts don't
-	// accumulate one background workspace each.
+func TestCmuxPush_AddsTabToFirstWorkspaceNeverCreatesOne(t *testing.T) {
+	// The hidden injection tab is parked in an existing workspace -- the
+	// first cmux lists -- so it adds no sidebar entry and no phantom
+	// terminal. (Earlier designs created a dedicated "agentcookie"
+	// workspace, which showed in the sidebar and, because short refs
+	// renumber across cmux restarts, could alias a live user workspace and
+	// pop into view.)
 	f := &fakeCmux{listOut: `{"workspaces":[
-		{"ref":"workspace:2","title":"✳ Claude Code"},
-		{"ref":"workspace:5","title":"⠂ agentcookie"}
+		{"ref":"workspace:5","title":"⠂ Process incoming email task"},
+		{"ref":"workspace:2","title":"✳ Claude Code"}
 	]}`}
 	a := newTestCmux(f, nil)
 	if err := a.Push([]chrome.Cookie{{HostKey: ".x.com", Name: "a", Value: "1"}}); err != nil {
 		t.Fatalf("Push: %v", err)
 	}
 	if c := findCall(f.calls, "workspace", "create"); c != nil {
-		t.Errorf("existing workspace must be reused, but create was called: %v", c)
+		t.Errorf("must never create a workspace, but create was called: %v", c)
 	}
-	open := findCall(f.calls, "browser", "open")
-	if open == nil || !hasFlag(open, "--workspace", "workspace:5") {
-		t.Errorf("open should target the existing workspace:5, got %v", open)
+	add := findCall(f.calls, "new-surface")
+	if add == nil {
+		t.Fatalf("no new-surface call, got %v", f.calls)
+	}
+	if !hasFlag(add, "--workspace", "workspace:5") {
+		t.Errorf("tab should target the first listed workspace:5, got %v", add)
+	}
+	if !hasFlag(add, "--focus", "false") {
+		t.Errorf("tab must be hidden (--focus false), got %v", add)
 	}
 }
 
-func TestCmuxPush_RecreatesClosedWorkspace(t *testing.T) {
-	// The cached background workspace was closed by the user between
-	// syncs: browser open fails with a workspace error, and the adapter
-	// recreates the workspace once and retries the open.
-	f := &fakeCmux{openErrs: []error{errors.New("not_found: Workspace not found")}}
+func TestCmuxPush_NoWorkspaceToHostIsAnError(t *testing.T) {
+	// cmux is running but reports no workspaces: there is nowhere to park
+	// the tab, so Push fails (soft, logged by the caller) rather than
+	// silently creating one.
+	f := &fakeCmux{listOut: `{"workspaces":[]}`}
 	a := newTestCmux(f, nil)
-	if err := a.Push([]chrome.Cookie{{HostKey: ".x.com", Name: "a", Value: "1"}}); err != nil {
-		t.Fatalf("Push should recover by recreating the workspace, got %v", err)
+	err := a.Push([]chrome.Cookie{{HostKey: ".x.com", Name: "a", Value: "1"}})
+	if err == nil {
+		t.Fatal("expected an error when no workspace exists to host the tab")
 	}
-	if findCall(f.calls, "workspace", "create") == nil {
-		t.Errorf("expected a workspace create after the stale-workspace open failure, calls: %v", f.calls)
-	}
-	if countOpens(f.calls) != 2 {
-		t.Errorf("expected 2 opens (stale fail + retry), got %d", countOpens(f.calls))
-	}
-	retryOpen := lastCall(f.calls, "browser", "open")
-	if retryOpen == nil || !hasFlag(retryOpen, "--workspace", "workspace:7") {
-		t.Errorf("retry open should target the recreated workspace:7, got %v", retryOpen)
+	if findCall(f.calls, "new-surface") != nil {
+		t.Errorf("must not add a surface when there is no host workspace: %v", f.calls)
 	}
 }
 
-func TestCmuxPush_AlwaysResolvesWorkspaceByName(t *testing.T) {
-	// Regression (2026-06-06): cmux restarted underneath the long-lived
-	// cmux-sync daemon. Short refs renumber across restarts, so a
-	// workspace ref cached before the restart aliased a live USER
-	// workspace afterwards -- `browser open` succeeded silently (no
-	// workspace error, no recreate) and parked the about:blank pane right
-	// in the user's view. The fix removed the cached ref entirely: every
-	// open resolves the background workspace by name. Here only user
-	// workspaces exist, so the adapter must `workspace list` (resolve by
-	// name), find none, create the agentcookie workspace, and never open
-	// into a user workspace.
-	f := &fakeCmux{listOut: `{"workspaces":[
-		{"ref":"workspace:2","title":"✳ Claude Code"},
-		{"ref":"workspace:5","title":"⠂ Process incoming email task"}
-	]}`}
-	a := newTestCmux(f, nil)
-	if err := a.Push([]chrome.Cookie{{HostKey: ".x.com", Name: "a", Value: "1"}}); err != nil {
-		t.Fatalf("Push: %v", err)
-	}
-	if findCall(f.calls, "workspace", "list") == nil {
-		t.Errorf("open must be preceded by a name resolution (workspace list), calls: %v", f.calls)
-	}
-	if findCall(f.calls, "workspace", "create") == nil {
-		t.Fatalf("no agentcookie workspace exists, so create is required; calls: %v", f.calls)
-	}
-	open := findCall(f.calls, "browser", "open")
-	if open == nil {
-		t.Fatalf("no browser open call, got %v", f.calls)
-	}
-	if hasFlag(open, "--workspace", "workspace:5") || hasFlag(open, "--workspace", "workspace:2") {
-		t.Errorf("open targeted a user workspace: %v", open)
-	}
-	if !hasFlag(open, "--workspace", "workspace:7") {
-		t.Errorf("open should target the freshly created background workspace:7, got %v", open)
-	}
-}
-
-func TestCmuxPush_ReopenAfterStaleSurfaceReResolvesWorkspaceByName(t *testing.T) {
-	// The exact incident path: a push against a stale cached surface fails
-	// with a surface error, and the reopen must re-resolve the background
-	// workspace by name (only user workspaces exist here) rather than
-	// reuse any pre-restart state.
+func TestCmuxPush_ReAddResolvesHostFreshNotCached(t *testing.T) {
+	// After a stale-surface error, the re-add resolves the host workspace
+	// by listing again -- short refs renumber across cmux restarts, so no
+	// pre-restart ref is reused. Here the host is workspace:8.
 	f := &fakeCmux{
 		listOut: `{"workspaces":[
-			{"ref":"workspace:5","title":"⠂ Process incoming email task"}
+			{"ref":"workspace:8","title":"⠂ Process incoming email task"}
 		]}`,
 		setErrs: []error{errors.New("not_found: Surface not found")},
 	}
 	a := newTestCmux(f, nil)
 	a.surfaceID = "surface:12" // pre-restart cache; surface is gone
 	if err := a.Push([]chrome.Cookie{{HostKey: ".x.com", Name: "a", Value: "1"}}); err != nil {
-		t.Fatalf("Push should recover via reopen, got %v", err)
+		t.Fatalf("Push should recover via re-add, got %v", err)
 	}
-	open := findCall(f.calls, "browser", "open")
-	if open == nil {
-		t.Fatalf("expected a reopen, got %v", f.calls)
+	add := findCall(f.calls, "new-surface")
+	if add == nil {
+		t.Fatalf("expected a re-add, got %v", f.calls)
 	}
-	if hasFlag(open, "--workspace", "workspace:5") {
-		t.Errorf("reopen targeted the user workspace:5: %v", open)
-	}
-	if !hasFlag(open, "--workspace", "workspace:7") {
-		t.Errorf("reopen should target the recreated background workspace, got %v", open)
+	if !hasFlag(add, "--workspace", "workspace:8") {
+		t.Errorf("re-add should target the freshly listed host workspace:8, got %v", add)
 	}
 }
 
-func TestFindWorkspaceRef(t *testing.T) {
+func TestFirstWorkspaceRef(t *testing.T) {
 	list := `{"workspaces":[
-		{"ref":"workspace:1","title":"✳ Claude Code"},
-		{"ref":"workspace:3","title":"agentcookie"},
-		{"ref":"workspace:4","title":"not-agentcookie"}
+		{"ref":"workspace:3","title":"✳ Claude Code"},
+		{"ref":"workspace:4","title":"other"}
 	]}`
-	if got := findWorkspaceRef(list, "agentcookie"); got != "workspace:3" {
-		t.Errorf("exact title: got %q, want workspace:3", got)
+	if got := firstWorkspaceRef(list); got != "workspace:3" {
+		t.Errorf("first ref: got %q, want workspace:3", got)
 	}
-	glyph := `{"workspaces":[{"ref":"workspace:9","title":"⠐ agentcookie"}]}`
-	if got := findWorkspaceRef(glyph, "agentcookie"); got != "workspace:9" {
-		t.Errorf("glyph-prefixed title: got %q, want workspace:9", got)
+	if got := firstWorkspaceRef(`{"workspaces":[]}`); got != "" {
+		t.Errorf("empty list should return empty, got %q", got)
 	}
-	// Greptile P2: only a single leading glyph is accepted -- a user
-	// workspace that merely ends with the name must not be hijacked.
-	words := `{"workspaces":[
-		{"ref":"workspace:2","title":"dev agentcookie"},
-		{"ref":"workspace:6","title":"my old agentcookie"}
-	]}`
-	if got := findWorkspaceRef(words, "agentcookie"); got != "" {
-		t.Errorf("word-prefixed titles must not match, got %q", got)
-	}
-	if got := findWorkspaceRef(list, "missing"); got != "" {
-		t.Errorf("missing name should return empty, got %q", got)
-	}
-	if got := findWorkspaceRef("not json", "agentcookie"); got != "" {
+	if got := firstWorkspaceRef("not json"); got != "" {
 		t.Errorf("bad json should return empty, got %q", got)
-	}
-}
-
-func TestIsWorkspaceError_OnlyMissingWorkspace(t *testing.T) {
-	// Greptile P1: only the closed/missing-ref signature triggers the
-	// one-shot recreate. Quota or permission failures would recur on a
-	// fresh workspace, so recreating for them just leaks workspaces.
-	if !isWorkspaceError(errors.New("not_found: Workspace not found")) {
-		t.Error("missing-workspace error must trigger recreate")
-	}
-	for _, msg := range []string{
-		"workspace quota exceeded",
-		"workspace permission denied",
-		"connection refused",
-	} {
-		if isWorkspaceError(errors.New(msg)) {
-			t.Errorf("%q must not trigger a workspace recreate", msg)
-		}
-	}
-	if isWorkspaceError(nil) {
-		t.Error("nil error must not trigger recreate")
 	}
 }
 

--- a/internal/sinkpush/adapter_cmux_test.go
+++ b/internal/sinkpush/adapter_cmux_test.go
@@ -399,6 +399,28 @@ func findCall(calls [][]string, prefix ...string) []string {
 	return nil
 }
 
+// lastCall is findCall scanning from the end -- the most recent matching
+// call, e.g. the retry open after a failed first open.
+func lastCall(calls [][]string, prefix ...string) []string {
+	for i := len(calls) - 1; i >= 0; i-- {
+		c := calls[i]
+		if len(c) < len(prefix) {
+			continue
+		}
+		match := true
+		for j, p := range prefix {
+			if c[j] != p {
+				match = false
+				break
+			}
+		}
+		if match {
+			return c
+		}
+	}
+	return nil
+}
+
 // hasFlag reports whether args contains the flag followed by value.
 func hasFlag(args []string, flag, value string) bool {
 	for i := 0; i+1 < len(args); i++ {
@@ -436,7 +458,6 @@ func TestCmuxPush_RecreatesClosedWorkspace(t *testing.T) {
 	// recreates the workspace once and retries the open.
 	f := &fakeCmux{openErrs: []error{errors.New("not_found: Workspace not found")}}
 	a := newTestCmux(f, nil)
-	a.workspaceRef = "workspace:stale"
 	if err := a.Push([]chrome.Cookie{{HostKey: ".x.com", Name: "a", Value: "1"}}); err != nil {
 		t.Fatalf("Push should recover by recreating the workspace, got %v", err)
 	}
@@ -446,27 +467,33 @@ func TestCmuxPush_RecreatesClosedWorkspace(t *testing.T) {
 	if countOpens(f.calls) != 2 {
 		t.Errorf("expected 2 opens (stale fail + retry), got %d", countOpens(f.calls))
 	}
-	if a.workspaceRef != "workspace:7" {
-		t.Errorf("workspaceRef should be the recreated workspace, got %q", a.workspaceRef)
+	retryOpen := lastCall(f.calls, "browser", "open")
+	if retryOpen == nil || !hasFlag(retryOpen, "--workspace", "workspace:7") {
+		t.Errorf("retry open should target the recreated workspace:7, got %v", retryOpen)
 	}
 }
 
-func TestCmuxPush_StaleWorkspaceRefNeverAliasesUserWorkspace(t *testing.T) {
+func TestCmuxPush_AlwaysResolvesWorkspaceByName(t *testing.T) {
 	// Regression (2026-06-06): cmux restarted underneath the long-lived
 	// cmux-sync daemon. Short refs renumber across restarts, so a
-	// workspace ref cached before the restart can alias a live USER
-	// workspace afterwards. Trusting it made `browser open` succeed
-	// silently -- no workspace error, no recreate -- and parked the
-	// about:blank pane right in the user's view. The adapter must
-	// re-resolve the background workspace by name instead.
+	// workspace ref cached before the restart aliased a live USER
+	// workspace afterwards -- `browser open` succeeded silently (no
+	// workspace error, no recreate) and parked the about:blank pane right
+	// in the user's view. The fix removed the cached ref entirely: every
+	// open resolves the background workspace by name. Here only user
+	// workspaces exist, so the adapter must `workspace list` (resolve by
+	// name), find none, create the agentcookie workspace, and never open
+	// into a user workspace.
 	f := &fakeCmux{listOut: `{"workspaces":[
 		{"ref":"workspace:2","title":"✳ Claude Code"},
 		{"ref":"workspace:5","title":"⠂ Process incoming email task"}
 	]}`}
 	a := newTestCmux(f, nil)
-	a.workspaceRef = "workspace:5" // pre-restart cache; now someone else's workspace
 	if err := a.Push([]chrome.Cookie{{HostKey: ".x.com", Name: "a", Value: "1"}}); err != nil {
 		t.Fatalf("Push: %v", err)
+	}
+	if findCall(f.calls, "workspace", "list") == nil {
+		t.Errorf("open must be preceded by a name resolution (workspace list), calls: %v", f.calls)
 	}
 	if findCall(f.calls, "workspace", "create") == nil {
 		t.Fatalf("no agentcookie workspace exists, so create is required; calls: %v", f.calls)
@@ -475,18 +502,19 @@ func TestCmuxPush_StaleWorkspaceRefNeverAliasesUserWorkspace(t *testing.T) {
 	if open == nil {
 		t.Fatalf("no browser open call, got %v", f.calls)
 	}
-	if hasFlag(open, "--workspace", "workspace:5") {
-		t.Errorf("open targeted the aliased user workspace:5: %v", open)
+	if hasFlag(open, "--workspace", "workspace:5") || hasFlag(open, "--workspace", "workspace:2") {
+		t.Errorf("open targeted a user workspace: %v", open)
 	}
 	if !hasFlag(open, "--workspace", "workspace:7") {
 		t.Errorf("open should target the freshly created background workspace:7, got %v", open)
 	}
 }
 
-func TestCmuxPush_ReopenAfterCmuxRestartReResolvesWorkspaceByName(t *testing.T) {
-	// The exact incident path: a push against the pre-restart cached
-	// surface fails with a surface error, and the reopen must not reuse
-	// the pre-restart workspace ref (which now aliases a user workspace).
+func TestCmuxPush_ReopenAfterStaleSurfaceReResolvesWorkspaceByName(t *testing.T) {
+	// The exact incident path: a push against a stale cached surface fails
+	// with a surface error, and the reopen must re-resolve the background
+	// workspace by name (only user workspaces exist here) rather than
+	// reuse any pre-restart state.
 	f := &fakeCmux{
 		listOut: `{"workspaces":[
 			{"ref":"workspace:5","title":"⠂ Process incoming email task"}
@@ -494,8 +522,7 @@ func TestCmuxPush_ReopenAfterCmuxRestartReResolvesWorkspaceByName(t *testing.T) 
 		setErrs: []error{errors.New("not_found: Surface not found")},
 	}
 	a := newTestCmux(f, nil)
-	a.surfaceID = "surface:12"     // pre-restart cache; surface is gone
-	a.workspaceRef = "workspace:5" // pre-restart cache; aliases a user workspace
+	a.surfaceID = "surface:12" // pre-restart cache; surface is gone
 	if err := a.Push([]chrome.Cookie{{HostKey: ".x.com", Name: "a", Value: "1"}}); err != nil {
 		t.Fatalf("Push should recover via reopen, got %v", err)
 	}
@@ -504,7 +531,7 @@ func TestCmuxPush_ReopenAfterCmuxRestartReResolvesWorkspaceByName(t *testing.T) 
 		t.Fatalf("expected a reopen, got %v", f.calls)
 	}
 	if hasFlag(open, "--workspace", "workspace:5") {
-		t.Errorf("reopen targeted the aliased user workspace:5: %v", open)
+		t.Errorf("reopen targeted the user workspace:5: %v", open)
 	}
 	if !hasFlag(open, "--workspace", "workspace:7") {
 		t.Errorf("reopen should target the recreated background workspace, got %v", open)


### PR DESCRIPTION
## Problem

The cmux cookie-sync popped an `about:blank` browser pane into the user's focused workspace every ~30s, and left an `agentcookie` workspace in the left sidebar.

Two layered causes:
1. **Ref aliasing:** the injection surface was parked in a dedicated `agentcookie` workspace cached by short ref (`workspace:N`). Short refs renumber when cmux restarts, and the cmux-sync LaunchAgent outlives cmux by days, so a cached ref could silently alias a live *user* workspace and drop the pane into focus.
2. **The workspace itself:** even fixed, the dedicated workspace showed in the sidebar, and `workspace create` auto-spawns a Claude Code terminal, so the parking spot carried a phantom agent session.

## Why a workspace was never needed

`browser.cookies.set` needs *a* `surface_id`, but WebKit cookies live at the `WKWebsiteDataStore` (profile) level, shared across every browser surface and surviving pane close. Verified empirically:
- a `cookies.set` on one surface is visible to `cookies.get` on any other (profile-level), and
- a **non-selected (hidden) browser tab still accepts `cookies.set`** (`set: 1` on an unfocused tab, the user's selected surface undisturbed).

## Fix

Add **one unfocused `about:blank` browser tab** to the first existing workspace cmux lists, and cache it. No workspace is created, nothing enters the sidebar, no phantom terminal, focus never moves. The only artifact is a small background tab chip. The host workspace is resolved fresh on every (re)add (never cached, since refs renumber across restarts); a stale-surface error re-adds once.

Deletes the workspace create/find/recreate machinery in favor of `hostWorkspaceLocked` + `firstWorkspaceRef`. Net -134 lines.

## Verification

Live against a running cmux: restarted the cmux-sync daemon on this build. No `agentcookie` workspace appears; the injection tab lands unfocused in the first workspace; 7,324 cookies read back from it. 321 tests pass, `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)