### PR TITLE
fix(cmux): scope __Host-/host-only cookies by url, not Domain

### DIFF
--- a/internal/sinkpush/adapter_cmux.go
+++ b/internal/sinkpush/adapter_cmux.go
@@ -57,8 +57,13 @@ var surfaceRefRE = regexp.MustCompile(`surface:\d+`)
 //
 // WebKit cookie semantics (confirmed empirically, differ from Chrome's
 // CDP path):
-//   - Domain is stored VERBATIM. ".example.com" is accepted, so unlike
-//     the CDP injector we do NOT strip the leading dot from host_key.
+//   - Cookie scoping is prefix/host-aware (see cmuxCookieParam). __Host--
+//     prefixed and host-only cookies are scoped by url with NO Domain;
+//     domain cookies (leading-dot host_key) keep Domain verbatim
+//     (".example.com" is accepted; the leading dot is not stripped). A
+//     __Host- cookie carrying ANY Domain attribute is hard-rejected by
+//     WebKit, which silently dropped GitHub's __Host-user_session_same_site
+//     on this lane until the url/no-Domain shaping was added.
 //   - expires is Unix seconds; omit it for session cookies. WebKit
 //     clamps far-future expiries to its ~400-day max (expected).
 //   - Cookie values are passed through VERBATIM. The App-Bound (Chrome
@@ -293,29 +298,90 @@ func cmuxCookiesJSON(surfaceID string, cookies []chrome.Cookie) (string, error) 
 }
 
 // cmuxCookieParam builds one cookie's params. Value and domain pass
-// through verbatim (see the CmuxAdapter doc on why no App-Bound re-strip
-// and no leading-dot strip). expires is omitted for session cookies
-// (ExpiresUTC == 0).
+// through verbatim (see the CmuxAdapter doc on why no App-Bound re-strip).
+// expires is omitted for session cookies (ExpiresUTC == 0).
+//
+// Cookie scoping mirrors the corrected shaping in internal/livecdp.buildParam,
+// translated to cmux's browser.cookies.set fields (a "url" the handler maps to
+// HTTPCookie's originURL, plus an optional "domain"):
+//
+//   - __Host--prefixed cookies carry NO Domain. WebKit hard-rejects a __Host-
+//     cookie that has a Domain attribute, which silently dropped GitHub's
+//     __Host-user_session_same_site on this lane. We send url, force Secure
+//     and Path "/", and omit Domain (host-only via the url's host).
+//   - Domain cookies (host_key with a leading dot) keep Domain verbatim
+//     (WebKit accepts the leading dot) plus url.
+//   - Host-only cookies (host_key without a leading dot) carry no Domain --
+//     scoped to the exact host via url. Setting Domain would widen them to
+//     all subdomains.
+//
+// url is required for the __Host- and host-only cases: with no Domain,
+// cmux's HTTPCookie(properties:) has nothing to scope the cookie to unless
+// originURL is set (the cached about:blank surface has no host to fall back
+// to).
 func cmuxCookieParam(c chrome.Cookie) map[string]any {
 	path := c.Path
 	if path == "" {
 		path = "/"
 	}
+	secure := c.IsSecure == 1
 	m := map[string]any{
 		"name":      c.Name,
-		"value":     c.Value,   // verbatim -- already App-Bound-stripped on the source
-		"domain":    c.HostKey, // verbatim -- WebKit accepts the leading dot
+		"value":     c.Value, // verbatim -- already App-Bound-stripped on the source
 		"path":      path,
-		"secure":    c.IsSecure == 1,
 		"http_only": c.IsHTTPOnly == 1,
 	}
+	if u := cmuxCookieURL(c); u != "" {
+		m["url"] = u
+	}
+	switch {
+	case strings.HasPrefix(c.Name, "__Host-"):
+		// __Host- invariants: Secure, Path "/", host-only (no Domain).
+		secure = true
+		m["path"] = "/"
+	case strings.HasPrefix(c.HostKey, "."):
+		// Domain cookie: valid for subdomains. WebKit accepts the leading dot.
+		m["domain"] = c.HostKey
+	default:
+		// Host-only cookie: scoped to the exact host via url, no Domain.
+	}
+	m["secure"] = secure
 	if ss := cmuxSameSite(c.SameSite); ss != "" {
+		// SameSite=None requires Secure -- a None cookie that isn't Secure is
+		// rejected by spec. Downgrade an insecure None to Lax so it survives
+		// rather than vanishing (mirrors internal/livecdp.buildParam and the
+		// CDP lane). Computed after the switch so a __Host- cookie's forced
+		// Secure keeps None.
+		if ss == "none" && !secure {
+			ss = "lax"
+		}
 		m["same_site"] = ss
 	}
 	if c.ExpiresUTC != 0 {
 		m["expires"] = chromeMicrosToUnixSec(c.ExpiresUTC)
 	}
 	return m
+}
+
+// cmuxCookieURL synthesizes a request-URI for a cookie from its host_key,
+// scheme, and path so cmux's WebKit cookie store scopes the cookie to the
+// right host -- and so __Host-/host-only cookies have an origin even with no
+// Domain attribute. The leading dot of a domain host_key is stripped for the
+// URL hostname.
+func cmuxCookieURL(c chrome.Cookie) string {
+	host := strings.TrimPrefix(c.HostKey, ".")
+	if host == "" {
+		return ""
+	}
+	scheme := "https"
+	if c.IsSecure == 0 {
+		scheme = "http"
+	}
+	path := c.Path
+	if path == "" {
+		path = "/"
+	}
+	return scheme + "://" + host + path
 }
 
 // cmuxSameSite maps Chrome's numeric SameSite (cookies.samesite) to the

