### PR TITLE
fix: drop stale "v0.12 closed beta" qualifier from doctor sealing output

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -927,7 +927,7 @@ func checkSealingWith(masterKeyExists func() bool) Check {
 	return Check{
 		Name:     "Sealing",
 		Severity: SeverityOK,
-		Detail:   "disabled (default in v0.12 closed beta)",
+		Detail:   "disabled (agentcookie-master Keychain item not present)",
 	}
 }
 


### PR DESCRIPTION
## What

The Sealing check in `agentcookie doctor` prints this on its disabled branch:

```
disabled (default in v0.12 closed beta)
```

This swaps it for a state description that matches the enabled branch:

```
disabled (agentcookie-master Keychain item not present)
```

## Why

On a public v0.17.1 binary the old string is stale in two ways:

1. It names v0.12 while the tool is v0.17.1.
2. It carries "closed beta" framing, which no longer fits a public release.

It prints on every `doctor` run, so it is the most visible spot the old label survives.

The enabled branch already reads `enabled (agentcookie-master Keychain item present)`. This change makes the two branches symmetric and describes the actual runtime Keychain state instead of a version label, which is also more useful to anyone (or any agent) reading doctor output to branch on sealing state.

## Scope

This is intentionally a one-line change to live CLI output only.

The historical version note in the code comment above `checkSealingWith` is left intact, since that comment pins version history on purpose.

Docs that describe internal state (`docs/quickstart-beta.md`, `docs/threat-model.md`, the dry-run notes, etc.) are deliberately untouched. The marketing-readme-rewrite plan already scoped doc "beta" wording as accurate-to-internal-state and out of scope; this PR stays inside that boundary by only correcting runtime output.

## Verification

- `go vet ./...` clean
- `go test ./internal/cli/...` passes (`TestCheckSealing` exercises both branches)
- `make build` then `strings bin/agentcookie` confirms the new string is compiled in and the old `default in v0.12 closed beta` string is gone
