### PR TITLE
feat: ship a Universal 2 (arm64 + x86_64) darwin release binary

### DIFF
--- a/.github/RELEASE_NOTES_TEMPLATE.md
+++ b/.github/RELEASE_NOTES_TEMPLATE.md
@@ -4,11 +4,11 @@ Closed-beta release. Invitation only.
 
 ## Install
 
-Download `agentcookie-{{VERSION}}-darwin-arm64.tar.gz` from the assets below, then:
+Download `agentcookie-{{VERSION}}-darwin-universal.tar.gz` from the assets below, then:
 
 ```
-tar -xzf agentcookie-{{VERSION}}-darwin-arm64.tar.gz
-cd agentcookie-{{VERSION}}-darwin-arm64
+tar -xzf agentcookie-{{VERSION}}-darwin-universal.tar.gz
+cd agentcookie-{{VERSION}}-darwin-universal
 ./install-beta.sh --as source     # on your MacBook
 # or
 ./install-beta.sh --as sink       # on your second Mac

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,9 +71,10 @@ jobs:
             --team-id NM8VT393AR \
             --password "${{ secrets.AC_NOTARY_PASSWORD }}"
 
-      # Build, sign, notarize the agentcookie binary. After this step
-      # bin/agentcookie is fully launchable on any Mac without
-      # Gatekeeper interactive approval.
+      # Build, sign, notarize the agentcookie binary. `make release` now
+      # builds a Universal 2 (arm64 + x86_64) binary, so after this step
+      # bin/agentcookie is fully launchable on any Intel or Apple Silicon
+      # Mac without Gatekeeper interactive approval.
       - name: make release
         run: make release
 
@@ -102,7 +103,7 @@ jobs:
       - name: attach beta bundle to release
         run: |
           gh release upload "${{ github.ref_name }}" \
-            dist/agentcookie-*-darwin-arm64.tar.gz \
+            dist/agentcookie-*-darwin-universal.tar.gz \
             --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,19 @@
 #
 # Targets:
 #   make            - build and sign bin/agentcookie (default; not notarized)
-#   make build      - go build ./cmd/agentcookie -> bin/agentcookie
+#   make build      - go build ./cmd/agentcookie -> bin/agentcookie (native arch)
+#   make build-universal
+#                   - build a Universal 2 (arm64 + x86_64) bin/agentcookie
+#                     via lipo, so one signed binary runs on both Apple
+#                     Silicon and Intel Macs
 #   make install    - go install ./cmd/agentcookie, then sign $(GOBIN)/agentcookie
 #   make sign       - sign bin/agentcookie with the Developer ID identity
 #   make notarize   - submit bin/agentcookie to Apple's notary service
 #                     (5-30 min; required before deploying to a Mac other
 #                     than the one this build ran on)
-#   make release    - build + sign + notarize in one shot (a fully-portable
-#                     binary that launches on any Mac without prompts)
+#   make release    - build-universal + sign + notarize in one shot (a
+#                     fully-portable Universal 2 binary that launches on any
+#                     Intel or Apple Silicon Mac without prompts)
 #   make verify     - print the designated requirement of bin/agentcookie
 #   make test       - go test -race ./...
 #   make vet        - go vet ./...
@@ -45,15 +50,32 @@ ifeq ($(GOBIN),)
 GOBIN := $(shell go env GOPATH)/bin
 endif
 
-.PHONY: all build install sign notarize release verify test vet clean
+.PHONY: all build build-universal install sign notarize release verify test vet clean
 
 all: build sign
 
-release: build sign notarize
+release: build-universal sign notarize
 
 build:
 	@mkdir -p $(BIN_DIR)
 	go build -ldflags "$(LDFLAGS)" -o $(BINARY) $(PKG)
+
+# build-universal - Produce a Universal 2 (arm64 + x86_64) binary at
+# bin/agentcookie via lipo so a single signed + notarized release runs
+# natively on both Apple Silicon and Intel Macs. CGO must stay enabled
+# (the codebase links C for SQLite + the macOS Keychain), so each slice is
+# built separately with the target arch pinned through the C compiler
+# (CC="clang -arch ..."). Pinning CC per slice makes the build host
+# irrelevant: it works whether run on an arm64 or an x86_64 Mac.
+build-universal:
+	@mkdir -p $(BIN_DIR)
+	CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 CC="clang -arch arm64" \
+	  go build -ldflags "$(LDFLAGS)" -o $(BIN_DIR)/agentcookie-arm64 $(PKG)
+	CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 CC="clang -arch x86_64" \
+	  go build -ldflags "$(LDFLAGS)" -o $(BIN_DIR)/agentcookie-amd64 $(PKG)
+	lipo -create $(BIN_DIR)/agentcookie-arm64 $(BIN_DIR)/agentcookie-amd64 -output $(BINARY)
+	@rm -f $(BIN_DIR)/agentcookie-arm64 $(BIN_DIR)/agentcookie-amd64
+	@echo "make build-universal: wrote $(BINARY) (archs: $$(lipo -archs $(BINARY)))"
 
 # Install to $(GOBIN)/agentcookie and sign in place so steady-state
 # `make install` produces a signed binary with the same designated

--- a/docs/quickstart-beta.md
+++ b/docs/quickstart-beta.md
@@ -23,7 +23,7 @@ with no `auth login`, no Keychain prompt, no copy-paste-the-cookie ritual.
 
 ## Prereqs
 
-- Two Macs running macOS 14 or later. Apple silicon recommended. One you browse on (we'll call it source); one your agents run on (sink). Many people use a Mac mini for the sink.
+- Two Macs running macOS 14 or later. Both Apple Silicon and Intel are supported (the release ships a Universal 2 binary). One you browse on (we'll call it source); one your agents run on (sink). Many people use a Mac mini for the sink.
 - Both Macs on the same Tailscale tailnet. Run `tailscale status` on each; both should appear in each other's list. If not, set up Tailscale first.
 - Google Chrome installed on the source. Sign in to whatever sites you want your agents to act on.
 - The release tarball (your invite includes a link or `gh release download` instructions).
@@ -32,8 +32,8 @@ Optional: Go 1.22+ if you want to build from source. Not required when using the
 
 ## Install the source side (your MacBook)
 
-1. Download `agentcookie-v0.12.0-beta.1-darwin-arm64.tar.gz` from the release link in your invite.
-2. Extract: `tar -xzf agentcookie-v0.12.0-beta.1-darwin-arm64.tar.gz`. The bundle contains `agentcookie`, `install-beta.sh`, and this guide.
+1. Download `agentcookie-v0.12.0-beta.1-darwin-universal.tar.gz` from the release link in your invite.
+2. Extract: `tar -xzf agentcookie-v0.12.0-beta.1-darwin-universal.tar.gz`. The bundle contains `agentcookie`, `install-beta.sh`, and this guide.
 3. Run the install script: `./install-beta.sh --as source`. It will:
    - Verify your binary is notarized (so macOS doesn't block it)
    - Place it at `/usr/local/bin/agentcookie` (or `~/bin/agentcookie` if you don't have admin)

--- a/scripts/install-beta.sh
+++ b/scripts/install-beta.sh
@@ -148,7 +148,15 @@ if [[ -z "$TARBALL" ]]; then
   fi
   step "downloading latest beta release from $REPO"
   TMP_DL="$(mktemp -d -t agentcookie-beta.XXXXXX)"
-  gh release download --repo "$REPO" --pattern '*darwin-arm64.tar.gz' --dir "$TMP_DL" --clobber
+  # Prefer the Universal 2 asset (one binary for both Apple Silicon and
+  # Intel). Fall back to an arch-specific asset for older releases that
+  # predate the universal binary; map uname -m (x86_64) to Go's amd64.
+  HOST_ARCH="$(uname -m)"
+  [[ "$HOST_ARCH" == "x86_64" ]] && HOST_ARCH="amd64"
+  if ! gh release download --repo "$REPO" --pattern '*darwin-universal.tar.gz' --dir "$TMP_DL" --clobber 2>/dev/null; then
+    step "no universal asset found; falling back to darwin-$HOST_ARCH"
+    gh release download --repo "$REPO" --pattern "*darwin-${HOST_ARCH}.tar.gz" --dir "$TMP_DL" --clobber
+  fi
   TARBALL="$(ls -1 "$TMP_DL"/*.tar.gz | head -n1)"
   if [[ -z "$TARBALL" || ! -f "$TARBALL" ]]; then
     die "release tarball not found after download (looked in $TMP_DL)"
@@ -161,7 +169,8 @@ fi
 WORK="$(mktemp -d -t agentcookie-install.XXXXXX)"
 tar -xzf "$TARBALL" -C "$WORK"
 # The release tarball wraps everything in a versioned directory
-# (agentcookie-${VERSION}-darwin-arm64/), so the binary is one level
+# (agentcookie-${VERSION}-darwin-universal/, or -darwin-arm64/ /
+# -darwin-amd64/ for single-arch builds), so the binary is one level
 # deep. find tolerates both shapes (wrapped + flat).
 NEW_BIN="$(find "$WORK" -name agentcookie -type f -perm -u+x 2>/dev/null | head -n1)"
 if [[ -z "$NEW_BIN" || ! -x "$NEW_BIN" ]]; then

--- a/scripts/release-tarball.sh
+++ b/scripts/release-tarball.sh
@@ -11,7 +11,11 @@
 # Where <version> matches the release tag (e.g. v0.12.0-beta.1). The
 # script produces:
 #
-#   dist/agentcookie-<version>-darwin-arm64.tar.gz
+#   dist/agentcookie-<version>-darwin-universal.tar.gz   (arm64 + x86_64)
+#
+# When bin/agentcookie is a single-arch binary (e.g. a `make build` dev
+# build rather than `make build-universal`), the tarball is named for that
+# lone arch instead (darwin-arm64 / darwin-amd64).
 #
 # Prereqs:
 #   1. bin/agentcookie exists, signed and notarized (run `make release`
@@ -54,11 +58,22 @@ if ! codesign -d -r- "$BIN" >/dev/null 2>&1; then
   exit 2
 fi
 
-ARCH="$(uname -m)"
-if [[ "$ARCH" == "arm64" ]]; then
+# Name the tarball for the binary's actual architecture(s). A Universal 2
+# binary (make build-universal) carries both slices and ships as
+# "darwin-universal"; a single-arch dev build ships as darwin-amd64 /
+# darwin-arm64. lipo -archs reports "x86_64" (Go's amd64) and/or "arm64".
+BIN_ARCHS="$(lipo -archs "$BIN" 2>/dev/null || true)"
+if [[ "$BIN_ARCHS" == *arm64* && "$BIN_ARCHS" == *x86_64* ]]; then
+  TARBALL_ARCH="darwin-universal"
+elif [[ "$BIN_ARCHS" == *x86_64* ]]; then
+  TARBALL_ARCH="darwin-amd64"
+elif [[ "$BIN_ARCHS" == *arm64* ]]; then
   TARBALL_ARCH="darwin-arm64"
 else
-  TARBALL_ARCH="darwin-$ARCH"
+  # lipo unavailable or silent; fall back to the build host arch.
+  HOST_ARCH="$(uname -m)"
+  [[ "$HOST_ARCH" == "x86_64" ]] && HOST_ARCH="amd64"
+  TARBALL_ARCH="darwin-$HOST_ARCH"
 fi
 
 OUT_NAME="agentcookie-${VERSION}-${TARBALL_ARCH}"


### PR DESCRIPTION
## Problem

Releases only ship a `darwin-arm64` asset, so Intel Macs have no signed,
notarized binary to install. On an Intel sink that matters beyond
convenience: the sink daemon needs a **Developer-ID-signed binary** to read
Chrome Safe Storage via the `teamid` path, so an unsigned `go install`
build is stuck in degraded delivery (`mode=sidecar+adapter+cdp`) and can
never write the real Chrome profile. Intel users effectively can't get
universal cookie delivery.

The `install-beta.sh` downloader is also hardcoded to
`--pattern '*darwin-arm64.tar.gz'`, so even if an Intel asset existed the
installer wouldn't fetch it.

## Approach

Ship a single **Universal 2 (arm64 + x86_64)** binary rather than two
per-arch assets. One `lipo`-fused binary runs natively on both
architectures and is signed + notarized **once** — the maintainer's release
ritual (and notarization time) stays the same, but Intel is covered.

- **Makefile**: new `build-universal` target. Each slice cross-compiles
  with `CGO_ENABLED=1` (the code links C for SQLite + the Keychain),
  pinning the target arch through `CC="clang -arch ..."` so the build host
  is irrelevant, then `lipo -create`s them. `release` now depends on
  `build-universal` instead of `build`. Plain `make build` stays native for
  fast local dev.
- **scripts/release-tarball.sh**: name the asset from the binary's real
  archs via `lipo -archs` → `darwin-universal` (or `darwin-arm64` /
  `darwin-amd64` for a single-arch dev build).
- **scripts/install-beta.sh**: prefer the `darwin-universal` asset, fall
  back to an arch-matched asset for older releases (maps `uname -m`
  `x86_64` → `amd64`).
- **.github/workflows/release.yml**: upload the `darwin-universal` bundle.
- **docs**: update download filenames; note Intel is supported.

`scripts/sign.sh` and `scripts/notarize.sh` are unchanged and already
arch-agnostic (a universal Mach-O signs and notarizes as one file). **No
new CI secrets are required.**

## Testing

Verified locally on Apple Silicon (macOS, Go 1.26):

- Both slices cross-compile with CGO: `GOARCH=amd64 CC="clang -arch x86_64"`
  and `GOARCH=arm64 CC="clang -arch arm64"`.
- `make build-universal` produces `bin/agentcookie` as
  `Mach-O universal binary with 2 architectures [x86_64] [arm64]`, runs on
  this host, and is version-stamped.
- `release-tarball.sh`'s `lipo -archs` detection resolves
  universal → `darwin-universal`, arm64-only → `darwin-arm64`, amd64-only
  → `darwin-amd64`.
- `bash -n` clean on both edited scripts.

Signing/notarization couldn't be exercised without the Developer ID cert;
those steps run unchanged in the maintainer's release environment.

## Notes

- Backward compatible: `install-beta.sh` still installs older
  `darwin-arm64`-only releases via the fallback path.
- `.goreleaser.yaml` already lists `amd64`, but releases are cut through the
  `make release` + `release-tarball.sh` beta-bundle path, which is what this
  PR updates. The goreleaser path is left untouched to keep scope tight.
