### PR TITLE
feat(chrome): add Helium as a source browser

### DIFF
--- a/internal/chrome/browser.go
+++ b/internal/chrome/browser.go
@@ -96,6 +96,22 @@ var browserRegistry = map[string]Browser{
 		KeychainAccount: "Arc",
 		KeychainService: "Arc Safe Storage",
 	},
+	"helium": {
+		Name: "helium",
+		// Helium (https://helium.computer, bundle net.imput.helium) is a
+		// standard Chromium build, so the file-based "<App> Safe Storage"
+		// keychain model and the Default-profile layout apply directly.
+		// Profile root verified on disk on 2026-06-15:
+		// ~/Library/Application Support/net.imput.helium/Default/Cookies
+		// plus Local State (reports Chrome/149). The keychain
+		// account/service follow the well-established Chromium convention
+		// (matching the Brave/Edge/Arc entries above); decryption is
+		// verified at runtime by the doctor source-adapter check rather
+		// than at registry-definition time.
+		SupportDir:      []string{"net.imput.helium"},
+		KeychainAccount: "Helium",
+		KeychainService: "Helium Safe Storage",
+	},
 }
 
 // LookupBrowser returns the browser descriptor for name. Empty name defaults

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -140,6 +140,7 @@ var sourceBrowserPaths = map[string]browserPathRef{
 	"brave":            {SupportDir: []string{"BraveSoftware", "Brave-Browser"}},
 	"edge":             {SupportDir: []string{"Microsoft Edge"}},
 	"arc":              {SupportDir: []string{"Arc", "User Data"}},
+	"helium":           {SupportDir: []string{"net.imput.helium"}},
 }
 
 // SecurityRef holds transport credentials. SharedSecret is the pre-pairing


### PR DESCRIPTION
## Summary
- Register **Helium** (`net.imput.helium`) as a supported source browser, in both the `internal/chrome` adapter and the `internal/config` path mirror.
- A `browser: helium` block in `source.yaml` now resolves Helium's Default-profile Cookies path and Safe Storage decrypt key.

## Why
Helium (https://helium.computer) is a standard Chromium build — it reports `Chrome/149`, uses the conventional macOS profile layout (`~/Library/Application Support/net.imput.helium/Default/...`), and the file-based `<App> Safe Storage` keychain item. So it slots straight into the pluggable source-browser adapter from #84 with no special handling, the same way Brave/Edge/Arc do.

## Implementation
- `internal/chrome/browser.go`: add a `helium` registry entry — `SupportDir: ["net.imput.helium"]`, keychain account `Helium`, service `Helium Safe Storage`.
- `internal/config/config.go`: add the matching CGO-free path entry. The cross-registry guard tests (`internal/cli/browser_registry_consistency_test.go`) enforce that the two tables stay in sync, so both had to change together.

## Testing
- `go test ./internal/chrome/ ./internal/config/`
- `go test ./internal/cli/ -run 'TestSourceBrowserRegistries|TestChromeAdapterMatchesChromepaths'` (registry consistency guard) — pass
- `go build ./...`
- Profile root verified on disk; the owned-browser CDP path already drives Helium fine (CDP up, cookies inject/deliver correctly). Decryption of Helium's live cookie store is verified at runtime by the `doctor` source-adapter check, matching how Brave/Edge/Arc were added (keychain account/service follow the standard Chromium convention rather than being exercised at registry-definition time).

## Related
- Follows #84 (pluggable Chromium source-browser adapter)
