### PR TITLE
fix(keychain): close CGO dialog leak, lock misclassification, and enable side-effect (follow-up to #107)

### DIFF
--- a/internal/chrome/keychain.go
+++ b/internal/chrome/keychain.go
@@ -3,6 +3,7 @@
 package chrome
 
 import (
+	"bytes"
 	"context"
 	"crypto/pbkdf2"
 	"crypto/sha1"
@@ -62,12 +63,62 @@ func SafeStoragePassword() (string, error) {
 // so tests can stub it without a real Keychain.
 var safeStorageViaKeybaseRunner = safeStoragePasswordViaKeybaseFor
 
+// Keychain read failure sentinels. SafeStoragePasswordFor wraps its error with
+// one of these via %w, and IsKeychainLocked / IsKeychainAccessError classify by
+// errors.Is rather than substring-matching the human-readable wrapper prose.
+// Classifying at the source is what keeps a transient locked-keychain error
+// from being misread as a permanent missing grant after it is wrapped (the bug
+// that survived PR #107's string-based check).
+var (
+	// ErrKeychainNoGrant: the binary is not in the Safe Storage partition / ACL
+	// and will not be without operator action (wizard set-keychain-access). A
+	// --watch agent exits 0 on this (no launchd restart).
+	ErrKeychainNoGrant = errors.New("keychain: binary not in Safe Storage partition (missing grant)")
+	// ErrKeychainLocked: the login keychain is locked -- transient (sleep-wake,
+	// screen-lock, SSH session). A --watch agent exits non-zero so launchd's
+	// KeepAlive retries once the keychain unlocks.
+	ErrKeychainLocked = errors.New("keychain: login keychain is locked")
+	// ErrKeychainTimeout: the security CLI read exceeded safeStorageReadTimeout.
+	// Treated as a missing grant (exit 0) -- an unattended agent cannot resolve
+	// a hung read, and U3's enable pre-flight prevents installing an agent
+	// without a grant in the first place.
+	ErrKeychainTimeout = errors.New("keychain: read timed out")
+)
+
+// securityCLIRead runs the `security` CLI Safe Storage read and returns stdout,
+// stderr, and the exec error separately. A package var so tests can classify
+// without a real Keychain. stderr is captured explicitly (rather than relying on
+// exec.ExitError.Stderr) so the locked-vs-missing-grant decision has a clean,
+// stubbable signal.
+var securityCLIRead = func(ctx context.Context, account, service string) (stdout, stderr []byte, err error) {
+	cmd := exec.CommandContext(ctx, "security",
+		"find-generic-password",
+		"-a", account,
+		"-s", service,
+		"-w",
+	)
+	var errBuf bytes.Buffer
+	cmd.Stderr = &errBuf
+	out, e := cmd.Output()
+	return out, errBuf.Bytes(), e
+}
+
+// keychainLockedSignal reports whether security-CLI stderr indicates a locked
+// keychain (-25308 "User interaction is not allowed") rather than a missing
+// grant. Shared by classification and the IsKeychainLocked legacy fallback.
+func keychainLockedSignal(s string) bool {
+	s = strings.ToLower(s)
+	return strings.Contains(s, "25308") || strings.Contains(s, "interaction is not allowed")
+}
+
 // SafeStoragePasswordFor returns b's Safe Storage password from the macOS
 // Keychain using b's account/service pair.
 func SafeStoragePasswordFor(b Browser) (string, error) {
-	// ad-hoc build: SecItemCopyMatching always prompts for unsigned binaries,
-	// leaving a goroutine-leaked dialog open before the security CLI fallback
-	// opens a second one. Skip to the CLI path when there is no team ID.
+	// Signed binary: try the no-prompt SecItem fast path first. It never opens a
+	// dialog (interaction is disabled), so a miss just falls through cheaply.
+	// Unsigned (go install) binaries skip it -- they are never in the per-app
+	// trust list, so the CLI lane (apple-tool: partition) is the only one that
+	// can succeed without a prompt.
 	exe, _ := os.Executable()
 	teamID, _ := BinaryTeamID(exe)
 	if teamID != "" {
@@ -80,18 +131,18 @@ func SafeStoragePasswordFor(b Browser) (string, error) {
 	// hung GUI Keychain prompt fails loud instead of blocking forever.
 	ctx, cancel := context.WithTimeout(context.Background(), safeStorageReadTimeout)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "security",
-		"find-generic-password",
-		"-a", b.KeychainAccount,
-		"-s", b.KeychainService,
-		"-w",
-	)
-	out, err := cmd.Output()
+	out, errOut, err := securityCLIRead(ctx, b.KeychainAccount, b.KeychainService)
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-		return "", fmt.Errorf("read %s from Keychain timed out after %s; this binary is not yet in the Safe Storage partition. %s", b.KeychainService, safeStorageReadTimeout, remediation)
+		return "", fmt.Errorf("read %s from Keychain timed out after %s; this binary is not yet in the Safe Storage partition. %s: %w", b.KeychainService, safeStorageReadTimeout, remediation, ErrKeychainTimeout)
 	}
 	if err != nil {
-		return "", fmt.Errorf("read %s from Keychain (did you grant access?): %w; %s", b.KeychainService, err, remediation)
+		// Classify at the source so the sentinel -- not the wrapper prose --
+		// drives the --watch exit decision. A locked keychain is transient
+		// (retry); a missing grant is permanent (exit 0).
+		if keychainLockedSignal(string(errOut)) {
+			return "", fmt.Errorf("read %s from Keychain: login keychain is locked (%s); %s: %w", b.KeychainService, strings.TrimSpace(string(errOut)), remediation, ErrKeychainLocked)
+		}
+		return "", fmt.Errorf("read %s from Keychain (did you grant access?): %v; %s: %w", b.KeychainService, err, remediation, ErrKeychainNoGrant)
 	}
 	return strings.TrimRight(string(out), "\n"), nil
 }
@@ -334,8 +385,13 @@ func IsKeychainLocked(err error) bool {
 	if err == nil {
 		return false
 	}
-	s := strings.ToLower(err.Error())
-	return strings.Contains(s, "25308") || strings.Contains(s, "interaction is not allowed")
+	// Sentinel is authoritative for errors from SafeStoragePasswordFor; the
+	// legacy string match keeps foreign callers (doctor probe, SSH-context
+	// reads that surface a raw -25308) working without a sentinel wrap.
+	if errors.Is(err, ErrKeychainLocked) {
+		return true
+	}
+	return keychainLockedSignal(err.Error())
 }
 
 // IsKeychainAccessError reports whether err came from SafeStoragePasswordFor
@@ -350,10 +406,9 @@ func IsKeychainLocked(err error) bool {
 // KeepAlive retry rather than stop the sync permanently. Use IsKeychainLocked
 // for that case.
 func IsKeychainAccessError(err error) bool {
-	if err == nil {
-		return false
-	}
-	s := err.Error()
-	return strings.Contains(s, "did you grant access?") ||
-		strings.Contains(s, "not yet in the Safe Storage partition")
+	// Pure errors.Is: a locked-keychain error wrapped in "did you grant access?"
+	// prose must NOT match here (that was the PR #107 bug). Only the missing-grant
+	// and timeout sentinels count as access errors. A locked error carries
+	// ErrKeychainLocked instead and is excluded.
+	return errors.Is(err, ErrKeychainNoGrant) || errors.Is(err, ErrKeychainTimeout)
 }

--- a/internal/chrome/keychain.go
+++ b/internal/chrome/keychain.go
@@ -63,6 +63,11 @@ func SafeStoragePassword() (string, error) {
 // so tests can stub it without a real Keychain.
 var safeStorageViaKeybaseRunner = safeStoragePasswordViaKeybaseFor
 
+// keychainLockedCheck reports whether the login keychain is locked; a package
+// var so tests can stub it. On non-darwin/cgo builds it returns an error, which
+// SafeStoragePasswordFor treats as "lock state unknown" (does not short-circuit).
+var keychainLockedCheck = keychainDefaultLocked
+
 // Keychain read failure sentinels. SafeStoragePasswordFor wraps its error with
 // one of these via %w, and IsKeychainLocked / IsKeychainAccessError classify by
 // errors.Is rather than substring-matching the human-readable wrapper prose.
@@ -108,7 +113,7 @@ var securityCLIRead = func(ctx context.Context, account, service string) (stdout
 // grant. Shared by classification and the IsKeychainLocked legacy fallback.
 func keychainLockedSignal(s string) bool {
 	s = strings.ToLower(s)
-	return strings.Contains(s, "25308") || strings.Contains(s, "interaction is not allowed")
+	return strings.Contains(s, "-25308") || strings.Contains(s, "interaction is not allowed")
 }
 
 // SafeStoragePasswordFor returns b's Safe Storage password from the macOS
@@ -127,6 +132,15 @@ func SafeStoragePasswordFor(b Browser) (string, error) {
 		}
 	}
 	remediation := safeStorageRemediationFor(b)
+	// If the login keychain is locked, the `security` CLI would hang on an unlock
+	// prompt until the timeout (then misclassify as a missing grant). Detect it
+	// up front and report a transient locked error so a --watch agent exits
+	// non-zero and launchd's KeepAlive retries once it unlocks -- and because we
+	// short-circuit before the CLI, retries fail fast instead of stacking unlock
+	// prompts. Lock state unknown (non-darwin/cgo, or status error) falls through.
+	if locked, lerr := keychainLockedCheck(); lerr == nil && locked {
+		return "", fmt.Errorf("read %s from Keychain: login keychain is locked; %s: %w", b.KeychainService, remediation, ErrKeychainLocked)
+	}
 	// Fall back to `security` CLI shell-out, bounded by a timeout so a
 	// hung GUI Keychain prompt fails loud instead of blocking forever.
 	ctx, cancel := context.WithTimeout(context.Background(), safeStorageReadTimeout)

--- a/internal/chrome/keychain_items_test.go
+++ b/internal/chrome/keychain_items_test.go
@@ -2,6 +2,7 @@ package chrome
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 )
 
@@ -77,6 +78,9 @@ func TestIsKeychainLocked(t *testing.T) {
 		{"explicit -25308 code", errors.New("keybase keychain GetGenericPassword: ... (-25308)"), true},
 		{"interaction-not-allowed text", errors.New("User interaction is not allowed."), true},
 		{"unrelated error is not locked", errors.New("not readable by this process"), false},
+		// Sentinel is authoritative even when wrapped without the -25308 string.
+		{"locked sentinel", fmt.Errorf("read Keychain: %w", ErrKeychainLocked), true},
+		{"missing-grant sentinel is not locked", fmt.Errorf("read Keychain: %w", ErrKeychainNoGrant), false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/chrome/keychain_keybase.go
+++ b/internal/chrome/keychain_keybase.go
@@ -19,6 +19,7 @@ import "C"
 import (
 	"errors"
 	"fmt"
+	"sync"
 	"unsafe"
 )
 
@@ -30,6 +31,12 @@ import (
 // presenting a SecurityAgent dialog. Callers fall through to the `security` CLI
 // lane, where locked-vs-missing-grant is classified (see SafeStoragePasswordFor).
 var ErrKeychainInteractionRequired = errors.New("keychain read requires interaction (binary not in Safe Storage partition or keychain locked); fall back to the security CLI")
+
+// interactionMu serializes the process-global
+// SecKeychainSetUserInteractionAllowed flip so a concurrent in-process keychain
+// caller never observes interaction in a half-flipped state. This package is the
+// sole owner of that flag.
+var interactionMu sync.Mutex
 
 // safeStoragePasswordViaKeybaseFor reads Chrome Safe Storage via the modern
 // SecItem API path. Used as the no-prompt fast path on darwin+CGO builds;
@@ -49,11 +56,16 @@ var ErrKeychainInteractionRequired = errors.New("keychain read requires interact
 // LocalAuthentication path; the interaction toggle is what suppresses the
 // legacy ACL dialog this code actually hits.
 func safeStoragePasswordViaKeybaseFor(service, account string) (string, error) {
-	// Process-global toggle; restore on return. This read path is the only
-	// place that disables interaction, and it is not run concurrently with an
-	// interactive keychain read, so the global flip is safe here.
+	// Process-global toggle; serialized and restored on return so a concurrent
+	// in-process keychain caller never sees it half-flipped. This package is the
+	// sole owner of the flag, so restoring to enabled (the macOS default) is
+	// correct.
+	interactionMu.Lock()
 	C.SecKeychainSetUserInteractionAllowed(C.Boolean(0))
-	defer C.SecKeychainSetUserInteractionAllowed(C.Boolean(1))
+	defer func() {
+		C.SecKeychainSetUserInteractionAllowed(C.Boolean(1))
+		interactionMu.Unlock()
+	}()
 
 	svc := cfString(service)
 	defer C.CFRelease(C.CFTypeRef(svc))
@@ -113,4 +125,24 @@ func cfString(s string) C.CFStringRef {
 		p = (*C.UInt8)(unsafe.Pointer(&b[0]))
 	}
 	return C.CFStringCreateWithBytes(C.kCFAllocatorDefault, p, C.CFIndex(len(b)), C.kCFStringEncodingUTF8, C.Boolean(0))
+}
+
+// keychainDefaultLocked reports whether the default (login) keychain is locked.
+// Chrome Safe Storage lives in the login keychain, so this distinguishes a
+// transient locked keychain (retry) from a permanent missing grant. Querying
+// status does not require unlocking and never prompts. It is consulted before
+// the `security` CLI read so a locked keychain short-circuits to a transient
+// error instead of hanging the CLI on an unlock prompt until the timeout.
+func keychainDefaultLocked() (bool, error) {
+	var kc C.SecKeychainRef
+	if st := C.SecKeychainCopyDefault(&kc); st != C.errSecSuccess {
+		return false, fmt.Errorf("SecKeychainCopyDefault: OSStatus %d", int(st))
+	}
+	defer C.CFRelease(C.CFTypeRef(kc))
+	var status C.SecKeychainStatus
+	if st := C.SecKeychainGetStatus(kc, &status); st != C.errSecSuccess {
+		return false, fmt.Errorf("SecKeychainGetStatus: OSStatus %d", int(st))
+	}
+	// kSecUnlockStateStatus set => unlocked; absent => locked.
+	return status&C.kSecUnlockStateStatus == 0, nil
 }

--- a/internal/chrome/keychain_keybase.go
+++ b/internal/chrome/keychain_keybase.go
@@ -67,9 +67,17 @@ func safeStoragePasswordViaKeybaseFor(service, account string) (string, error) {
 		interactionMu.Unlock()
 	}()
 
+	// CFStringCreateWithBytes / CFDictionaryCreate return NULL on allocation
+	// failure; CFRelease(NULL) is undefined behavior, so guard before deferring.
 	svc := cfString(service)
+	if svc == 0 {
+		return "", errors.New("CFStringCreateWithBytes returned NULL for service")
+	}
 	defer C.CFRelease(C.CFTypeRef(svc))
 	acc := cfString(account)
+	if acc == 0 {
+		return "", errors.New("CFStringCreateWithBytes returned NULL for account")
+	}
 	defer C.CFRelease(C.CFTypeRef(acc))
 
 	keys := []C.CFTypeRef{
@@ -96,6 +104,9 @@ func safeStoragePasswordViaKeybaseFor(service, account string) (string, error) {
 		&C.kCFTypeDictionaryKeyCallBacks,
 		&C.kCFTypeDictionaryValueCallBacks,
 	)
+	if query == 0 {
+		return "", errors.New("CFDictionaryCreate returned NULL")
+	}
 	defer C.CFRelease(C.CFTypeRef(query))
 
 	var result C.CFTypeRef

--- a/internal/chrome/keychain_keybase.go
+++ b/internal/chrome/keychain_keybase.go
@@ -2,65 +2,115 @@
 
 package chrome
 
-import (
-	"context"
-	"errors"
-	"time"
+/*
+#cgo LDFLAGS: -framework CoreFoundation -framework Security
+#include <CoreFoundation/CoreFoundation.h>
+#include <Security/Security.h>
 
-	keychain "github.com/keybase/go-keychain"
+// SecKeychainSetUserInteractionAllowed is deprecated but is the only API that
+// suppresses the legacy keychain ACL-confirmation dialog (the "agentcookie
+// wants to use the Chrome Safe Storage key" prompt). kSecUseAuthenticationUI
+// only governs LocalAuthentication UI, not this ACL gate. Silence the
+// deprecation warning so the build stays clean.
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+*/
+import "C"
+
+import (
+	"errors"
+	"fmt"
+	"unsafe"
 )
 
-// keybaseReadTimeout caps how long safeStoragePasswordViaKeybase will
-// wait for the modern Apple Security API (SecItemCopyMatching) before
-// giving up and letting the caller fall through to the security CLI
-// path. Three seconds is well past the call's normal success time
-// (sub-millisecond when the keychain is unlocked and the binary is in
-// the trust list) but well under the user's tolerance for "is it
-// hung?" -- if the keybase path is going to prompt, we want to abandon
-// it and let the legacy CLI succeed instead of blocking forever on a
-// SecurityAgent prompt nobody is going to answer.
-const keybaseReadTimeout = 3 * time.Second
+// ErrKeychainInteractionRequired means SecItemCopyMatching would have needed a
+// GUI prompt to satisfy the read -- the calling binary is not in the item's
+// ACL / Safe Storage partition, or the keychain is locked. Because user
+// interaction is disabled for the call (SecKeychainSetUserInteractionAllowed),
+// the API returns errSecInteractionNotAllowed (-25308) immediately instead of
+// presenting a SecurityAgent dialog. Callers fall through to the `security` CLI
+// lane, where locked-vs-missing-grant is classified (see SafeStoragePasswordFor).
+var ErrKeychainInteractionRequired = errors.New("keychain read requires interaction (binary not in Safe Storage partition or keychain locked); fall back to the security CLI")
 
-// ErrKeybaseTimedOut means the keybase/go-keychain call did not return
-// within keybaseReadTimeout. Almost always indicates a hung
-// SecurityAgent prompt: the modern SecItemCopyMatching API requires the
-// calling binary to be in the keychain item's per-app trust list AND
-// signed by a recognized identity. Ad-hoc-signed Go binaries
-// (`go install` output) fail both conditions, so SecItem blocks
-// waiting for a UI prompt that no one is going to dismiss.
-var ErrKeybaseTimedOut = errors.New("keybase keychain GetGenericPassword timed out (likely a SecurityAgent prompt waiting that no one can dismiss; fall back to the security CLI)")
-
-// safeStoragePasswordViaKeybase reads Chrome Safe Storage via the
-// modern SecItem API path. Used as the fast path on darwin+CGO builds;
-// callers fall back to the security CLI if this returns an error.
+// safeStoragePasswordViaKeybaseFor reads Chrome Safe Storage via the modern
+// SecItem API path. Used as the no-prompt fast path on darwin+CGO builds;
+// callers fall back to the `security` CLI on any error.
 //
-// The CGO call is run in a goroutine and capped by keybaseReadTimeout
-// so a hung SecurityAgent prompt does not stall the entire process.
-// In practice this happens often on Mac mini sinks where agentcookie
-// is the only ad-hoc-signed binary the user re-deploys frequently --
-// each rebuild invalidates the cdhash that the per-app trust list
-// pinned, so subsequent SecItem calls hit a prompt that no one will
-// answer.
+// User interaction is disabled around the call via
+// SecKeychainSetUserInteractionAllowed(false), so SecItemCopyMatching never
+// opens the keychain ACL-confirmation dialog: when the binary is in the item's
+// trust list / Safe Storage partition the read succeeds without a prompt, and
+// otherwise it returns errSecInteractionNotAllowed (-25308) right away. That is
+// what lets the call be synchronous -- there is no GUI prompt to hang on, so
+// there is no goroutine to abandon and no orphaned dialog to leak (the bug
+// behind the #106 prompt storm on signed binaries that lost their grant). The
+// historical goroutine + timeout dance is gone by construction.
+//
+// kSecUseAuthenticationUIFail is set as well to cover the (unused here)
+// LocalAuthentication path; the interaction toggle is what suppresses the
+// legacy ACL dialog this code actually hits.
 func safeStoragePasswordViaKeybaseFor(service, account string) (string, error) {
-	type result struct {
-		pw  []byte
-		err error
-	}
-	ch := make(chan result, 1)
-	go func() {
-		password, err := keychain.GetGenericPassword(service, account, "", "")
-		ch <- result{pw: password, err: err}
-	}()
+	// Process-global toggle; restore on return. This read path is the only
+	// place that disables interaction, and it is not run concurrently with an
+	// interactive keychain read, so the global flip is safe here.
+	C.SecKeychainSetUserInteractionAllowed(C.Boolean(0))
+	defer C.SecKeychainSetUserInteractionAllowed(C.Boolean(1))
 
-	ctx, cancel := context.WithTimeout(context.Background(), keybaseReadTimeout)
-	defer cancel()
-	select {
-	case r := <-ch:
-		if r.err != nil {
-			return "", r.err
-		}
-		return string(r.pw), nil
-	case <-ctx.Done():
-		return "", ErrKeybaseTimedOut
+	svc := cfString(service)
+	defer C.CFRelease(C.CFTypeRef(svc))
+	acc := cfString(account)
+	defer C.CFRelease(C.CFTypeRef(acc))
+
+	keys := []C.CFTypeRef{
+		C.CFTypeRef(C.kSecClass),
+		C.CFTypeRef(C.kSecAttrService),
+		C.CFTypeRef(C.kSecAttrAccount),
+		C.CFTypeRef(C.kSecMatchLimit),
+		C.CFTypeRef(C.kSecReturnData),
+		C.CFTypeRef(C.kSecUseAuthenticationUI),
 	}
+	vals := []C.CFTypeRef{
+		C.CFTypeRef(C.kSecClassGenericPassword),
+		C.CFTypeRef(svc),
+		C.CFTypeRef(acc),
+		C.CFTypeRef(C.kSecMatchLimitOne),
+		C.CFTypeRef(C.kCFBooleanTrue),
+		C.CFTypeRef(C.kSecUseAuthenticationUIFail),
+	}
+	query := C.CFDictionaryCreate(
+		C.kCFAllocatorDefault,
+		(*unsafe.Pointer)(unsafe.Pointer(&keys[0])),
+		(*unsafe.Pointer)(unsafe.Pointer(&vals[0])),
+		C.CFIndex(len(keys)),
+		&C.kCFTypeDictionaryKeyCallBacks,
+		&C.kCFTypeDictionaryValueCallBacks,
+	)
+	defer C.CFRelease(C.CFTypeRef(query))
+
+	var result C.CFTypeRef
+	status := C.SecItemCopyMatching(C.CFDictionaryRef(query), &result)
+	if status == C.errSecInteractionNotAllowed {
+		return "", ErrKeychainInteractionRequired
+	}
+	if status != C.errSecSuccess {
+		return "", fmt.Errorf("SecItemCopyMatching: OSStatus %d", int(status))
+	}
+	defer C.CFRelease(result)
+
+	data := C.CFDataRef(result)
+	length := C.CFDataGetLength(data)
+	if length == 0 {
+		return "", nil
+	}
+	return string(C.GoBytes(unsafe.Pointer(C.CFDataGetBytePtr(data)), C.int(length))), nil
+}
+
+// cfString builds an immutable CFStringRef from a Go string (UTF-8). The caller
+// owns the result and must CFRelease it.
+func cfString(s string) C.CFStringRef {
+	b := []byte(s)
+	var p *C.UInt8
+	if len(b) > 0 {
+		p = (*C.UInt8)(unsafe.Pointer(&b[0]))
+	}
+	return C.CFStringCreateWithBytes(C.kCFAllocatorDefault, p, C.CFIndex(len(b)), C.kCFStringEncodingUTF8, C.Boolean(0))
 }

--- a/internal/chrome/keychain_keybase_stub.go
+++ b/internal/chrome/keychain_keybase_stub.go
@@ -7,3 +7,9 @@ import "errors"
 func safeStoragePasswordViaKeybaseFor(_, _ string) (string, error) {
 	return "", errors.New("safeStoragePasswordViaKeybase: requires darwin+cgo build")
 }
+
+// keychainDefaultLocked is unsupported off darwin+cgo; report "not locked" with
+// an error so callers treat lock status as unknown and do not short-circuit.
+func keychainDefaultLocked() (bool, error) {
+	return false, errors.New("keychainDefaultLocked: requires darwin+cgo build")
+}

--- a/internal/chrome/keychain_keybase_test.go
+++ b/internal/chrome/keychain_keybase_test.go
@@ -1,0 +1,44 @@
+//go:build darwin && cgo
+
+package chrome
+
+import (
+	"testing"
+	"time"
+)
+
+// TestSafeStoragePasswordViaKeybase_ReturnsPromptly is the regression guard for
+// the #106 leak: with kSecUseAuthenticationUIFail the SecItem call can never
+// block on a SecurityAgent prompt, so it must return quickly whether or not
+// this test binary is in the Safe Storage partition. If this ever hangs, the
+// no-UI query attribute regressed and the goroutine-leak bug is back.
+func TestSafeStoragePasswordViaKeybase_ReturnsPromptly(t *testing.T) {
+	type res struct {
+		pw  string
+		err error
+	}
+	done := make(chan res, 1)
+	go func() {
+		pw, err := safeStoragePasswordViaKeybaseFor(keychainService, keychainAccount)
+		done <- res{pw, err}
+	}()
+
+	select {
+	case r := <-done:
+		// Either outcome is valid and environment-dependent:
+		//   - granted (binary in the partition): success, non-empty password
+		//   - not granted / locked: ErrKeychainInteractionRequired (no prompt)
+		// The contract under test is "no hang + a usable key on success", not
+		// which branch this particular machine takes.
+		if r.err == nil && r.pw == "" {
+			t.Error("success path returned an empty Safe Storage password")
+		}
+		if r.err == nil {
+			if _, err := DeriveAESKey(r.pw); err != nil {
+				t.Errorf("password from keychain did not derive an AES key: %v", err)
+			}
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("safeStoragePasswordViaKeybaseFor hung; kSecUseAuthenticationUIFail should make it non-blocking")
+	}
+}

--- a/internal/chrome/keychain_test.go
+++ b/internal/chrome/keychain_test.go
@@ -1,6 +1,7 @@
 package chrome
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"slices"
@@ -28,6 +29,66 @@ func TestSafeStoragePasswordFor_SkipsCGOForUnsignedBinary(t *testing.T) {
 	SafeStoragePasswordFor(b) //nolint:errcheck
 	if keybaseCalled {
 		t.Error("safeStorageViaKeybaseRunner must not be called for unsigned binaries")
+	}
+}
+
+func TestSafeStoragePasswordFor_LockedKeychainShortCircuitsBeforeCLI(t *testing.T) {
+	// A locked login keychain must short-circuit to ErrKeychainLocked BEFORE the
+	// `security` CLI runs -- otherwise the CLI hangs on an unlock prompt until the
+	// timeout and the error gets misclassified as a missing grant (exit 0). The
+	// transient lock must let a --watch agent exit non-zero so launchd retries.
+	origCodesign, origKeybase, origLocked, origCLI := codesignRunner, safeStorageViaKeybaseRunner, keychainLockedCheck, securityCLIRead
+	t.Cleanup(func() {
+		codesignRunner, safeStorageViaKeybaseRunner, keychainLockedCheck, securityCLIRead = origCodesign, origKeybase, origLocked, origCLI
+	})
+
+	codesignRunner = func(string) (string, error) { return "code object is not signed at all", nil } // unsigned: skip CGO
+	keychainLockedCheck = func() (bool, error) { return true, nil }                                   // keychain is locked
+	cliCalled := false
+	securityCLIRead = func(_ context.Context, _, _ string) ([]byte, []byte, error) {
+		cliCalled = true
+		return nil, nil, nil
+	}
+
+	b, _ := LookupBrowser("")
+	_, err := SafeStoragePasswordFor(b)
+	if !errors.Is(err, ErrKeychainLocked) {
+		t.Errorf("locked keychain should return ErrKeychainLocked, got: %v", err)
+	}
+	if IsKeychainAccessError(err) {
+		t.Error("a locked keychain must not be classified as an access error (it should retry)")
+	}
+	if cliCalled {
+		t.Error("security CLI must not run when the keychain is locked (avoids hang/unlock-prompt storm)")
+	}
+}
+
+func TestSafeStoragePasswordFor_UnknownLockStateFallsThroughToCLI(t *testing.T) {
+	// When lock state is unknown (status error, or non-darwin/cgo build), do not
+	// short-circuit -- fall through to the CLI lane.
+	origCodesign, origKeybase, origLocked, origCLI := codesignRunner, safeStorageViaKeybaseRunner, keychainLockedCheck, securityCLIRead
+	t.Cleanup(func() {
+		codesignRunner, safeStorageViaKeybaseRunner, keychainLockedCheck, securityCLIRead = origCodesign, origKeybase, origLocked, origCLI
+	})
+
+	codesignRunner = func(string) (string, error) { return "code object is not signed at all", nil }
+	keychainLockedCheck = func() (bool, error) { return false, errors.New("status unavailable") }
+	cliCalled := false
+	securityCLIRead = func(_ context.Context, _, _ string) ([]byte, []byte, error) {
+		cliCalled = true
+		return []byte("pw\n"), nil, nil
+	}
+
+	b, _ := LookupBrowser("")
+	pw, err := SafeStoragePasswordFor(b)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pw != "pw" {
+		t.Errorf("password = %q, want %q", pw, "pw")
+	}
+	if !cliCalled {
+		t.Error("unknown lock state should fall through to the security CLI")
 	}
 }
 

--- a/internal/chrome/keychain_test.go
+++ b/internal/chrome/keychain_test.go
@@ -2,6 +2,7 @@ package chrome
 
 import (
 	"errors"
+	"fmt"
 	"slices"
 	"testing"
 )
@@ -93,12 +94,16 @@ func TestIsKeychainAccessError(t *testing.T) {
 	}{
 		{"nil", nil, false},
 		{"generic error", errors.New("network timeout"), false},
-		{"did you grant access", errors.New("read Chrome Safe Storage from Keychain (did you grant access?): exit status 1"), true},
-		{"not yet in partition", errors.New("read Chrome Safe Storage from Keychain timed out after 10s; this binary is not yet in the Safe Storage partition."), true},
-		// Locked keychain (-25308) is transient, not a missing grant: launchd
-		// should retry, so this must NOT be classified as an access error.
-		{"keychain locked 25308 is not access error", errors.New("error -25308: User interaction is not allowed"), false},
-		{"keychain locked phrase is not access error", errors.New("interaction is not allowed"), false},
+		{"missing grant sentinel", fmt.Errorf("read Keychain (did you grant access?): %w", ErrKeychainNoGrant), true},
+		{"timeout sentinel", fmt.Errorf("read Keychain timed out: %w", ErrKeychainTimeout), true},
+		// Sentinel survives an extra wrap layer -- the boundary the old string
+		// match defeated: classification holds even after re-wrapping.
+		{"missing grant wrapped twice", fmt.Errorf("cmux-sync: %w", fmt.Errorf("read Keychain: %w", ErrKeychainNoGrant)), true},
+		// The PR #107 regression guard: a LOCKED error wrapped in the
+		// "did you grant access?" prose must NOT be classified as an access
+		// error -- it carries ErrKeychainLocked, so launchd should retry.
+		{"locked wrapped in grant prose is not access error", fmt.Errorf("read Keychain (did you grant access?): login keychain is locked: %w", ErrKeychainLocked), false},
+		{"raw locked string is not access error", errors.New("error -25308: User interaction is not allowed"), false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/chrome/keychain_test.go
+++ b/internal/chrome/keychain_test.go
@@ -43,7 +43,7 @@ func TestSafeStoragePasswordFor_LockedKeychainShortCircuitsBeforeCLI(t *testing.
 	})
 
 	codesignRunner = func(string) (string, error) { return "code object is not signed at all", nil } // unsigned: skip CGO
-	keychainLockedCheck = func() (bool, error) { return true, nil }                                   // keychain is locked
+	keychainLockedCheck = func() (bool, error) { return true, nil }                                  // keychain is locked
 	cliCalled := false
 	securityCLIRead = func(_ context.Context, _, _ string) ([]byte, []byte, error) {
 		cliCalled = true

--- a/internal/cli/cmux_sync_enable.go
+++ b/internal/cli/cmux_sync_enable.go
@@ -28,6 +28,14 @@ var (
 		_, err := chrome.SafeStoragePasswordFor(b)
 		return err
 	}
+	// cmuxSyncConfigExists reports whether cmux's config file is present. It lets
+	// enableCmuxLoop run the Keychain pre-flight BEFORE mutating cmux.json while
+	// still surfacing the "launch cmux once" no-op first -- a stubbable seam so
+	// tests don't depend on a real cmux.json on disk.
+	cmuxSyncConfigExists = func(path string) bool {
+		info, err := os.Stat(path)
+		return err == nil && !info.IsDir()
+	}
 )
 
 var cmuxSyncEnableCmuxPath string
@@ -103,8 +111,30 @@ func enableCmuxLoop(cmuxPath string, quiet bool) error {
 	if err != nil {
 		return err
 	}
+
+	// cmux.json-missing no-op: surface "launch cmux once" before anything else
+	// so a never-launched cmux gets the relevant remediation, not a Keychain one.
+	if !cmuxSyncConfigExists(cfgPath) {
+		logf("agentcookie cmux-sync: cmux is installed but %s is missing; launch cmux once, then re-run `agentcookie cmux-sync enable`", cfgPath)
+		return nil
+	}
+
+	// Keychain pre-flight runs BEFORE mutating cmux.json. A go install binary is
+	// ad-hoc signed and always needs a first-run grant; failing here prevents the
+	// KeepAlive restart loop before it starts AND leaves cmux.json untouched (no
+	// orphaned socketControlMode=allowAll on an aborted enable). It runs after the
+	// cmux-absent / cmux.json-missing no-ops so those surface first.
+	defaultBrowser, _ := chrome.LookupBrowser("")
+	if err := cmuxSyncKeychainCheck(defaultBrowser); err != nil {
+		fmt.Fprintf(os.Stderr, "agentcookie cmux-sync enable: Keychain pre-flight failed — %v\n", err)
+		fmt.Fprintf(os.Stderr, "agentcookie cmux-sync enable: fix first: %s\n", chrome.SafeStorageRemediation)
+		return fmt.Errorf("cmux-sync enable: Keychain not accessible; run `agentcookie wizard set-keychain-access` first")
+	}
+
 	bak, err := cmuxSyncSetMode(cfgPath, "allowAll", "", time.Now())
 	if errors.Is(err, cmuxconfig.ErrNotFound) {
+		// cmux.json vanished between the existence check and the write (TOCTOU);
+		// no mutation happened, so this is still a clean no-op.
 		logf("agentcookie cmux-sync: cmux is installed but %s is missing; launch cmux once, then re-run `agentcookie cmux-sync enable`", cfgPath)
 		return nil
 	}
@@ -112,18 +142,6 @@ func enableCmuxLoop(cmuxPath string, quiet bool) error {
 		return fmt.Errorf("set cmux socketControlMode: %w", err)
 	}
 	logf("agentcookie cmux-sync: set socketControlMode=allowAll in %s (backup: %s)", cfgPath, bak)
-
-	// Keychain pre-flight: verify Keychain access before installing the agent.
-	// A go install binary is ad-hoc signed and always needs a first-run grant;
-	// failing here prevents the KeepAlive restart loop before it starts. Runs
-	// after the cmux-absent / cmux.json-missing no-ops so those surface their
-	// own (more relevant) remediation first.
-	defaultBrowser, _ := chrome.LookupBrowser("")
-	if err := cmuxSyncKeychainCheck(defaultBrowser); err != nil {
-		fmt.Fprintf(os.Stderr, "agentcookie cmux-sync enable: Keychain pre-flight failed — %v\n", err)
-		fmt.Fprintf(os.Stderr, "agentcookie cmux-sync enable: fix first: %s\n", chrome.SafeStorageRemediation)
-		return fmt.Errorf("cmux-sync enable: Keychain not accessible; run `agentcookie wizard set-keychain-access` first")
-	}
 
 	binPath, err := os.Executable()
 	if err != nil {

--- a/internal/cli/cmux_sync_enable_test.go
+++ b/internal/cli/cmux_sync_enable_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/mvanhorn/agentcookie/internal/chrome"
-	"github.com/mvanhorn/agentcookie/internal/cmuxconfig"
 	"github.com/mvanhorn/agentcookie/internal/launchd"
 )
 
@@ -26,7 +25,7 @@ func stubEnableSeams(t *testing.T) (setCalls *[]string, installed *[]launchd.Spe
 	t.Setenv("HOME", t.TempDir()) // keep logDir + os.Executable side effects in tmp
 	sc := []string{}
 	ins := []launchd.Spec{}
-	origSet, origInstall, origCheck := cmuxSyncSetMode, cmuxSyncInstallAgent, cmuxSyncKeychainCheck
+	origSet, origInstall, origCheck, origExists := cmuxSyncSetMode, cmuxSyncInstallAgent, cmuxSyncKeychainCheck, cmuxSyncConfigExists
 	cmuxSyncSetMode = func(path, mode, password string, now time.Time) (string, error) {
 		sc = append(sc, mode)
 		return path + ".bak", nil
@@ -36,8 +35,9 @@ func stubEnableSeams(t *testing.T) (setCalls *[]string, installed *[]launchd.Spe
 		return nil
 	}
 	cmuxSyncKeychainCheck = func(chrome.Browser) error { return nil } // pre-flight always passes
+	cmuxSyncConfigExists = func(string) bool { return true }          // cmux.json present
 	t.Cleanup(func() {
-		cmuxSyncSetMode, cmuxSyncInstallAgent, cmuxSyncKeychainCheck = origSet, origInstall, origCheck
+		cmuxSyncSetMode, cmuxSyncInstallAgent, cmuxSyncKeychainCheck, cmuxSyncConfigExists = origSet, origInstall, origCheck, origExists
 	})
 	return &sc, &ins
 }
@@ -75,10 +75,12 @@ func TestEnableCmuxLoop_WiresModeAndAgent(t *testing.T) {
 
 func TestEnableCmuxLoop_NoAgentWhenCmuxConfigMissing(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
+	setCalls := []string{}
 	installed := []launchd.Spec{}
-	origSet, origInstall, origCheck := cmuxSyncSetMode, cmuxSyncInstallAgent, cmuxSyncKeychainCheck
-	cmuxSyncSetMode = func(string, string, string, time.Time) (string, error) {
-		return "", cmuxconfig.ErrNotFound
+	origSet, origInstall, origCheck, origExists := cmuxSyncSetMode, cmuxSyncInstallAgent, cmuxSyncKeychainCheck, cmuxSyncConfigExists
+	cmuxSyncSetMode = func(_, mode, _ string, _ time.Time) (string, error) {
+		setCalls = append(setCalls, mode)
+		return "", nil
 	}
 	cmuxSyncInstallAgent = func(spec launchd.Spec) error {
 		installed = append(installed, spec)
@@ -86,8 +88,9 @@ func TestEnableCmuxLoop_NoAgentWhenCmuxConfigMissing(t *testing.T) {
 	}
 	checkCalled := false
 	cmuxSyncKeychainCheck = func(chrome.Browser) error { checkCalled = true; return nil }
+	cmuxSyncConfigExists = func(string) bool { return false } // cmux installed but never launched
 	t.Cleanup(func() {
-		cmuxSyncSetMode, cmuxSyncInstallAgent, cmuxSyncKeychainCheck = origSet, origInstall, origCheck
+		cmuxSyncSetMode, cmuxSyncInstallAgent, cmuxSyncKeychainCheck, cmuxSyncConfigExists = origSet, origInstall, origCheck, origExists
 	})
 
 	if err := enableCmuxLoop(fakeCmuxBinary(t), true); err != nil {
@@ -96,10 +99,15 @@ func TestEnableCmuxLoop_NoAgentWhenCmuxConfigMissing(t *testing.T) {
 	if len(installed) != 0 {
 		t.Errorf("no agent should be installed when cmux.json is missing, got %d", len(installed))
 	}
-	// P2: the Keychain pre-flight must not run when cmux.json is missing, so the
+	// cmux.json missing must short-circuit before any mutation: no socketControlMode
+	// write so a re-run after launching cmux starts clean.
+	if len(setCalls) != 0 {
+		t.Errorf("socketControlMode must not be set when cmux.json is missing, got %v", setCalls)
+	}
+	// The Keychain pre-flight must not run when cmux.json is missing, so the
 	// user sees "launch cmux once" rather than a misleading Keychain message.
 	if checkCalled {
-		t.Error("Keychain pre-flight must not run when cmux.json is missing (ErrNotFound)")
+		t.Error("Keychain pre-flight must not run when cmux.json is missing")
 	}
 }
 
@@ -107,7 +115,7 @@ func TestEnableCmuxLoop_AbortsWhenKeychainPreflightFails(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	setCalls := []string{}
 	installed := []launchd.Spec{}
-	origSet, origInstall, origCheck := cmuxSyncSetMode, cmuxSyncInstallAgent, cmuxSyncKeychainCheck
+	origSet, origInstall, origCheck, origExists := cmuxSyncSetMode, cmuxSyncInstallAgent, cmuxSyncKeychainCheck, cmuxSyncConfigExists
 	cmuxSyncSetMode = func(path, mode, password string, now time.Time) (string, error) {
 		setCalls = append(setCalls, mode)
 		return path + ".bak", nil
@@ -119,18 +127,22 @@ func TestEnableCmuxLoop_AbortsWhenKeychainPreflightFails(t *testing.T) {
 	cmuxSyncKeychainCheck = func(chrome.Browser) error {
 		return errors.New("read Chrome Safe Storage from Keychain (did you grant access?): exit status 1")
 	}
+	cmuxSyncConfigExists = func(string) bool { return true } // cmux.json present, so pre-flight is reached
 	t.Cleanup(func() {
-		cmuxSyncSetMode, cmuxSyncInstallAgent, cmuxSyncKeychainCheck = origSet, origInstall, origCheck
+		cmuxSyncSetMode, cmuxSyncInstallAgent, cmuxSyncKeychainCheck, cmuxSyncConfigExists = origSet, origInstall, origCheck, origExists
 	})
 
 	err := enableCmuxLoop(fakeCmuxBinary(t), true)
 	if err == nil {
 		t.Fatal("enable should abort when Keychain pre-flight fails")
 	}
+	// R4: the pre-flight runs BEFORE the cmux.json write, so an aborted enable
+	// leaves cmux.json untouched -- no orphaned socketControlMode=allowAll.
+	if len(setCalls) != 0 {
+		t.Errorf("socketControlMode must not be set when pre-flight fails, got %v", setCalls)
+	}
 	// The agent is what starts the restart loop; it must never be installed
-	// when the pre-flight fails. (socketControlMode may already be set — the
-	// pre-flight runs after the cmux.json ErrNotFound guard so a never-launched
-	// cmux gets the correct "launch cmux once" message instead of a Keychain one.)
+	// when the pre-flight fails.
 	if len(installed) != 0 {
 		t.Errorf("no agent should be installed when pre-flight fails, got %d", len(installed))
 	}

--- a/internal/cli/cmux_sync_test.go
+++ b/internal/cli/cmux_sync_test.go
@@ -108,10 +108,10 @@ func TestCmuxSyncFlagValidation(t *testing.T) {
 	})
 }
 
-// keychainAccessErr is a representative missing-grant failure matching what
+// errKeychainAccess is a representative missing-grant failure matching what
 // SafeStoragePasswordFor returns when access is denied: the operator-facing
 // prose plus the ErrKeychainNoGrant sentinel that drives classification.
-var keychainAccessErr = fmt.Errorf("read Chrome Safe Storage from Keychain (did you grant access?): exit status 1: %w", chrome.ErrKeychainNoGrant)
+var errKeychainAccess = fmt.Errorf("read Chrome Safe Storage from Keychain (did you grant access?): exit status 1: %w", chrome.ErrKeychainNoGrant)
 
 func stubCmuxSyncPassword(t *testing.T, pw string, err error) {
 	t.Helper()
@@ -134,7 +134,7 @@ func TestRunCmuxSync_ExitsZeroOnKeychainFailureInWatchMode(t *testing.T) {
 	cmuxSyncWatch = true
 	t.Cleanup(func() { cmuxSyncOnce = false; cmuxSyncWatch = false })
 
-	stubCmuxSyncPassword(t, "", keychainAccessErr)
+	stubCmuxSyncPassword(t, "", errKeychainAccess)
 	exitCode := stubCmuxExitFunc(t)
 
 	err := runCmuxSync(&cobra.Command{}, nil)
@@ -151,7 +151,7 @@ func TestRunCmuxSync_ReturnsErrorOnKeychainFailureInOnceMode(t *testing.T) {
 	cmuxSyncWatch = false
 	t.Cleanup(func() { cmuxSyncOnce = false; cmuxSyncWatch = false })
 
-	stubCmuxSyncPassword(t, "", keychainAccessErr)
+	stubCmuxSyncPassword(t, "", errKeychainAccess)
 	exitCode := stubCmuxExitFunc(t)
 
 	err := runCmuxSync(&cobra.Command{}, nil)

--- a/internal/cli/cmux_sync_test.go
+++ b/internal/cli/cmux_sync_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -107,9 +108,10 @@ func TestCmuxSyncFlagValidation(t *testing.T) {
 	})
 }
 
-// keychainAccessErr is a representative Keychain access failure string matching
-// what SafeStoragePasswordFor returns when access is denied.
-const keychainAccessErr = "read Chrome Safe Storage from Keychain (did you grant access?): exit status 1"
+// keychainAccessErr is a representative missing-grant failure matching what
+// SafeStoragePasswordFor returns when access is denied: the operator-facing
+// prose plus the ErrKeychainNoGrant sentinel that drives classification.
+var keychainAccessErr = fmt.Errorf("read Chrome Safe Storage from Keychain (did you grant access?): exit status 1: %w", chrome.ErrKeychainNoGrant)
 
 func stubCmuxSyncPassword(t *testing.T, pw string, err error) {
 	t.Helper()
@@ -132,7 +134,7 @@ func TestRunCmuxSync_ExitsZeroOnKeychainFailureInWatchMode(t *testing.T) {
 	cmuxSyncWatch = true
 	t.Cleanup(func() { cmuxSyncOnce = false; cmuxSyncWatch = false })
 
-	stubCmuxSyncPassword(t, "", errors.New(keychainAccessErr))
+	stubCmuxSyncPassword(t, "", keychainAccessErr)
 	exitCode := stubCmuxExitFunc(t)
 
 	err := runCmuxSync(&cobra.Command{}, nil)
@@ -149,7 +151,7 @@ func TestRunCmuxSync_ReturnsErrorOnKeychainFailureInOnceMode(t *testing.T) {
 	cmuxSyncWatch = false
 	t.Cleanup(func() { cmuxSyncOnce = false; cmuxSyncWatch = false })
 
-	stubCmuxSyncPassword(t, "", errors.New(keychainAccessErr))
+	stubCmuxSyncPassword(t, "", keychainAccessErr)
 	exitCode := stubCmuxExitFunc(t)
 
 	err := runCmuxSync(&cobra.Command{}, nil)
@@ -175,6 +177,29 @@ func TestRunCmuxSync_ReturnsErrorOnNonKeychainFailureInWatchMode(t *testing.T) {
 	}
 	if *exitCode != -1 {
 		t.Errorf("exitFunc must not be called for non-Keychain errors, got %d", *exitCode)
+	}
+}
+
+func TestRunCmuxSync_ReturnsErrorOnLockedKeychainInWatchMode(t *testing.T) {
+	// A locked keychain is transient: --watch must exit non-zero so launchd's
+	// KeepAlive retries once it unlocks, NOT exit 0 (which would stop the sync
+	// permanently). This is the PR #107 misclassification fix at the call site:
+	// the error carries ErrKeychainLocked even though it reads as an access
+	// failure, so IsKeychainAccessError is false and exitFunc is never called.
+	cmuxSyncOnce = false
+	cmuxSyncWatch = true
+	t.Cleanup(func() { cmuxSyncOnce = false; cmuxSyncWatch = false })
+
+	lockedErr := fmt.Errorf("read Keychain (did you grant access?): login keychain is locked: %w", chrome.ErrKeychainLocked)
+	stubCmuxSyncPassword(t, "", lockedErr)
+	exitCode := stubCmuxExitFunc(t)
+
+	err := runCmuxSync(&cobra.Command{}, nil)
+	if err == nil {
+		t.Error("runCmuxSync should return error (non-zero) on a locked keychain in --watch mode")
+	}
+	if *exitCode != -1 {
+		t.Errorf("exitFunc must not be called for a locked keychain, got %d", *exitCode)
 	}
 }
 


### PR DESCRIPTION
Follow-up to #107. That PR stopped the `cmux-sync enable` prompt **storm**; this closes three residual defects the storm fix left in the same keychain-failure subsystem.

## What this fixes

1. **CGO dialog/goroutine leak.** `safeStoragePasswordViaKeybaseFor` ran `SecItemCopyMatching` in a goroutine abandoned on a 3s timeout; on a signed binary that lost its grant the abandoned call held a SecurityAgent dialog open and the `security` CLI fallback opened a second one. The read now disables keychain user interaction (`SecKeychainSetUserInteractionAllowed`) around a direct `SecItem` query, so it returns `errSecInteractionNotAllowed` immediately instead of prompting — making the call synchronous, with no goroutine to abandon and no orphaned dialog. (`kSecUseAuthenticationUIFail` alone does not suppress this prompt: the Chrome Safe Storage dialog is a legacy keychain ACL confirmation, not a LocalAuthentication UI.)

2. **Lock vs missing-grant misclassification.** `SafeStoragePasswordFor` wrapped every non-timeout `security`-CLI failure as "did you grant access?" and `IsKeychainAccessError` string-matched that wrapper, so a transient locked keychain was misread as a permanent missing grant — and `--watch` exited 0 (no launchd retry), permanently stopping the sync. The raw-`-25308` exclusion #107 added never fired because the live path discards the raw error and re-wraps it. Now there are typed sentinels (`ErrKeychainNoGrant` / `ErrKeychainLocked` / `ErrKeychainTimeout`), classification happens at the source (including a `SecKeychainGetStatus` lock check *before* the CLI so a locked keychain can't hang it), and the predicates use `errors.Is`.

3. **`socketControlMode` side-effect on aborted enable.** `enableCmuxLoop` wrote `socketControlMode=allowAll` before the Keychain pre-flight could abort, leaving `cmux.json` mutated on a failed enable. The pre-flight now runs before the write (gated by a stubbable `cmux.json` existence check), so an aborted enable leaves `cmux.json` untouched.

## Testing

- `go build ./...`, `go vet`, and the full suite pass; `go test -race ./internal/chrome/ ./internal/cli/` is clean.
- New coverage: no-hang regression guard on the CGO read; locked-keychain short-circuits before the CLI; locked-vs-missing-grant classification survives extra wrap layers (the #107 gap); `--watch` exits non-zero on a locked keychain; aborted enable leaves `cmux.json` unmutated.
- Both changes were adversarially reviewed (CGO memory safety + classification correctness); the lock-before-CLI check and the interaction-flip mutex came out of that review.

Manual check on a Developer-ID build whose grant was invalidated: `cmux-sync --once` fails fast with the no-grant remediation and **zero** SecurityAgent dialogs; with the login keychain locked, `cmux-sync --watch` exits non-zero (launchd retries) rather than exit 0.

## Post-Deploy Monitoring & Validation

- **Watch:** `~/.agentcookie/logs/` for the cmux-sync agent. Healthy = silent sync; on a missing grant, a single "Keychain not accessible; exiting cleanly" line and no restart loop; on a locked keychain, non-zero exit with launchd retry that recovers after unlock.
- **Failure signal / rollback trigger:** any recurrence of repeated SecurityAgent prompts, or a `--watch` agent that stops permanently after a sleep-wake. Mitigation: `launchctl unload ~/Library/LaunchAgents/dev.agentcookie.cmux-sync.plist` then `agentcookie wizard set-keychain-access`; revert is a clean `git revert` of this range (no migrations, no persisted state).
- **Validation window:** next real `cmux-sync enable` + one sleep-wake cycle.
