### PR TITLE
fix(livecdp): preserve leading dot on domain cookies (subdomain scope)

### DIFF
--- a/internal/livecdp/inject.go
+++ b/internal/livecdp/inject.go
@@ -60,9 +60,11 @@ func Inject(ctx context.Context, cookies []chrome.Cookie) error {
 //     Domain -- they are scoped to the exact host via URL. Setting Domain
 //     would silently widen them to all subdomains.
 //
-// Domain cookies (host_key with a leading dot) keep Domain (dot stripped,
-// the CDP-accepted form) plus a synthesized URL so Chrome applies the same
-// relaxed validation a real Set-Cookie navigation would.
+// Domain cookies (host_key with a leading dot) keep Domain WITH its leading
+// dot plus a synthesized URL so Chrome applies the same relaxed validation a
+// real Set-Cookie navigation would. The dot is load-bearing: CDP
+// Network.setCookie stores a dot-less Domain host-only, which narrows a
+// parent-domain cookie to its apex and breaks delivery to app subdomains.
 func BuildCookieParams(cookies []chrome.Cookie) []*network.CookieParam {
 	params := make([]*network.CookieParam, 0, len(cookies))
 	for _, c := range cookies {
@@ -97,9 +99,13 @@ func buildParam(c chrome.Cookie) *network.CookieParam {
 		p.Path = "/"
 		// Domain left empty.
 	case strings.HasPrefix(c.HostKey, "."):
-		// Domain cookie: valid for subdomains. Strip the leading dot to
-		// the CDP-accepted Domain form.
-		p.Domain = strings.TrimPrefix(c.HostKey, ".")
+		// Domain cookie: valid for subdomains. The leading dot is
+		// load-bearing for CDP Network.setCookie -- a Domain WITHOUT a
+		// leading dot is stored host-only (apex only), so a parent-domain
+		// session cookie (e.g. ".example.com") never reaches the app's
+		// subdomain (e.g. app.example.com) and the agent browser lands
+		// logged out. Keep the dot to preserve subdomain scope.
+		p.Domain = c.HostKey
 	default:
 		// Host-only cookie: scoped to the exact host via URL, no Domain.
 	}

--- a/internal/livecdp/inject_test.go
+++ b/internal/livecdp/inject_test.go
@@ -55,12 +55,13 @@ func TestBuildCookieParams_HostOnly(t *testing.T) {
 }
 
 // TestBuildCookieParams_DomainCookie: a domain cookie (leading dot) keeps
-// Domain with the dot stripped to the CDP-accepted form.
+// Domain WITH its leading dot so CDP stores it as a subdomain-scoped cookie
+// rather than host-only.
 func TestBuildCookieParams_DomainCookie(t *testing.T) {
 	c := chrome.Cookie{HostKey: ".github.com", Name: "_octo", Value: "v", Path: "/", IsSecure: 1}
 	p := BuildCookieParams([]chrome.Cookie{c})[0]
-	if p.Domain != "github.com" {
-		t.Errorf("domain cookie Domain (dot stripped): got %q", p.Domain)
+	if p.Domain != ".github.com" {
+		t.Errorf("domain cookie keeps the leading dot for subdomain scope: got %q", p.Domain)
 	}
 	if p.URL != "https://github.com/" {
 		t.Errorf("domain cookie URL: got %q", p.URL)


### PR DESCRIPTION
## Summary
- `agent-sync` (and any caller of `livecdp.BuildCookieParams`) injected **domain cookies host-only**, so a parent-domain session cookie never reached the app's subdomain.
- Root cause: `buildParam` stripped the leading dot from `Domain`; CDP `Network.setCookie` treats a dot-less `Domain` as host-only.
- Fix: pass `c.HostKey` with the leading dot intact. One-line behavior change plus comment and unit-test updates.

## Why
On SSO-style sites the session cookie is set on the parent domain (e.g. `.example.com`) while the app is served from a subdomain (e.g. `app.example.com`). With the dot stripped, the injected cookie is scoped host-only to the apex host, so the connected agent browser sends nothing to the app subdomain and lands on the login page — even though the cookie is present in the browser's jar.

This is invisible on `github.com` (the README's end-to-end verification target) because there the app and the auth cookie share a single host, so host-only vs. domain scope never matters. It surfaces on any parent-domain → subdomain split.

## Before / After
- **Before:** `.example.com` cookie → injected as `Domain=example.com` → stored host-only → **not** sent to `app.example.com`.
- **After:** `.example.com` cookie → injected as `Domain=.example.com` → stored as a domain cookie → sent to `app.example.com` and all subdomains.

Isolated with raw CDP `Network.setCookie` → `Network.getCookies` (Chrome 149):

| `domain` passed | `url` also passed | sent to apex | sent to subdomain |
|---|---|---|---|
| `example.com` (dot stripped — old) | yes | yes | **no — host-only** |
| `example.com` (dot stripped) | no | yes | **no — host-only** |
| `.example.com` (dot kept — new) | no | yes | yes |
| `.example.com` (dot kept) | yes | yes | yes |

The synthesized `URL` is irrelevant to the outcome; the leading dot is the deciding factor. The `__Host-` and host-only branches are unchanged.

## Commit Notes
- `fix(livecdp): preserve leading dot on domain cookies`
  - Why: dot-less `Domain` is stored host-only by CDP, breaking subdomain delivery.
  - What changed: `buildParam` now sets `p.Domain = c.HostKey` (keeps the dot); doc comment and `TestBuildCookieParams_DomainCookie` updated to expect `.github.com`.
  - Implication: domain cookies now reach subdomains; no change to `__Host-` or host-only cookies.

## Testing
- `go vet ./internal/livecdp/`
- `go test ./internal/livecdp/`
- `go build ./...`
- Manual: with the dot preserved, CDP `Network.getCookies({urls:["https://app.<domain>/"]})` includes the auth cookie, and a real SSO app authenticated on cookies alone (empty localStorage) after the fix.

## Related
- Fixes #99
