### PR TITLE
fix(cmux): honest auth status for browser-bound sessions (GitHub)

### DIFF
--- a/internal/chrome/boundsession.go
+++ b/internal/chrome/boundsession.go
@@ -1,0 +1,68 @@
+package chrome
+
+import "strings"
+
+// This file models browser-bound web sessions: sites whose logged-in session
+// is bound by the SERVER to the originating browser, distinct from DBSC.
+//
+// DBSC (see dbsc.go) is a Chrome mechanism that binds a session key to the
+// source machine's secure hardware; a copied DBSC cookie works until its
+// short-lived refresh fails. A browser-bound session is different: the server
+// gates the logged-in response on a SameSite/site-context cookie and the
+// originating browser, and rejects a transplanted session presented from a
+// DIFFERENT browser engine even on the same machine and IP. GitHub is the
+// known case (its __Host-user_session_same_site cookie and a
+// `vary: Sec-Fetch-Site` response): the cookies copy in and are even sent on
+// requests, but the session never authenticates in cmux's WebKit browser.
+//
+// Cookie copying cannot reconstruct a browser-bound session. The honest fix is
+// a native login in the target browser (which binds a fresh session to it), or
+// gh CLI for git work. This classification exists ONLY to phrase that guidance
+// accurately -- it never gates shipping, and bound-session cookies still ship
+// (the non-session cookies remain useful, and a later native login benefits
+// from the preference/analytics cookies already present).
+
+// boundSessionHosts are registrable-domain suffixes whose web session is
+// server-bound to the originating browser. Kept separate from dbscKnownHosts so
+// messaging never mislabels a browser-bound session as DBSC.
+var boundSessionHosts = []string{
+	"github.com",
+}
+
+// BoundSessionHosts returns the known browser-bound-session hosts. Callers use
+// it to drive post-injection auth verification (see internal/sinkpush.Verify).
+func BoundSessionHosts() []string {
+	out := make([]string, len(boundSessionHosts))
+	copy(out, boundSessionHosts)
+	return out
+}
+
+// IsBoundSessionHost reports whether host (leading dot trimmed, any case)
+// equals or is a subdomain of a known browser-bound-session host.
+func IsBoundSessionHost(host string) bool {
+	return hostMatchesSuffix(host, boundSessionHosts)
+}
+
+// hostMatchesSuffix reports whether host (leading dot trimmed, lower-cased)
+// equals or is a subdomain of any registrable-domain suffix in suffixes.
+// Shared by the DBSC (dbsc.go) and browser-bound-session classifiers so the
+// host-matching semantics cannot drift between them.
+func hostMatchesSuffix(host string, suffixes []string) bool {
+	host = strings.ToLower(strings.TrimPrefix(host, "."))
+	for _, k := range suffixes {
+		if host == k || strings.HasSuffix(host, "."+k) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsBoundSessionCookie reports whether c is the fingerprint of a browser-bound
+// session: a Secure cookie on a known bound-session host. A non-secure cookie
+// is never a session credential, so it is never a bound-session marker.
+func IsBoundSessionCookie(c Cookie) bool {
+	if c.IsSecure == 0 {
+		return false
+	}
+	return IsBoundSessionHost(c.HostKey)
+}

--- a/internal/chrome/boundsession_test.go
+++ b/internal/chrome/boundsession_test.go
@@ -1,0 +1,56 @@
+package chrome
+
+import "testing"
+
+func TestIsBoundSessionHost(t *testing.T) {
+	cases := []struct {
+		host string
+		want bool
+	}{
+		{"github.com", true},
+		{".github.com", true},     // leading dot trimmed
+		{"GitHub.com", true},      // case-insensitive
+		{"gist.github.com", true}, // subdomain
+		{"google.com", false},     // DBSC host, NOT a bound-session host (no cross-contamination)
+		{"notgithub.com", false},  // suffix must be on a dot boundary
+		{"example.com", false},    // ordinary host
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := IsBoundSessionHost(tc.host); got != tc.want {
+			t.Errorf("IsBoundSessionHost(%q) = %v, want %v", tc.host, got, tc.want)
+		}
+	}
+}
+
+func TestIsBoundSessionCookie(t *testing.T) {
+	// A secure cookie on github.com is a bound-session marker.
+	if !IsBoundSessionCookie(Cookie{HostKey: "github.com", Name: "user_session", IsSecure: 1}) {
+		t.Error("secure github.com cookie should be a bound-session marker")
+	}
+	// A non-secure cookie is never a session credential.
+	if IsBoundSessionCookie(Cookie{HostKey: "github.com", Name: "tz", IsSecure: 0}) {
+		t.Error("non-secure github.com cookie must not be a bound-session marker")
+	}
+	// A Google (DBSC) cookie is not a bound-session marker -- it routes through
+	// the DBSC path instead.
+	if IsBoundSessionCookie(Cookie{HostKey: "google.com", Name: "SID", IsSecure: 1}) {
+		t.Error("google.com cookie must not classify as bound-session")
+	}
+	// An ordinary host is neither.
+	if IsBoundSessionCookie(Cookie{HostKey: "example.com", Name: "s", IsSecure: 1}) {
+		t.Error("example.com cookie must not classify as bound-session")
+	}
+}
+
+func TestBoundSessionHostsIsCopy(t *testing.T) {
+	got := BoundSessionHosts()
+	if len(got) == 0 {
+		t.Fatal("BoundSessionHosts should not be empty")
+	}
+	// Mutating the returned slice must not affect the package state.
+	got[0] = "mutated.example"
+	if BoundSessionHosts()[0] == "mutated.example" {
+		t.Error("BoundSessionHosts must return a copy, not the backing slice")
+	}
+}

--- a/internal/chrome/dbsc.go
+++ b/internal/chrome/dbsc.go
@@ -153,13 +153,9 @@ func chromeTimeToUnix(micros int64) time.Time {
 	return time.UnixMicro(micros - chromeEpochOffsetMicros).UTC()
 }
 
-// matchesKnownDBSCHost reports whether host (leading dot already trimmed,
-// lower-cased) equals or is a subdomain of a known DBSC host.
+// matchesKnownDBSCHost reports whether host equals or is a subdomain of a known
+// DBSC host. Shares hostMatchesSuffix (boundsession.go) with the bound-session
+// classifier so the two host matchers cannot drift apart.
 func matchesKnownDBSCHost(host string) bool {
-	for _, k := range dbscKnownHosts {
-		if host == k || strings.HasSuffix(host, "."+k) {
-			return true
-		}
-	}
-	return false
+	return hostMatchesSuffix(host, dbscKnownHosts)
 }

--- a/internal/cli/cmux_sync.go
+++ b/internal/cli/cmux_sync.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"hash/fnv"
+	"io"
 	"os"
 	"sync"
 	"time"
@@ -22,6 +23,7 @@ var (
 	cmuxSyncVerbose  bool
 	cmuxSyncDryRun   bool
 	cmuxSyncSkipDBSC bool
+	cmuxSyncVerify   bool
 	cmuxSyncDomains  []string
 	cmuxSyncCmuxPath string
 	cmuxSyncBrowser  string
@@ -54,6 +56,7 @@ func init() {
 	cmuxSyncCmd.Flags().BoolVar(&cmuxSyncWatch, "watch", false, "long-running fsnotify watcher; re-injects on every Chrome cookie write (debounced)")
 	cmuxSyncCmd.Flags().BoolVar(&cmuxSyncVerbose, "verbose", false, "log per-cycle counts to stderr")
 	cmuxSyncCmd.Flags().BoolVar(&cmuxSyncDryRun, "dry-run", false, "read + filter but do not inject into cmux")
+	cmuxSyncCmd.Flags().BoolVar(&cmuxSyncVerify, "verify", true, "after a --once push, verify each browser-bound-session host (e.g. github.com) actually authenticates and report honestly (delivery != authentication); ignored in --watch")
 	cmuxSyncCmd.Flags().BoolVar(&cmuxSyncSkipDBSC, "skip-dbsc-suspect", false, "drop cookies that look device-bound (DBSC); also honored via AGENTCOOKIE_SKIP_DBSC_SUSPECT=1")
 	cmuxSyncCmd.Flags().StringSliceVar(&cmuxSyncDomains, "domain", nil, "limit to these host_key LIKE patterns (repeatable), e.g. --domain %github.com; overrides cmux.domain_filter")
 	cmuxSyncCmd.Flags().StringVar(&cmuxSyncCmuxPath, "cmux-path", "", "override the cmux CLI path (default: cmux.cmux_path, then the app bundle)")
@@ -181,6 +184,13 @@ func runCmuxSync(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("cmux-sync: %w (if cmux is running, check socketControlMode -- `agentcookie doctor` prints the fix)", err)
 		}
 		fmt.Fprintf(os.Stderr, "agentcookie cmux-sync: injected %d cookies into cmux\n", n)
+		// Delivery is not authentication. For browser-bound-session hosts the
+		// cookies land but the session may still be rejected server-side; verify
+		// empirically and report honestly. Non-fatal: a probe never changes the
+		// exit status of a successful push.
+		if cmuxSyncVerify && !cmuxSyncDryRun {
+			reportCmuxVerify(adapter, domainFilter, os.Stderr)
+		}
 		return nil
 	}
 
@@ -202,6 +212,34 @@ func runCmuxSync(cmd *cobra.Command, args []string) error {
 	}
 	fmt.Fprintf(os.Stderr, "agentcookie cmux-sync --watch: watching %s, injecting into cmux\n", cfg.Chrome.DBPath)
 	return w.Run(cmd.Context())
+}
+
+// cmuxVerifier is the subset of CmuxAdapter reportCmuxVerify needs; an
+// interface so the reporting glue is testable without a live cmux.
+type cmuxVerifier interface {
+	Verify(specs []sinkpush.VerifySpec) []sinkpush.VerifyResult
+}
+
+// reportCmuxVerify runs the post-injection auth probe for the browser-bound
+// -session hosts in scope and prints one honest line per host to w. It never
+// errors: a session that cannot be probed reports "unknown" and a
+// delivered-but-not-authenticated session prints the native-login / gh-CLI
+// guidance.
+func reportCmuxVerify(v cmuxVerifier, domainFilter []string, w io.Writer) {
+	specs := sinkpush.VerifySpecsForHosts(domainFilter)
+	if len(specs) == 0 {
+		return
+	}
+	for _, r := range v.Verify(specs) {
+		switch r.State {
+		case sinkpush.AuthYes:
+			fmt.Fprintf(w, "agentcookie cmux-sync: session check: %s authenticated\n", r.Host)
+		case sinkpush.AuthNo:
+			fmt.Fprintf(w, "agentcookie cmux-sync: session check: %s NOT authenticated -- %s\n", r.Host, r.Detail)
+		default:
+			fmt.Fprintf(w, "agentcookie cmux-sync: session check: %s unknown (%s)\n", r.Host, r.Detail)
+		}
+	}
 }
 
 // cmuxCookieKey identifies a cookie across sync cycles. Host+name+path is

--- a/internal/cli/cmux_sync_test.go
+++ b/internal/cli/cmux_sync_test.go
@@ -1,13 +1,83 @@
 package cli
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
 
 	"github.com/mvanhorn/agentcookie/internal/chrome"
+	"github.com/mvanhorn/agentcookie/internal/sinkpush"
 )
+
+// fakeVerifier returns scripted verify results without a live cmux.
+type fakeVerifier struct {
+	results []sinkpush.VerifyResult
+	called  bool
+}
+
+func (f *fakeVerifier) Verify(specs []sinkpush.VerifySpec) []sinkpush.VerifyResult {
+	f.called = true
+	return f.results
+}
+
+func TestReportCmuxVerify_Output(t *testing.T) {
+	cases := []struct {
+		name    string
+		result  sinkpush.VerifyResult
+		want    string
+		notWant string
+	}{
+		{
+			name:    "authenticated",
+			result:  sinkpush.VerifyResult{Host: "github.com", State: sinkpush.AuthYes},
+			want:    "github.com authenticated",
+			notWant: "NOT authenticated",
+		},
+		{
+			name:   "not authenticated carries guidance",
+			result: sinkpush.VerifyResult{Host: "github.com", State: sinkpush.AuthNo, Detail: "log in to github.com once inside the cmux browser"},
+			want:   "NOT authenticated -- log in to github.com once inside the cmux browser",
+		},
+		{
+			name:   "unknown is non-scary",
+			result: sinkpush.VerifyResult{Host: "github.com", State: sinkpush.AuthUnknown, Detail: "eval error: boom"},
+			want:   "github.com unknown (eval error: boom)",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := &fakeVerifier{results: []sinkpush.VerifyResult{tc.result}}
+			var buf bytes.Buffer
+			// nil filter -> builtin specs are non-empty, so Verify is invoked.
+			reportCmuxVerify(v, nil, &buf)
+			if !v.called {
+				t.Fatal("Verify should have been called")
+			}
+			got := buf.String()
+			if !strings.Contains(got, tc.want) {
+				t.Errorf("output %q missing %q", got, tc.want)
+			}
+			if tc.notWant != "" && strings.Contains(got, tc.notWant) {
+				t.Errorf("output %q should not contain %q", got, tc.notWant)
+			}
+		})
+	}
+}
+
+func TestReportCmuxVerify_NoSpecsNoProbe(t *testing.T) {
+	// A domain filter that matches no bound-session host means no probe at all.
+	v := &fakeVerifier{}
+	var buf bytes.Buffer
+	reportCmuxVerify(v, []string{"%example.com"}, &buf)
+	if v.called {
+		t.Error("Verify must not be called when no bound-session host is in scope")
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected no output, got %q", buf.String())
+	}
+}
 
 // runCmuxSync validates the mode flags before any Chrome/keychain/cmux I/O,
 // mirroring `source`. These cases exercise that gate without touching the

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -74,6 +74,12 @@ type doctorDeps struct {
 	SourceAdapterCookiesExists func(path string) error
 	SourceAdapterPassword      func(chrome.Browser) (string, error)
 	SourceAdapterDecrypt       func(path string, key []byte) error
+
+	// CmuxSessionHealth verifies that browser-bound-session hosts (e.g.
+	// github.com) actually authenticate in the live cmux browser. Injected so
+	// tests don't open a real browser surface; nil falls back to the live
+	// checkCmuxSessionHealth.
+	CmuxSessionHealth func(config.CmuxRef) Check
 }
 
 var doctorCmd = &cobra.Command{
@@ -265,9 +271,23 @@ func buildReport(d doctorDeps) DoctorReport {
 	// applied (not still cmuxOnly, which means a restart is pending).
 	if srcCfg != nil {
 		checks = append(checks, checkCmuxLocalLoop(srcCfg.Cmux))
+		// 10d. cmux session health -- delivery is not authentication. Empirically
+		// verify that browser-bound-session hosts (github.com) actually
+		// authenticate in the cmux browser. Self-skips fast when cmux is not
+		// running, so it adds cost only when there is a live browser to probe.
+		sessionHealth := d.CmuxSessionHealth
+		if sessionHealth == nil {
+			sessionHealth = checkCmuxSessionHealth
+		}
+		checks = append(checks, sessionHealth(srcCfg.Cmux))
 	} else {
 		checks = append(checks, Check{
 			Name:     "cmux local loop",
+			Severity: SeveritySkipped,
+			Detail:   "sink-only install",
+		})
+		checks = append(checks, Check{
+			Name:     "cmux session health",
 			Severity: SeveritySkipped,
 			Detail:   "sink-only install",
 		})
@@ -1128,6 +1148,68 @@ func probeCmuxAccessMode(binary string) (string, error) {
 		return "", fmt.Errorf("parse capabilities: %w", err)
 	}
 	return caps.AccessMode, nil
+}
+
+// checkCmuxSessionHealth verifies, empirically, that delivered sessions for
+// browser-bound-session hosts (e.g. github.com) actually authenticate in the
+// cmux browser. Delivery is not authentication: GitHub binds the session to the
+// origin browser and rejects a transplanted one, so a "healthy" push can still
+// leave the cmux browser logged out. OK means authenticated; WARN means
+// delivered-but-not-authenticated (with the native-login fix); skipped means
+// cmux is not running or the probe was inconclusive (never a FAIL -- a flaky
+// probe must not fail doctor).
+func checkCmuxSessionHealth(cmux config.CmuxRef) Check {
+	verify := func(specs []sinkpush.VerifySpec) []sinkpush.VerifyResult {
+		return sinkpush.NewCmux(cmux.CmuxPath, nil).Verify(specs)
+	}
+	return checkCmuxSessionHealthWith(cmux, probeCmuxAccessMode, verify)
+}
+
+func checkCmuxSessionHealthWith(
+	cmux config.CmuxRef,
+	probe func(string) (string, error),
+	verify func([]sinkpush.VerifySpec) []sinkpush.VerifyResult,
+) Check {
+	const name = "cmux session health"
+	binary := sinkpush.ResolveCmuxBinary(cmux.CmuxPath)
+	info, statErr := os.Stat(binary)
+	if statErr != nil || info.IsDir() {
+		return Check{Name: name, Severity: SeveritySkipped, Detail: "cmux not installed"}
+	}
+	if _, err := probe(binary); err != nil {
+		return Check{Name: name, Severity: SeveritySkipped, Detail: "cmux not running; cannot check session health"}
+	}
+	specs := sinkpush.BuiltinVerifySpecs()
+	if len(specs) == 0 {
+		return Check{Name: name, Severity: SeveritySkipped, Detail: "no browser-bound-session hosts to check"}
+	}
+
+	results := verify(specs)
+	var notAuthed []string
+	authed := 0
+	unknown := 0
+	for _, r := range results {
+		switch r.State {
+		case sinkpush.AuthNo:
+			notAuthed = append(notAuthed, r.Host)
+		case sinkpush.AuthYes:
+			authed++
+		default:
+			unknown++
+		}
+	}
+	if len(notAuthed) > 0 {
+		return Check{
+			Name:        name,
+			Severity:    SeverityWarn,
+			Detail:      fmt.Sprintf("%s: cookies delivered but the session is NOT authenticated (the site binds the session to the origin browser)", strings.Join(notAuthed, ", ")),
+			Remediation: "log in to the site once inside the cmux browser to bind a working session; use the gh CLI for git and PR work",
+		}
+	}
+	if authed > 0 && unknown == 0 {
+		return Check{Name: name, Severity: SeverityOK, Detail: fmt.Sprintf("%d browser-bound-session host(s) authenticated", authed)}
+	}
+	return Check{Name: name, Severity: SeveritySkipped, Detail: "session-health probe was inconclusive (page did not load or cmux did not answer)"}
 }
 
 func checkCDPInjector(sinkCfg *config.SinkConfig) Check {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -738,6 +738,10 @@ peer:
 		SourceAdapterCookiesExists: func(string) error { return nil },
 		SourceAdapterPassword:      func(chrome.Browser) (string, error) { return "safe-storage-password", nil },
 		SourceAdapterDecrypt:       func(string, []byte) error { return nil },
+		// Stub so the envelope test never opens a live cmux browser surface.
+		CmuxSessionHealth: func(config.CmuxRef) Check {
+			return Check{Name: "cmux session health", Severity: SeveritySkipped, Detail: "stub"}
+		},
 	})
 
 	// v0.12.0-beta.3 added two checks: Adapter coverage + CDP injector.
@@ -746,9 +750,11 @@ peer:
 	// The consumption bridge added the Secret coverage + Binary install checks.
 	// Universal cookie delivery added the Cookie delivery check. Source browser
 	// adapters added the Source adapter check. The cmux delivery surface added
-	// the cmux delivery check.
-	if got := len(report.Checks); got != 19 {
-		t.Fatalf("got %d checks, want 19", got)
+	// the cmux delivery check. Browser-bound-session honesty added the cmux
+	// session health check (source role only; present here since this fixture
+	// is source).
+	if got := len(report.Checks); got != 20 {
+		t.Fatalf("got %d checks, want 20", got)
 	}
 
 	// Serialize the envelope and confirm it round-trips.
@@ -860,6 +866,71 @@ func TestCheckCmuxLocalLoop(t *testing.T) {
 		c := checkCmuxLocalLoopWith(cfg, agentUp, okProbe)
 		if c.Severity != SeverityOK || !strings.Contains(c.Detail, "loop active") {
 			t.Fatalf("got %q / %q, want OK + loop active", c.Severity, c.Detail)
+		}
+	})
+}
+
+func TestCheckCmuxSessionHealth(t *testing.T) {
+	okProbe := func(string) (string, error) { return "allowAll", nil }
+	downProbe := func(string) (string, error) { return "", errors.New("connection refused") }
+	authedVerify := func([]sinkpush.VerifySpec) []sinkpush.VerifyResult {
+		return []sinkpush.VerifyResult{{Host: "github.com", State: sinkpush.AuthYes}}
+	}
+	notAuthedVerify := func([]sinkpush.VerifySpec) []sinkpush.VerifyResult {
+		return []sinkpush.VerifyResult{{Host: "github.com", State: sinkpush.AuthNo, Detail: "bound"}}
+	}
+	unknownVerify := func([]sinkpush.VerifySpec) []sinkpush.VerifyResult {
+		return []sinkpush.VerifyResult{{Host: "github.com", State: sinkpush.AuthUnknown, Detail: "timeout"}}
+	}
+	mustNotVerify := func([]sinkpush.VerifySpec) []sinkpush.VerifyResult {
+		t.Helper()
+		t.Fatal("verify should not run when cmux is absent or unreachable")
+		return nil
+	}
+
+	t.Run("cmux absent = skipped, no probe", func(t *testing.T) {
+		cfg := config.CmuxRef{CmuxPath: filepath.Join(t.TempDir(), "no-cmux")}
+		c := checkCmuxSessionHealthWith(cfg, func(string) (string, error) {
+			t.Fatal("probe should not run when cmux is absent")
+			return "", nil
+		}, mustNotVerify)
+		if c.Severity != SeveritySkipped {
+			t.Fatalf("got %q, want SKIPPED", c.Severity)
+		}
+	})
+
+	t.Run("cmux not running = skipped, no verify", func(t *testing.T) {
+		cfg := config.CmuxRef{CmuxPath: writeExecutable(t)}
+		c := checkCmuxSessionHealthWith(cfg, downProbe, mustNotVerify)
+		if c.Severity != SeveritySkipped || !strings.Contains(c.Detail, "not running") {
+			t.Fatalf("got %q / %q, want SKIPPED + not running", c.Severity, c.Detail)
+		}
+	})
+
+	t.Run("authenticated = OK", func(t *testing.T) {
+		cfg := config.CmuxRef{CmuxPath: writeExecutable(t)}
+		c := checkCmuxSessionHealthWith(cfg, okProbe, authedVerify)
+		if c.Severity != SeverityOK {
+			t.Fatalf("got %q / %q, want OK", c.Severity, c.Detail)
+		}
+	})
+
+	t.Run("not authenticated = WARN with native-login fix", func(t *testing.T) {
+		cfg := config.CmuxRef{CmuxPath: writeExecutable(t)}
+		c := checkCmuxSessionHealthWith(cfg, okProbe, notAuthedVerify)
+		if c.Severity != SeverityWarn {
+			t.Fatalf("got %q, want WARN", c.Severity)
+		}
+		if !strings.Contains(c.Detail, "github.com") || !strings.Contains(c.Remediation, "log in") {
+			t.Fatalf("WARN must name the host and the native-login fix, got %q / %q", c.Detail, c.Remediation)
+		}
+	})
+
+	t.Run("inconclusive probe = skipped, never FAIL", func(t *testing.T) {
+		cfg := config.CmuxRef{CmuxPath: writeExecutable(t)}
+		c := checkCmuxSessionHealthWith(cfg, okProbe, unknownVerify)
+		if c.Severity != SeveritySkipped {
+			t.Fatalf("got %q, want SKIPPED (a flaky probe must never FAIL doctor)", c.Severity)
 		}
 	})
 }

