### PR TITLE
fix: drop stale "v0.12 closed beta" framing from doctor Sealing output

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -912,10 +912,9 @@ func checkDBSCFrom(st *state.SourceState) Check {
 	}
 }
 
-// checkSealingWith is informational: in v0.12 closed beta the master
-// key Keychain item is off by default. Doctor reports the state so
-// agents downstream can branch on it, but never WARN/FAIL on either
-// branch -- the user-facing default is "disabled" for this release.
+// checkSealingWith is informational. It reports whether the
+// agentcookie-master Keychain item is present; when the item is missing,
+// Doctor reports Sealing as disabled, but never WARN/FAIL on either state.
 func checkSealingWith(masterKeyExists func() bool) Check {
 	if masterKeyExists() {
 		return Check{
@@ -927,7 +926,7 @@ func checkSealingWith(masterKeyExists func() bool) Check {
 	return Check{
 		Name:     "Sealing",
 		Severity: SeverityOK,
-		Detail:   "disabled (default in v0.12 closed beta)",
+		Detail:   "disabled (agentcookie-master Keychain item not present)",
 	}
 }
 


### PR DESCRIPTION
## Summary
On a public v0.17.1 binary, `agentcookie doctor`'s Sealing check still carried "v0.12 closed beta" framing — both the runtime `Detail` string and the `checkSealingWith` comment. This swaps them for version-agnostic descriptions of the actual behavior (mirroring the enabled branch).

Closes #110

## Verified
- [x] `go build ./...`
- [x] `go vet ./...`
- [ ] `go test ./...` — not run; comment + display-string change only, no logic touched.

## Notes
Comment/string only — no behavior change.

Co-drafted with my AI coding agent (cross-checked by a second model), verified locally with `go build` / `go vet` before opening.
