### PR TITLE
fix(cmux): restore Domain on host-only cookies so WebKit sends them (GitHub login regression)

### DIFF
--- a/internal/chrome/boundsession.go
+++ b/internal/chrome/boundsession.go
@@ -2,35 +2,32 @@ package chrome
 
 import "strings"
 
-// This file models browser-bound web sessions: sites whose logged-in session
-// is bound by the SERVER to the originating browser, distinct from DBSC.
+// This file lists the hosts whose post-injection login is worth VERIFYING,
+// because for them "cookies delivered" has not always meant "session
+// authenticated" and a silent failure is costly to debug.
 //
-// DBSC (see dbsc.go) is a Chrome mechanism that binds a session key to the
-// source machine's secure hardware; a copied DBSC cookie works until its
-// short-lived refresh fails. A browser-bound session is different: the server
-// gates the logged-in response on a SameSite/site-context cookie and the
-// originating browser, and rejects a transplanted session presented from a
-// DIFFERENT browser engine even on the same machine and IP. GitHub is the
-// known case (its __Host-user_session_same_site cookie and a
-// `vary: Sec-Fetch-Site` response): the cookies copy in and are even sent on
-// requests, but the session never authenticates in cmux's WebKit browser.
+// CORRECTION: an earlier version claimed GitHub's session is bound by the
+// server to the originating browser and cannot be transplanted. That was WRONG.
+// GitHub authenticates fine from transplanted cookies once they are shaped so
+// the sink browser actually SENDS them. A cmux regression had stripped the
+// Domain from host-only cookies (cmuxCookieParam), so WebKit STORED
+// user_session but never sent it -- delivered yet not authenticated. Verified
+// by injecting the same cookies into both Chromium (agent-sync) and cmux's
+// WebKit and watching GitHub log in. It is not browser-bound, not DBSC.
 //
-// Cookie copying cannot reconstruct a browser-bound session. The honest fix is
-// a native login in the target browser (which binds a fresh session to it), or
-// gh CLI for git work. This classification exists ONLY to phrase that guidance
-// accurately -- it never gates shipping, and bound-session cookies still ship
-// (the non-session cookies remain useful, and a later native login benefits
-// from the preference/analytics cookies already present).
+// The list still earns its keep: these hosts get an empirical auth probe after
+// a push (internal/sinkpush.Verify) so a future shaping/send regression is
+// caught loudly instead of silently leaving the pane logged out. It never gates
+// shipping; all cookies still ship.
 
-// boundSessionHosts are registrable-domain suffixes whose web session is
-// server-bound to the originating browser. Kept separate from dbscKnownHosts so
-// messaging never mislabels a browser-bound session as DBSC.
+// boundSessionHosts (historical name) are registrable-domain suffixes whose
+// post-push login is verified empirically. Kept separate from dbscKnownHosts.
 var boundSessionHosts = []string{
 	"github.com",
 }
 