--- a/internal/sinkpush/adapter_cmux.go
+++ b/internal/sinkpush/adapter_cmux.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/mvanhorn/agentcookie/internal/chrome"
 )
@@ -80,6 +81,10 @@ type CmuxAdapter struct {
 	// run executes a cmux subcommand and returns stdout. Swappable in
 	// tests; defaults to execCmux.
 	run func(args ...string) (string, error)
+
+	// sleep waits between auth-verify poll attempts (see verify.go). Swappable
+	// in tests to avoid real waits; defaults to time.Sleep.
+	sleep func(time.Duration)
 }
 
 // NewCmux returns a cmux delivery adapter. cmuxPath overrides the binary
@@ -89,6 +94,7 @@ type CmuxAdapter struct {
 func NewCmux(cmuxPath string, domainFilter []string) *CmuxAdapter {
 	a := &CmuxAdapter{binary: ResolveCmuxBinary(cmuxPath), domainFilter: domainFilter}
 	a.run = a.execCmux
+	a.sleep = time.Sleep
 	return a
 }
 
@@ -337,8 +343,21 @@ func cmuxCookieParam(c chrome.Cookie) map[string]any {
 	switch {
 	case strings.HasPrefix(c.Name, "__Host-"):
 		// __Host- invariants: Secure, Path "/", host-only (no Domain).
+		// WebKit hard-rejects a __Host- cookie carrying ANY Domain, so we both
+		// refrain from setting one here and defensively delete any Domain a
+		// future edit before this switch might add.
+		//
+		// The host-only scoping relies entirely on url: cmux's handler falls
+		// back to the injection surface's host when no Domain AND no url is
+		// sent, and a navigated/reused surface (host != nil) would re-introduce
+		// a Domain on the __Host- cookie -- the known residual from PR #103.
+		// Guaranteeing url is present (set above from HostKey) neutralizes that
+		// fallback regardless of the surface's current host. A __Host- cookie
+		// with no derivable host (empty url) is unusable and is dropped earlier
+		// by the caller's Validate gate.
 		secure = true
 		m["path"] = "/"
+		delete(m, "domain")
 	case strings.HasPrefix(c.HostKey, "."):
 		// Domain cookie: valid for subdomains. WebKit accepts the leading dot.
 		m["domain"] = c.HostKey

--- a/internal/sinkpush/adapter_cmux_test.go
+++ b/internal/sinkpush/adapter_cmux_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/mvanhorn/agentcookie/internal/chrome"
 )
@@ -22,6 +23,12 @@ type fakeCmux struct {
 	listErr  error
 	setErrs  []error // consumed in order, one per browser.cookies.set call
 	setCalls int
+
+	// Auth-verify (verify.go) scripting.
+	evalOuts   []string // browser.eval responses, consumed in order; last repeats
+	evalErrs   []error  // browser.eval errors, consumed in order; last repeats
+	evalIdx    int
+	closeCalls int // count of rpc surface.close calls
 }
 
 func (f *fakeCmux) run(args ...string) (string, error) {
@@ -58,7 +65,42 @@ func (f *fakeCmux) run(args ...string) (string, error) {
 		}
 		return `{"set":1}`, nil
 	}
+	if len(args) >= 2 && args[0] == "rpc" && args[1] == "browser.eval" {
+		i := f.evalIdx
+		f.evalIdx++
+		if e := pickAt(f.evalErrs, i); e != nil {
+			return "", e
+		}
+		return pickStrAt(f.evalOuts, i), nil
+	}
+	if len(args) >= 2 && args[0] == "rpc" && args[1] == "surface.close" {
+		f.closeCalls++
+		return `{"closed":1}`, nil
+	}
 	return "", nil
+}
+
+// pickAt returns errs[i], or the last element when i is past the end, or nil
+// when empty. Lets a fake script "then this forever" with one trailing entry.
+func pickAt(errs []error, i int) error {
+	if len(errs) == 0 {
+		return nil
+	}
+	if i >= len(errs) {
+		i = len(errs) - 1
+	}
+	return errs[i]
+}
+
+// pickStrAt is pickAt for strings (returns "" when empty).
+func pickStrAt(s []string, i int) string {
+	if len(s) == 0 {
+		return ""
+	}
+	if i >= len(s) {
+		i = len(s) - 1
+	}
+	return s[i]
 }
 
 // flagValue returns the value following flag in args, or "".
@@ -74,6 +116,7 @@ func flagValue(args []string, flag string) string {
 func newTestCmux(f *fakeCmux, filter []string) *CmuxAdapter {
 	a := &CmuxAdapter{binary: "/fake/cmux", domainFilter: filter}
 	a.run = f.run
+	a.sleep = func(time.Duration) {} // no real waits in tests
 	return a
 }
 
@@ -162,6 +205,29 @@ func TestCmuxCookieParam_HostPrefixIsHostOnly(t *testing.T) {
 	}
 	if m["path"] != "/" {
 		t.Errorf("__Host- cookie must force path=/, got %v", m["path"])
+	}
+}
+
+func TestCmuxCookieParam_HostPrefixForcedHostOnlyDespiteDotHostKey(t *testing.T) {
+	// Hardening for PR #103's known residual: the __Host- invariant must hold
+	// regardless of upstream state. Even if a __Host- cookie arrives with a
+	// leading-dot host_key (which would otherwise take the domain-cookie
+	// branch), the __Host- guard must win -- no Domain emitted, url present --
+	// so cmux's handler never has to fall back to a navigated surface's host
+	// (which would re-add a Domain and get the cookie dropped by WebKit).
+	c := chrome.Cookie{
+		HostKey:  ".github.com", // leading dot would normally set Domain
+		Name:     "__Host-user_session_same_site",
+		Value:    "sess",
+		Path:     "/",
+		IsSecure: 1,
+	}
+	m := cmuxCookieParam(c)
+	if _, ok := m["domain"]; ok {
+		t.Errorf("__Host- cookie must never carry a domain even with a dot host_key, got %v", m["domain"])
+	}
+	if m["url"] != "https://github.com/" {
+		t.Errorf("__Host- cookie must always carry a url so cmux never falls back to the surface host, got %v", m["url"])
 	}
 }
 

--- a/internal/sinkpush/verify.go
+++ b/internal/sinkpush/verify.go
@@ -170,6 +170,11 @@ func (a *CmuxAdapter) verifyOne(s VerifySpec) VerifyResult {
 				res.Detail = boundSessionGuidance(s.Host)
 			}
 			return res
+		} else {
+			// Successful eval, page still loading: clear any detail from an
+			// earlier transient error so a later timeout reports the timeout,
+			// not a stale "eval error" from an attempt the page recovered from.
+			res.Detail = ""
 		}
 		if attempt < verifyMaxAttempts-1 {
 			a.sleep(verifyPollInterval)
@@ -227,8 +232,13 @@ func predicateExpr(p Predicate) string {
 	arg, _ := json.Marshal(p.Arg)
 	switch p.Kind {
 	case metaPresent:
-		// non-empty content on <meta name=ARG>
-		return "(document.querySelector('meta[name=' + " + string(arg) + " + ']')||{}).content"
+		// non-empty content on <meta name="ARG">. Build the full selector with
+		// a double-quoted attribute value (e.g. meta[name="user-login"]) and
+		// JSON-encode the whole selector: an unquoted CSS attribute value is
+		// only valid for identifier-shaped names and breaks on values with
+		// hyphens-at-start, colons, dots, etc.
+		sel, _ := json.Marshal("meta[name=" + string(arg) + "]")
+		return "(document.querySelector(" + string(sel) + ")||{}).content"
 	case selectorPresent:
 		return "document.querySelector(" + string(arg) + ")"
 	case selectorAbsent:

--- a/internal/sinkpush/verify.go
+++ b/internal/sinkpush/verify.go
@@ -1,0 +1,269 @@
+package sinkpush
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/mvanhorn/agentcookie/internal/chrome"
+)
+
+// This file adds an EMPIRICAL post-injection auth check for the cmux lane.
+//
+// Delivering cookies is not the same as authenticating. For browser-bound
+// sessions (see internal/chrome/boundsession.go, e.g. GitHub) the cookies copy
+// in and are even sent on requests, yet the server still serves the logged-out
+// page. The only honest way to know whether a delivered session actually
+// authenticates is to ASK the site: open a hidden browser surface, navigate to
+// it, and evaluate a logged-in marker. That is what Verify does, reusing the
+// same cmux surface machinery the injection path uses.
+//
+// Verification is non-fatal by construction: any rpc error, parse failure, or
+// load timeout yields AuthUnknown, never an error that could abort a sync.
+
+// AuthState is the verdict for one host's post-injection session check.
+type AuthState int
+
+const (
+	// AuthUnknown means the probe could not determine the state (cmux error,
+	// timeout, or unparseable response). Never treated as a failure.
+	AuthUnknown AuthState = iota
+	// AuthYes means the delivered session authenticates: the logged-in marker
+	// was present.
+	AuthYes
+	// AuthNo means the cookies were delivered but the session does NOT
+	// authenticate -- the browser-bound-session symptom.
+	AuthNo
+)
+
+func (s AuthState) String() string {
+	switch s {
+	case AuthYes:
+		return "authenticated"
+	case AuthNo:
+		return "not authenticated"
+	default:
+		return "unknown"
+	}
+}
+
+// predicateKind enumerates the safe, deterministic checks a VerifySpec may run
+// in the page's isolated content world. Arbitrary JS is deliberately not
+// supported -- only these named shapes.
+type predicateKind int
+
+const (
+	// metaPresent: a <meta name=ARG> exists with non-empty content.
+	metaPresent predicateKind = iota
+	// selectorPresent: document.querySelector(ARG) matches an element.
+	selectorPresent
+	// selectorAbsent: document.querySelector(ARG) matches nothing.
+	selectorAbsent
+)
+
+// Predicate is a named, parameterized logged-in check.
+type Predicate struct {
+	Kind predicateKind
+	Arg  string
+}
+
+// VerifySpec describes how to verify one host's session: navigate to URL and
+// evaluate Predicate as the logged-in signal.
+type VerifySpec struct {
+	Host      string
+	URL       string
+	Predicate Predicate
+}
+
+// VerifyResult is the outcome of probing one host.
+type VerifyResult struct {
+	Host   string
+	State  AuthState
+	Detail string // populated for AuthUnknown (why) and AuthNo (guidance)
+}
+
+// BuiltinVerifySpecs returns the verification specs for the known
+// browser-bound-session hosts (see chrome.BoundSessionHosts). github.com is
+// verified by the presence of a non-empty <meta name="user-login">, which
+// GitHub renders only for an authenticated request.
+func BuiltinVerifySpecs() []VerifySpec {
+	specs := make([]VerifySpec, 0, len(chrome.BoundSessionHosts()))
+	for _, h := range chrome.BoundSessionHosts() {
+		switch h {
+		case "github.com":
+			specs = append(specs, VerifySpec{
+				Host:      "github.com",
+				URL:       "https://github.com/",
+				Predicate: Predicate{Kind: metaPresent, Arg: "user-login"},
+			})
+		}
+	}
+	return specs
+}
+
+// VerifySpecsForHosts filters BuiltinVerifySpecs to the hosts that match any of
+// the given SQLite-LIKE host patterns (e.g. "%github.com"). An empty/nil filter
+// returns all builtin specs.
+func VerifySpecsForHosts(patterns []string) []VerifySpec {
+	all := BuiltinVerifySpecs()
+	if len(patterns) == 0 {
+		return all
+	}
+	out := make([]VerifySpec, 0, len(all))
+	for _, s := range all {
+		for _, p := range patterns {
+			// Reuse the lane's SQLite-LIKE matcher (matchLike, adapter.go) so
+			// spec filtering and cookie filtering share one semantics. Lowercase
+			// both sides since hosts compare case-insensitively.
+			if matchLike(strings.ToLower(s.Host), strings.ToLower(p)) {
+				out = append(out, s)
+				break
+			}
+		}
+	}
+	return out
+}
+
+// verifyMaxAttempts and verifyPollInterval bound how long a single host probe
+// waits for the page to finish loading before giving up with AuthUnknown.
+const (
+	verifyMaxAttempts  = 6
+	verifyPollInterval = 1 * time.Second
+)
+
+// Verify probes each spec and returns one result per host. It opens a dedicated
+// hidden browser surface per host, navigates to the spec URL, polls the
+// predicate until the page is loaded (or times out), and closes the surface. It
+// never returns an error: a probe that cannot complete reports AuthUnknown.
+func (a *CmuxAdapter) Verify(specs []VerifySpec) []VerifyResult {
+	out := make([]VerifyResult, 0, len(specs))
+	for _, s := range specs {
+		out = append(out, a.verifyOne(s))
+	}
+	return out
+}
+
+func (a *CmuxAdapter) verifyOne(s VerifySpec) VerifyResult {
+	res := VerifyResult{Host: s.Host, State: AuthUnknown}
+
+	sid, err := a.openProbeSurface(s.URL)
+	if err != nil {
+		res.Detail = fmt.Sprintf("could not open probe surface: %v", err)
+		return res
+	}
+	defer a.closeProbeSurface(sid)
+
+	script := probeScript(s.Predicate)
+	for attempt := 0; attempt < verifyMaxAttempts; attempt++ {
+		raw, err := a.run("rpc", "browser.eval", probeEvalParams(sid, script))
+		if err != nil {
+			res.Detail = fmt.Sprintf("eval error: %v", err)
+		} else if ready, authed, perr := parseProbeResult(raw); perr != nil {
+			res.Detail = fmt.Sprintf("unparseable probe result: %v", perr)
+		} else if ready {
+			if authed {
+				res.State = AuthYes
+				res.Detail = ""
+			} else {
+				res.State = AuthNo
+				res.Detail = boundSessionGuidance(s.Host)
+			}
+			return res
+		}
+		if attempt < verifyMaxAttempts-1 {
+			a.sleep(verifyPollInterval)
+		}
+	}
+	if res.Detail == "" {
+		res.Detail = "page did not finish loading before timeout"
+	}
+	return res
+}
+
+// openProbeSurface creates a dedicated hidden browser surface already navigated
+// to url, and returns its surface:N ref. Distinct from the cached injection
+// surface so the probe can be closed without disturbing injection.
+func (a *CmuxAdapter) openProbeSurface(url string) (string, error) {
+	out, err := a.run("new-surface", "--type", "browser", "--url", url, "--focus", "false")
+	if err != nil {
+		return "", err
+	}
+	sid := surfaceRefRE.FindString(out)
+	if sid == "" {
+		return "", fmt.Errorf("could not parse surface ref from %q", strings.TrimSpace(out))
+	}
+	return sid, nil
+}
+
+// closeProbeSurface best-effort closes a probe surface; errors are ignored
+// (a leaked surface is harmless and cmux reclaims it on restart).
+func (a *CmuxAdapter) closeProbeSurface(sid string) {
+	params, err := json.Marshal(map[string]any{"surface_id": sid})
+	if err != nil {
+		return
+	}
+	_, _ = a.run("rpc", "surface.close", string(params))
+}
+
+// probeEvalParams builds browser.eval params for a synchronous expression.
+func probeEvalParams(sid, script string) string {
+	b, _ := json.Marshal(map[string]any{"surface_id": sid, "script": script})
+	return string(b)
+}
+
+// probeScript returns a synchronous JS expression that evaluates to a JSON
+// string {"ready":bool,"authed":bool}. ready gates on document.readyState so a
+// not-yet-loaded page is retried rather than reported as logged-out. The
+// predicate runs in the isolated content world (shares the DOM); only DOM
+// queries are used, never page-world globals.
+func probeScript(p Predicate) string {
+	return "JSON.stringify({ready: document.readyState === 'complete', authed: !!(" + predicateExpr(p) + ")})"
+}
+
+// predicateExpr renders one Predicate as a boolean JS expression. Args are
+// JSON-encoded so they are safely quoted inside the expression.
+func predicateExpr(p Predicate) string {
+	arg, _ := json.Marshal(p.Arg)
+	switch p.Kind {
+	case metaPresent:
+		// non-empty content on <meta name=ARG>
+		return "(document.querySelector('meta[name=' + " + string(arg) + " + ']')||{}).content"
+	case selectorPresent:
+		return "document.querySelector(" + string(arg) + ")"
+	case selectorAbsent:
+		return "!document.querySelector(" + string(arg) + ")"
+	default:
+		return "false"
+	}
+}
+
+// parseProbeResult unwraps cmux's browser.eval response (which carries the
+// evaluated value under "value" as a string) and decodes the inner
+// {"ready","authed"} JSON.
+func parseProbeResult(raw string) (ready, authed bool, err error) {
+	var outer struct {
+		Value string `json:"value"`
+	}
+	if uerr := json.Unmarshal([]byte(raw), &outer); uerr != nil {
+		return false, false, uerr
+	}
+	if outer.Value == "" {
+		return false, false, fmt.Errorf("empty eval value")
+	}
+	var inner struct {
+		Ready  bool `json:"ready"`
+		Authed bool `json:"authed"`
+	}
+	if uerr := json.Unmarshal([]byte(outer.Value), &inner); uerr != nil {
+		return false, false, uerr
+	}
+	return inner.Ready, inner.Authed, nil
+}
+
+// boundSessionGuidance is the actionable message for a delivered-but-not
+// -authenticated session: cookie copy cannot reconstruct a server-bound
+// session; log in natively in the cmux browser, or use gh CLI for git work.
+func boundSessionGuidance(host string) string {
+	return fmt.Sprintf("cookies delivered, but %s binds the session to the origin browser and rejects the transplant; log in to %s once inside the cmux browser, or use the gh CLI for git and PR work", host, host)
+}

--- a/internal/sinkpush/verify.go
+++ b/internal/sinkpush/verify.go
@@ -155,7 +155,7 @@ func (a *CmuxAdapter) verifyOne(s VerifySpec) VerifyResult {
 	defer a.closeProbeSurface(sid)
 
 	script := probeScript(s.Predicate)
-	for attempt := 0; attempt < verifyMaxAttempts; attempt++ {
+	for attempt := range verifyMaxAttempts {
 		raw, err := a.run("rpc", "browser.eval", probeEvalParams(sid, script))
 		if err != nil {
 			res.Detail = fmt.Sprintf("eval error: %v", err)

--- a/internal/sinkpush/verify_test.go
+++ b/internal/sinkpush/verify_test.go
@@ -1,0 +1,169 @@
+package sinkpush
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/agentcookie/internal/chrome"
+)
+
+// evalValue wraps an inner {ready,authed} JSON the way cmux's browser.eval
+// response carries it: under a "value" string field.
+func evalValue(ready, authed bool) string {
+	inner := `{"ready":` + boolStr(ready) + `,"authed":` + boolStr(authed) + `}`
+	b, _ := json.Marshal(map[string]any{"value": inner})
+	return string(b)
+}
+
+func boolStr(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}
+
+func TestVerify_Authenticated(t *testing.T) {
+	f := &fakeCmux{evalOuts: []string{evalValue(true, true)}}
+	a := newTestCmux(f, nil)
+
+	results := a.Verify([]VerifySpec{{Host: "github.com", URL: "https://github.com/", Predicate: Predicate{Kind: metaPresent, Arg: "user-login"}}})
+	if len(results) != 1 {
+		t.Fatalf("want 1 result, got %d", len(results))
+	}
+	if results[0].State != AuthYes {
+		t.Errorf("state = %v, want AuthYes", results[0].State)
+	}
+	if f.closeCalls != 1 {
+		t.Errorf("probe surface must be closed, closeCalls = %d", f.closeCalls)
+	}
+}
+
+func TestVerify_NotAuthenticatedGivesGuidance(t *testing.T) {
+	f := &fakeCmux{evalOuts: []string{evalValue(true, false)}}
+	a := newTestCmux(f, nil)
+
+	res := a.Verify([]VerifySpec{{Host: "github.com", URL: "https://github.com/", Predicate: Predicate{Kind: metaPresent, Arg: "user-login"}}})[0]
+	if res.State != AuthNo {
+		t.Errorf("state = %v, want AuthNo", res.State)
+	}
+	if res.Detail == "" {
+		t.Error("AuthNo result must carry actionable guidance")
+	}
+}
+
+func TestVerify_EvalErrorIsUnknownNotFatal(t *testing.T) {
+	f := &fakeCmux{evalErrs: []error{errors.New("boom")}}
+	a := newTestCmux(f, nil)
+
+	res := a.Verify([]VerifySpec{{Host: "github.com", URL: "https://github.com/", Predicate: Predicate{Kind: metaPresent, Arg: "user-login"}}})[0]
+	if res.State != AuthUnknown {
+		t.Errorf("state = %v, want AuthUnknown on eval error", res.State)
+	}
+	// Even on error the surface is closed (no leak).
+	if f.closeCalls != 1 {
+		t.Errorf("probe surface must be closed even on error, closeCalls = %d", f.closeCalls)
+	}
+}
+
+func TestVerify_SurfaceOpenFailureIsUnknown(t *testing.T) {
+	f := &fakeCmux{addErrs: []error{errors.New("no workspace")}}
+	a := newTestCmux(f, nil)
+
+	res := a.Verify([]VerifySpec{{Host: "github.com", URL: "https://github.com/", Predicate: Predicate{Kind: metaPresent, Arg: "user-login"}}})[0]
+	if res.State != AuthUnknown {
+		t.Errorf("state = %v, want AuthUnknown when surface cannot open", res.State)
+	}
+	// No surface opened means none to close.
+	if f.closeCalls != 0 {
+		t.Errorf("no surface should be closed when open failed, closeCalls = %d", f.closeCalls)
+	}
+}
+
+func TestVerify_RetriesUntilReady(t *testing.T) {
+	// First eval reports not-ready (page still loading), second reports
+	// ready+authed. Verifier must poll past the not-ready response.
+	f := &fakeCmux{evalOuts: []string{evalValue(false, false), evalValue(true, true)}}
+	a := newTestCmux(f, nil)
+
+	res := a.Verify([]VerifySpec{{Host: "github.com", URL: "https://github.com/", Predicate: Predicate{Kind: metaPresent, Arg: "user-login"}}})[0]
+	if res.State != AuthYes {
+		t.Errorf("state = %v, want AuthYes after retry", res.State)
+	}
+	if f.evalIdx < 2 {
+		t.Errorf("expected at least 2 eval attempts, got %d", f.evalIdx)
+	}
+}
+
+func TestVerify_TimesOutToUnknown(t *testing.T) {
+	// Page never finishes loading: every eval reports not-ready.
+	f := &fakeCmux{evalOuts: []string{evalValue(false, false)}}
+	a := newTestCmux(f, nil)
+
+	res := a.Verify([]VerifySpec{{Host: "github.com", URL: "https://github.com/", Predicate: Predicate{Kind: metaPresent, Arg: "user-login"}}})[0]
+	if res.State != AuthUnknown {
+		t.Errorf("state = %v, want AuthUnknown on load timeout", res.State)
+	}
+	if f.evalIdx != verifyMaxAttempts {
+		t.Errorf("expected %d eval attempts before timeout, got %d", verifyMaxAttempts, f.evalIdx)
+	}
+}
+
+func TestVerify_MultipleHostsIndependent(t *testing.T) {
+	f := &fakeCmux{evalOuts: []string{evalValue(true, true)}}
+	a := newTestCmux(f, nil)
+
+	specs := []VerifySpec{
+		{Host: "a.example", URL: "https://a.example/", Predicate: Predicate{Kind: selectorPresent, Arg: "#x"}},
+		{Host: "b.example", URL: "https://b.example/", Predicate: Predicate{Kind: selectorPresent, Arg: "#y"}},
+	}
+	results := a.Verify(specs)
+	if len(results) != 2 {
+		t.Fatalf("want 2 results, got %d", len(results))
+	}
+	if results[0].Host != "a.example" || results[1].Host != "b.example" {
+		t.Errorf("results out of order: %q, %q", results[0].Host, results[1].Host)
+	}
+}
+
+func TestVerifySpecsForHosts_Filter(t *testing.T) {
+	// Empty filter returns all builtin specs (github.com today).
+	if len(VerifySpecsForHosts(nil)) == 0 {
+		t.Error("nil filter should return all builtin specs")
+	}
+	// A matching pattern keeps github.
+	if got := VerifySpecsForHosts([]string{"%github.com"}); len(got) != 1 || got[0].Host != "github.com" {
+		t.Errorf("github filter: got %v", got)
+	}
+	// A non-matching pattern drops everything.
+	if got := VerifySpecsForHosts([]string{"%example.com"}); len(got) != 0 {
+		t.Errorf("non-matching filter should return none, got %v", got)
+	}
+}
+
+// TestBuiltinVerifySpecsCoverAllBoundSessionHosts guards the drift between the
+// classification list (chrome.BoundSessionHosts) and the probe table
+// (BuiltinVerifySpecs): a host added to one without the other would otherwise
+// silently never get verified. This fails loudly instead.
+func TestBuiltinVerifySpecsCoverAllBoundSessionHosts(t *testing.T) {
+	specHosts := map[string]bool{}
+	for _, s := range BuiltinVerifySpecs() {
+		specHosts[s.Host] = true
+	}
+	for _, h := range chrome.BoundSessionHosts() {
+		if !specHosts[h] {
+			t.Errorf("bound-session host %q has no BuiltinVerifySpec; add a verification spec (logged-in marker) for it or it will silently never be checked", h)
+		}
+	}
+}
+
+func TestProbeScript_UsesPredicate(t *testing.T) {
+	s := probeScript(Predicate{Kind: metaPresent, Arg: "user-login"})
+	if !strings.Contains(s, "document.readyState") {
+		t.Error("probe script must gate on readyState")
+	}
+	if !strings.Contains(s, "user-login") {
+		t.Error("probe script must embed the predicate arg")
+	}
+}


### PR DESCRIPTION
## Problem

Delivering cookies is not authentication. GitHub binds its web session to the origin browser (the `__Host-user_session_same_site` cookie plus a `vary: Sec-Fetch-Site` response). The cookies copy into cmux's WebKit store and are even sent on requests, yet GitHub still serves the logged-out page. `cmux-sync` reported a healthy `injected N cookies` push regardless, so a broken session looked like success.

Verified empirically: source Chrome logged in with valid cookies, all 16 land in the cmux store (`__Host-` correctly host-only), the webview sends them (same-origin `fetch(credentials:include)`), and GitHub still returns the logged-out homepage. No DBSC challenge headers, so this is server-side browser binding, not classic DBSC.

## Change

- `cmux-sync --verify` (default on for `--once`, never in `--watch`): after a push, open a hidden browser surface, navigate each browser-bound-session host, check a logged-in marker, and print delivery-vs-authentication truth plus the real fix (native login in cmux, or `gh` CLI for git work).
- `doctor`: a per-host `cmux session health` check (OK / WARN-with-fix / skipped; never FAIL on a flaky probe).
- `internal/chrome/boundsession.go`: bound-session host model, distinct from DBSC so messaging never mislabels it.
- Hardens the #103 known residual: `__Host-` cookies defensively drop any Domain and always carry a `url`, so cmux never falls back to a navigated surface's host.

Live output now:
\`\`\`
agentcookie cmux-sync: injected 16 cookies into cmux
agentcookie cmux-sync: session check: github.com NOT authenticated -- cookies delivered, but github.com binds the session to the origin browser and rejects the transplant; log in to github.com once inside the cmux browser, or use the gh CLI for git and PR work
\`\`\`

## Tests

774 pass, `go vet` clean, gofmt clean. New coverage: bound-session classification, the verifier (authed/not-authed/error/timeout/retry/multi-host/filter), honest reporting output, doctor session-health states, the `__Host-` host-only invariant, and a parity guard so a bound-session host added without a probe spec fails loudly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)