--- a/internal/sinkpush/adapter_cmux_test.go
+++ b/internal/sinkpush/adapter_cmux_test.go
@@ -102,6 +102,9 @@ func TestCmuxCookieJSON_FieldMapping(t *testing.T) {
 	if m["domain"] != ".github.com" {
 		t.Errorf("domain should be verbatim with leading dot, got %v", m["domain"])
 	}
+	if m["url"] != "https://github.com/api" {
+		t.Errorf("url should be synthesized from host/path, got %v", m["url"])
+	}
 	if m["name"] != "session" || m["value"] != "abc123" {
 		t.Errorf("name/value: got %v / %v", m["name"], m["value"])
 	}
@@ -132,6 +135,59 @@ func TestCmuxCookieJSON_FieldMapping(t *testing.T) {
 	}
 	if env.SurfaceID != "surface:9" || len(env.Cookies) != 2 {
 		t.Errorf("envelope: surface_id=%q cookies=%d, want surface:9 / 2", env.SurfaceID, len(env.Cookies))
+	}
+}
+
+func TestCmuxCookieParam_HostPrefixIsHostOnly(t *testing.T) {
+	// Regression guard for the GitHub-login bug: a __Host--prefixed cookie
+	// (GitHub's session) is hard-rejected by WebKit if it carries ANY Domain
+	// attribute. It must be sent host-only -- url set, no domain -- with
+	// Secure and Path "/" forced.
+	c := chrome.Cookie{
+		HostKey:  "github.com", // host-only in Chrome's store (no leading dot)
+		Name:     "__Host-user_session_same_site",
+		Value:    "sess",
+		Path:     "/",
+		IsSecure: 1,
+	}
+	m := cmuxCookieParam(c)
+	if _, ok := m["domain"]; ok {
+		t.Errorf("__Host- cookie must NOT carry a domain (WebKit rejects it), got %v", m["domain"])
+	}
+	if m["url"] != "https://github.com/" {
+		t.Errorf("__Host- cookie must be scoped by url, got %v", m["url"])
+	}
+	if m["secure"] != true {
+		t.Errorf("__Host- cookie must force secure=true, got %v", m["secure"])
+	}
+	if m["path"] != "/" {
+		t.Errorf("__Host- cookie must force path=/, got %v", m["path"])
+	}
+}
+
+func TestCmuxCookieParam_HostOnlyNoDomainWidening(t *testing.T) {
+	// A host-only cookie (host_key with no leading dot) must not be widened
+	// to subdomains: no Domain attribute, scoped to the exact host via url.
+	c := chrome.Cookie{HostKey: "github.com", Name: "user_session", Value: "v", Path: "/", IsSecure: 1}
+	m := cmuxCookieParam(c)
+	if _, ok := m["domain"]; ok {
+		t.Errorf("host-only cookie must NOT carry a domain, got %v", m["domain"])
+	}
+	if m["url"] != "https://github.com/" {
+		t.Errorf("host-only cookie must be scoped by url, got %v", m["url"])
+	}
+}
+
+func TestCmuxCookieParam_InsecureNoneDowngradesToLax(t *testing.T) {
+	// A SameSite=None cookie that is not Secure is rejected by spec; downgrade
+	// to Lax so it survives. A secure None cookie keeps None.
+	insecure := chrome.Cookie{HostKey: "example.com", Name: "x", Value: "v", Path: "/", IsSecure: 0, SameSite: 0}
+	if m := cmuxCookieParam(insecure); m["same_site"] != "lax" {
+		t.Errorf("insecure None must downgrade to lax, got %v", m["same_site"])
+	}
+	secure := chrome.Cookie{HostKey: "example.com", Name: "x", Value: "v", Path: "/", IsSecure: 1, SameSite: 0}
+	if m := cmuxCookieParam(secure); m["same_site"] != "none" {
+		t.Errorf("secure None must stay none, got %v", m["same_site"])
 	}
 }
 


### PR DESCRIPTION
## Problem

The cmux sync lane delivered every cookie with a `Domain` attribute set
(`domain: c.HostKey`). WebKit hard-rejects any `__Host-`-prefixed cookie that
carries a `Domain` attribute, so GitHub's `__Host-user_session_same_site` was
silently dropped on every push. `user_session` landed but the same-site session
cookie did not, leaving the cmux agent browser on the GitHub login page despite
a "healthy" 1,600-cookie push and a valid session in source Chrome.

The cold CDP lane was already fixed for this on main (`fix(cdp): faithful
host-only/__Host- cookie injection`); the cmux lane was the remaining gap.

## Fix

`cmuxCookieParam` now mirrors the shaping already used by the CDP and livecdp
lanes:

- `__Host-` cookies: scoped host-only via a synthesized `url`, no `Domain`,
  with `Secure` and `Path "/"` forced.
- Domain cookies (leading-dot host_key): keep `Domain`.
- Host-only cookies: scoped by `url`, no `Domain` (no subdomain widening).

Adds `cmuxCookieURL` and regression tests asserting `__Host-` is emitted
host-only with no `Domain`, and host-only cookies are not widened.

## Verification

Rebuilt + restarted the local `cmux-sync` watcher and forced a one-shot
`--once --domain %github.com` re-injection: 16 GitHub cookies injected with the
corrected shaping, restoring the logged-in session in the cmux browser. Full
suite green.

## Known residual

The cmux handler falls back to `props[.domain] = fallbackURL.host` when no
`domain` is sent. Dormant because the injection surface is `about:blank` (host
`nil`), but a navigated/reused surface could re-introduce a `Domain` on
`__Host-` cookies. Worth a follow-up to harden the surface invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