-// BoundSessionHosts returns the known browser-bound-session hosts. Callers use
-// it to drive post-injection auth verification (see internal/sinkpush.Verify).
+// BoundSessionHosts returns the hosts whose post-push login is verified. Callers
+// use it to drive post-injection auth verification (see internal/sinkpush.Verify).
 func BoundSessionHosts() []string {
 	out := make([]string, len(boundSessionHosts))
 	copy(out, boundSessionHosts)

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -1202,8 +1202,8 @@ func checkCmuxSessionHealthWith(
 		return Check{
 			Name:        name,
 			Severity:    SeverityWarn,
-			Detail:      fmt.Sprintf("%s: cookies delivered but the session is NOT authenticated (the site binds the session to the origin browser)", strings.Join(notAuthed, ", ")),
-			Remediation: "log in to the site once inside the cmux browser to bind a working session; use the gh CLI for git and PR work",
+			Detail:      fmt.Sprintf("%s: cookies delivered but the session did NOT authenticate in the cmux browser", strings.Join(notAuthed, ", ")),
+			Remediation: "if it persists, log in to the site once inside the cmux browser, or use the gh CLI for git and PR work",
 		}
 	}
 	if authed > 0 && unknown == 0 {

--- a/internal/sinkpush/adapter_cmux.go
+++ b/internal/sinkpush/adapter_cmux.go
@@ -342,27 +342,29 @@ func cmuxCookieParam(c chrome.Cookie) map[string]any {
 	}
 	switch {
 	case strings.HasPrefix(c.Name, "__Host-"):
-		// __Host- invariants: Secure, Path "/", host-only (no Domain).
-		// WebKit hard-rejects a __Host- cookie carrying ANY Domain, so we both
-		// refrain from setting one here and defensively delete any Domain a
-		// future edit before this switch might add.
-		//
-		// The host-only scoping relies entirely on url: cmux's handler falls
-		// back to the injection surface's host when no Domain AND no url is
-		// sent, and a navigated/reused surface (host != nil) would re-introduce
-		// a Domain on the __Host- cookie -- the known residual from PR #103.
-		// Guaranteeing url is present (set above from HostKey) neutralizes that
-		// fallback regardless of the surface's current host. A __Host- cookie
-		// with no derivable host (empty url) is unusable and is dropped earlier
-		// by the caller's Validate gate.
+		// __Host- MUST be host-only with NO Domain: WebKit hard-rejects a
+		// __Host- cookie carrying ANY Domain, which silently dropped GitHub's
+		// __Host-user_session_same_site. Scope it host-only via url (set above
+		// from HostKey), force Secure + Path "/", and defensively delete any
+		// Domain a future edit before this switch might add.
 		secure = true
 		m["path"] = "/"
 		delete(m, "domain")
-	case strings.HasPrefix(c.HostKey, "."):
-		// Domain cookie: valid for subdomains. WebKit accepts the leading dot.
-		m["domain"] = c.HostKey
 	default:
-		// Host-only cookie: scoped to the exact host via url, no Domain.
+		// Every other cookie -- domain cookies (leading-dot host_key) AND
+		// host-only cookies (bare host) -- carries Domain = host_key so cmux's
+		// WebKit actually SENDS it on requests.
+		//
+		// REGRESSION FIX (was PR #103): scoping host-only cookies by url alone
+		// with NO Domain stores them in WebKit's cookie jar (cookies.get sees
+		// them) but they are NOT sent on a real navigation, so GitHub's
+		// user_session / _gh_sess were delivered yet never authenticated --
+		// the cmux pane stayed logged out. Restoring Domain = host_key makes
+		// WebKit send them (verified: GitHub logs in). A bare host_key is sent
+		// to that host; a leading-dot host_key is a subdomain-valid domain
+		// cookie (WebKit accepts the dot). url stays set above (harmless
+		// alongside Domain, and the scoping anchor for the __Host- case).
+		m["domain"] = c.HostKey
 	}
 	m["secure"] = secure
 	if ss := cmuxSameSite(c.SameSite); ss != "" {

--- a/internal/sinkpush/adapter_cmux_test.go
+++ b/internal/sinkpush/adapter_cmux_test.go
@@ -231,16 +231,24 @@ func TestCmuxCookieParam_HostPrefixForcedHostOnlyDespiteDotHostKey(t *testing.T)
 	}
 }
 
-func TestCmuxCookieParam_HostOnlyNoDomainWidening(t *testing.T) {
-	// A host-only cookie (host_key with no leading dot) must not be widened
-	// to subdomains: no Domain attribute, scoped to the exact host via url.
+func TestCmuxCookieParam_HostOnlyCarriesDomainSoWebKitSendsIt(t *testing.T) {
+	// REGRESSION GUARD (PR #103 -> fix): a host-only cookie (host_key with no
+	// leading dot, e.g. GitHub's user_session) MUST carry Domain = host_key.
+	// Scoping it by url alone stores it but WebKit does not send it on a real
+	// navigation, so GitHub's session was delivered yet never authenticated.
+	// Domain = host_key makes WebKit send it (verified: GitHub logs in).
 	c := chrome.Cookie{HostKey: "github.com", Name: "user_session", Value: "v", Path: "/", IsSecure: 1}
 	m := cmuxCookieParam(c)
-	if _, ok := m["domain"]; ok {
-		t.Errorf("host-only cookie must NOT carry a domain, got %v", m["domain"])
+	if m["domain"] != "github.com" {
+		t.Errorf("host-only cookie must carry Domain=host_key so WebKit sends it, got %v", m["domain"])
 	}
 	if m["url"] != "https://github.com/" {
-		t.Errorf("host-only cookie must be scoped by url, got %v", m["url"])
+		t.Errorf("host-only cookie should still carry url, got %v", m["url"])
+	}
+	// __Host- is the ONLY case that must stay Domain-less.
+	h := chrome.Cookie{HostKey: "github.com", Name: "__Host-user_session_same_site", Value: "v", Path: "/", IsSecure: 1}
+	if _, ok := cmuxCookieParam(h)["domain"]; ok {
+		t.Error("__Host- cookie must NOT carry a domain (WebKit rejects it)")
 	}
 }
 

--- a/internal/sinkpush/verify.go
+++ b/internal/sinkpush/verify.go
@@ -147,14 +147,28 @@ func (a *CmuxAdapter) Verify(specs []VerifySpec) []VerifyResult {
 func (a *CmuxAdapter) verifyOne(s VerifySpec) VerifyResult {
 	res := VerifyResult{Host: s.Host, State: AuthUnknown}
 
-	sid, err := a.openProbeSurface(s.URL)
+	// Open the probe surface on about:blank FIRST, then navigate to the target
+	// in a separate step. Creating the surface with --url loads the page as
+	// part of surface creation, which races cookie propagation into the new
+	// webview's network context -- the page can finish loading logged-out
+	// before the shared cookie store is attached, a false negative. about:blank
+	// then an explicit navigate gives the webview its cookie store before the
+	// request goes out (verified: navigate-after-create authenticates where
+	// navigate-at-create does not).
+	sid, err := a.openProbeSurface()
 	if err != nil {
 		res.Detail = fmt.Sprintf("could not open probe surface: %v", err)
 		return res
 	}
 	defer a.closeProbeSurface(sid)
 
-	script := probeScript(s.Predicate)
+	navParams, _ := json.Marshal(map[string]any{"surface_id": sid, "url": s.URL})
+	if _, err := a.run("rpc", "browser.navigate", string(navParams)); err != nil {
+		res.Detail = fmt.Sprintf("navigate error: %v", err)
+		return res
+	}
+
+	script := probeScript(s.Predicate, s.Host)
 	for attempt := range verifyMaxAttempts {
 		raw, err := a.run("rpc", "browser.eval", probeEvalParams(sid, script))
 		if err != nil {
@@ -186,11 +200,12 @@ func (a *CmuxAdapter) verifyOne(s VerifySpec) VerifyResult {
 	return res
 }
 
-// openProbeSurface creates a dedicated hidden browser surface already navigated
-// to url, and returns its surface:N ref. Distinct from the cached injection
-// surface so the probe can be closed without disturbing injection.
-func (a *CmuxAdapter) openProbeSurface(url string) (string, error) {
-	out, err := a.run("new-surface", "--type", "browser", "--url", url, "--focus", "false")
+// openProbeSurface creates a dedicated hidden about:blank browser surface and
+// returns its surface:N ref. The caller navigates it separately (see verifyOne
+// on why navigate-at-create races cookie propagation). Distinct from the cached
+// injection surface so the probe can be closed without disturbing injection.
+func (a *CmuxAdapter) openProbeSurface() (string, error) {
+	out, err := a.run("new-surface", "--type", "browser", "--url", "about:blank", "--focus", "false")
 	if err != nil {
 		return "", err
 	}
@@ -218,12 +233,18 @@ func probeEvalParams(sid, script string) string {
 }
 
 // probeScript returns a synchronous JS expression that evaluates to a JSON
-// string {"ready":bool,"authed":bool}. ready gates on document.readyState so a
-// not-yet-loaded page is retried rather than reported as logged-out. The
-// predicate runs in the isolated content world (shares the DOM); only DOM
-// queries are used, never page-world globals.
-func probeScript(p Predicate) string {
-	return "JSON.stringify({ready: document.readyState === 'complete', authed: !!(" + predicateExpr(p) + ")})"
+// string {"ready":bool,"authed":bool}. ready gates on BOTH document.readyState
+// AND being on the target host: browser.navigate is async, so a poll right
+// after it can still see about:blank (readyState 'complete', no marker) and
+// would falsely report logged-out. Requiring location.hostname to match host
+// makes the poll wait for the real page. The predicate runs in the isolated
+// content world (shares the DOM); only DOM queries are used, never page-world
+// globals.
+func probeScript(p Predicate, host string) string {
+	h, _ := json.Marshal(host)
+	onHost := "(location.hostname === " + string(h) + " || location.hostname.endsWith('.' + " + string(h) + "))"
+	ready := "(document.readyState === 'complete' && " + onHost + ")"
+	return "JSON.stringify({ready: " + ready + ", authed: !!(" + predicateExpr(p) + ")})"
 }
 
 // predicateExpr renders one Predicate as a boolean JS expression. Args are
@@ -272,8 +293,11 @@ func parseProbeResult(raw string) (ready, authed bool, err error) {
 }
 
 // boundSessionGuidance is the actionable message for a delivered-but-not
-// -authenticated session: cookie copy cannot reconstruct a server-bound
-// session; log in natively in the cmux browser, or use gh CLI for git work.
+// -authenticated session. It states the FACT (delivered, not authenticated)
+// without asserting a cause -- the cause varies (stale/rotated cookies, a
+// genuinely device-bound site like Google/DBSC, or a shaping bug) and an
+// earlier version wrongly blamed "browser binding" for what was actually a
+// cmux cookie-shaping regression. The remediation is generic and safe.
 func boundSessionGuidance(host string) string {
-	return fmt.Sprintf("cookies delivered, but %s binds the session to the origin browser and rejects the transplant; log in to %s once inside the cmux browser, or use the gh CLI for git and PR work", host, host)
+	return fmt.Sprintf("cookies for %s were delivered but the session did not authenticate; if it persists, log in to %s once inside the cmux browser, or use the gh CLI for git and PR work", host, host)
 }

--- a/internal/sinkpush/verify_test.go
+++ b/internal/sinkpush/verify_test.go
@@ -159,9 +159,12 @@ func TestBuiltinVerifySpecsCoverAllBoundSessionHosts(t *testing.T) {
 }
 
 func TestProbeScript_UsesPredicate(t *testing.T) {
-	s := probeScript(Predicate{Kind: metaPresent, Arg: "user-login"})
+	s := probeScript(Predicate{Kind: metaPresent, Arg: "user-login"}, "github.com")
 	if !strings.Contains(s, "document.readyState") {
 		t.Error("probe script must gate on readyState")
+	}
+	if !strings.Contains(s, "location.hostname") {
+		t.Error("probe script must gate on being on the target host (navigate is async)")
 	}
 	if !strings.Contains(s, "user-login") {
 		t.Error("probe script must embed the predicate arg")


### PR DESCRIPTION
## Regression

PR #103 scoped host-only cookies by \`url\` alone with **no Domain**. WebKit *stores* such a cookie (\`cookies.get\` sees it) but does **not send** it on a real navigation. So GitHub's \`user_session\` / \`_gh_sess\` were delivered yet never authenticated — the cmux pane silently stayed logged out. #103 fixed the \`__Host-\` rejection but regressed every other host-only auth cookie.

## Fix

Restore \`Domain = host_key\` for all non-\`__Host-\` cookies (the pre-#103 behavior that worked); keep the url-only/no-Domain shaping **only** for \`__Host-\` (which WebKit rejects when it carries a Domain).

Verified end to end — GitHub logs in as the user in cmux's WebKit browser after a normal sync:
\`\`\`
session check: github.com authenticated
[OK] cmux session health: 1 browser-bound-session host(s) authenticated
\`\`\`

## Corrects the v0.17.0 framing

v0.17.0 concluded GitHub "binds the session to the origin browser" and cookie copy couldn't fix it. **That was wrong.** The same cookies authenticate in both Chromium (\`agent-sync\`) and cmux once shaped to be *sent*. Updated the bound-session doc, the \`doctor\` WARN, and the verify guidance to state the fact (delivered ≠ authenticated) without the false cause.

## Also: --verify false negative

The probe navigated at surface-creation (racing cookie propagation) and gated "ready" on \`readyState\` alone, so a poll landing on \`about:blank\` reported logged-out. Now it opens \`about:blank\`, navigates explicitly, and gates ready on being on the target host.

## Tests

774 pass, \`go vet\` clean, gofmt clean. Updated the host-only test to assert Domain is present (the regression guard) and \`__Host-\` stays Domain-less; probe test asserts host-gated readiness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)