### PR TITLE
build: inject version via ldflags in make build/install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,18 @@ BIN_DIR := bin
 BINARY := $(BIN_DIR)/agentcookie
 PKG := ./cmd/agentcookie
 
+# Inject the version at link time so `make build` / `make install` -- and the
+# CI release build, which runs `make` (see the comment above) -- report the
+# real tag instead of the "0.0.1-dev" default baked into internal/cli.Version.
+# Mirrors the -X ldflag in .goreleaser.yaml. `git describe` yields e.g. 0.17.1
+# on a tagged build or 0.17.1-2-gfe6f405 between tags; the leading v is stripped
+# to match goreleaser's {{ .Version }}. Falls back to the in-source default when
+# git is unavailable (e.g. building from a release tarball).
+VERSION := $(shell git describe --tags --always --dirty 2>/dev/null | sed 's/^v//')
+ifneq ($(VERSION),)
+LDFLAGS := -X github.com/mvanhorn/agentcookie/internal/cli.Version=$(VERSION)
+endif
+
 GOBIN := $(shell go env GOBIN)
 ifeq ($(GOBIN),)
 GOBIN := $(shell go env GOPATH)/bin
@@ -41,13 +53,13 @@ release: build sign notarize
 
 build:
 	@mkdir -p $(BIN_DIR)
-	go build -o $(BINARY) $(PKG)
+	go build -ldflags "$(LDFLAGS)" -o $(BINARY) $(PKG)
 
 # Install to $(GOBIN)/agentcookie and sign in place so steady-state
 # `make install` produces a signed binary with the same designated
 # requirement as the local build.
 install:
-	go install $(PKG)
+	go install -ldflags "$(LDFLAGS)" $(PKG)
 	scripts/sign.sh "$(GOBIN)/agentcookie"
 
 sign:


### PR DESCRIPTION
## Problem

`make build` and `make install` produce binaries that report `0.0.1-dev` — the default value of `internal/cli.Version` — because neither target passes an `-X` ldflag.

This isn't only a local-dev papercut. The Makefile header notes that **CI release builds run `make` (build + sign)**, and `release.yml` says current releases are *"cut locally with `make release`"* (the goreleaser job is gated behind `RELEASE_CI_ENABLED == 'true'`). Since `make release` → `make build`, **every published binary inherits the bug.** The v0.17.1 release tarball reports:

```
$ agentcookie version
0.0.1-dev
$ agentcookie doctor --json | python3 -c 'import sys,json;print(json.load(sys.stdin)["version"])'
0.0.1-dev
```

That makes `version` / `doctor` output unhelpful for triage — which the dry-run notes already flagged as friction (`docs/dry-run-2026-05-19.md` #2, `docs/dry-run-2026-05-21.md` #23).

`.goreleaser.yaml` already injects the version correctly via `-X ...cli.Version={{ .Version }}`, but goreleaser isn't the path that builds the shipped tarball today.

## Fix

Mirror the goreleaser `-X` ldflag in the Makefile's `build` and `install` targets:

```make
VERSION := $(shell git describe --tags --always --dirty 2>/dev/null | sed 's/^v//')
ifneq ($(VERSION),)
LDFLAGS := -X github.com/mvanhorn/agentcookie/internal/cli.Version=$(VERSION)
endif
```

- Leading `v` stripped so `make` output matches goreleaser's `{{ .Version }}` (`0.17.1`, not `v0.17.1`).
- Guarded with `ifneq` so a no-git build (e.g. from an extracted release tarball) falls back to the in-source `0.0.1-dev` default instead of injecting an empty version string.

## Verification

```
$ make build && ./bin/agentcookie version
0.17.1-3-g0d7a679        # was: 0.0.1-dev
```

On a tagged release build this prints the bare tag (`0.17.1`).

## Notes / decisions for the maintainer

- I deliberately did **not** add goreleaser's `-s -w` (strip symbol table / DWARF) to the Makefile build, to keep debug symbols in contributor/dev builds. The bug here is purely version reporting. Happy to add `-s -w` if you'd prefer `make`-built release binaries to match goreleaser's stripped archives byte-for-byte.
- Optional follow-up (intentionally **not** in this PR to keep it focused): a `runtime/debug.ReadBuildInfo()` fallback in `internal/cli` would also fix the `go install github.com/mvanhorn/agentcookie/...@vX` path, since `go install` doesn't run the Makefile. Glad to add it here or as a separate PR if it'd be useful.
