### PR TITLE
fix(cli): report live CDP and stop installing LaunchAgents on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,51 @@ The source is macOS only (it reads Chrome via the macOS Keychain-backed decrypt 
 - **macOS sink**: full two-machine continuous sync via Tailscale `/sync`. Writes Chrome SQLite + plaintext sidecar + per-CLI adapters. LaunchAgent for unattended sync.
 - **Linux sink** (new in v0.14): continuous sync via Tailscale `/sync`, with live CDP injection into a running Chrome. This is the Grok Bot / agent-runtime path: the Linux box wakes up logged into source-allowlisted sites without a second login. No Chrome SQLite rewrite, no Keychain, no libsecret — just live CDP injection into Chrome started with `--remote-debugging-port`. The Linux sink MUST bind a Tailscale 100.x address; it will not start without a tailnet. Security: missing policy defaults to allowlist-empty (ship nothing) on Linux, so the operator must explicitly configure which domains sync.
 
+### Linux sink configuration
+
+The Linux sink injects cookies via CDP into an already-running Chrome. Key configuration points:
+
+1. **live_cdp.endpoint**: Set in `sink.yaml` to the Chrome debug port. Default is `http://127.0.0.1:9223`. If your Chrome runs on a different port (e.g., 9228), configure it:
+
+   ```yaml
+   live_cdp:
+     enabled: true
+     endpoint: http://127.0.0.1:9228
+   ```
+
+2. **Cookie policy**: Linux defaults to allowlist-empty (ship nothing) when no `blocklist.yaml` exists. You MUST explicitly allow domains:
+
+   ```yaml
+   version: 1
+   policy: allowlist
+   domains:
+     - pattern: "github.com"
+     - pattern: "%.github.com"
+     - pattern: "%.amazon.com"
+   ```
+
+3. **Ok-line and status**: The sink reports `wrote 0 cookies` for Chrome SQLite on Linux — this is expected. The real injection happens via live CDP. Look for `live_cdp: injected N cookies into M context(s)` in the response and `agentcookie status` output. `agentcookie doctor` checks the live CDP endpoint and probes common debug ports if the configured one is unreachable.
+
+4. **Daemon setup**: Linux has no LaunchAgents. The wizard prints a systemd user unit you can install:
+
+   ```bash
+   # Copy the unit file to ~/.config/systemd/user/
+   systemctl --user daemon-reload
+   systemctl --user enable --now agentcookie-sink.service
+   ```
+
+   Or run the sink manually / via supervisor:
+
+   ```bash
+   agentcookie sink
+   ```
+
+5. **Chrome launch**: Start Chrome with the debug port before the sink runs:
+
+   ```bash
+   google-chrome --remote-debugging-port=9223
+   ```
+
 Working:
 
 - Continuous laptop to second-Mac sync via fsnotify on Chrome's Cookies file, debounced, cookie-policy filtered, AES-256-GCM over Tailscale.
@@ -254,7 +299,7 @@ Working:
 - Universal cookie delivery: one macOS login-password entry at install (no GUI click) opens the sink's Chrome Safe Storage key to any cookie reader via a partition list (`apple-tool:,apple:,teamid:<your-team>`), so unmodified cookie tools (yt-dlp, gallery-dl, browser-driving agents, the Printing Press CLIs) read the real synced Default Chrome profile. Verified live on macOS 15.x.
 - Apple Developer ID signed binaries; the sink daemon reads Chrome Safe Storage via the `teamid:` partition (no per-binary trust list, no recreate of the key value).
 - Headless second-Mac install over SSH: one login-password entry, no GUI SecurityAgent click. A box with no password available installs in degraded mode (sidecar + adapters still work) and prints the one-line upgrade command.
-- `agentcookie doctor` runs fifteen health categories including cookie delivery (universal vs degraded, with duplicate-keychain-item race detection), binary signature + install, Tailscale, config, keystore, listener bind, sink/source state, sealing posture, adapter coverage, CDP injector health, secrets-bus + secret coverage, and DBSC-suspect cookies.
+- `agentcookie doctor` runs health checks including cookie delivery (universal vs degraded, with duplicate-keychain-item race detection), binary signature + install, daemon binary path match, Tailscale, config, keystore, listener bind, sink/source state, sealing posture, adapter coverage, CDP injector health, live CDP endpoint (Linux), secrets-bus + secret coverage, and DBSC-suspect cookies.
 - 520+ unit tests across 26 packages.
 
 Not yet:

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -21,6 +22,7 @@ import (
 	"github.com/mvanhorn/agentcookie/internal/config"
 	"github.com/mvanhorn/agentcookie/internal/keystore"
 	"github.com/mvanhorn/agentcookie/internal/launchd"
+	"github.com/mvanhorn/agentcookie/internal/livecdp"
 	"github.com/mvanhorn/agentcookie/internal/secretsbus"
 	"github.com/mvanhorn/agentcookie/internal/sinkpush"
 	"github.com/mvanhorn/agentcookie/internal/state"
@@ -253,6 +255,19 @@ func buildReport(d doctorDeps) DoctorReport {
 		})
 	}
 
+	// 10a. Live CDP endpoint (Linux sink primary injection path) -- verifies
+	// the configured live_cdp.endpoint is reachable. If not, probes common
+	// loopback debug ports to suggest the correct setting.
+	if sinkCfg != nil {
+		checks = append(checks, checkLiveCDPEndpoint(sinkCfg))
+	} else {
+		checks = append(checks, Check{
+			Name:     "Live CDP endpoint",
+			Severity: SeveritySkipped,
+			Detail:   "source-only install",
+		})
+	}
+
 	// 10b. cmux delivery (sink surface) -- verifies the opt-in cmux sink
 	// surface can reach cmux, and specifically that socketControlMode is
 	// not the default "cmuxOnly" that would reject the LaunchAgent sink.
@@ -308,6 +323,12 @@ func buildReport(d doctorDeps) DoctorReport {
 	// 13. Binary install. Flags multiple diverging agentcookie binaries so
 	// the on-PATH copy and the daemon's copy don't silently differ.
 	checks = append(checks, checkBinaryInstall())
+
+	// 13a. Daemon binary path. Warns if the daemon's configured binary
+	// differs from the binary running doctor. This catches the common
+	// install-time mistake where a LaunchAgent plist points at ~/bin/agentcookie
+	// while the user runs doctor from ~/go/bin/agentcookie, causing confusion.
+	checks = append(checks, checkDaemonBinaryPath(srcCfg, sinkCfg))
 
 	// 14. Cookie delivery (v0.13 universal cookie delivery) -- sink role
 	// only. Tells the operator whether ANY unmodified cookie CLI works on
@@ -440,6 +461,90 @@ func binaryInstallCheckFrom(candidates []string) Check {
 		Detail:      fmt.Sprintf("%d agentcookie binaries differ; the one on PATH may not be the one your daemon runs: %s", len(infos), strings.Join(paths, ", ")),
 		Remediation: "reinstall so every location is the same build, or delete the stale copy, so status/doctor reflect the running daemon",
 	}
+}
+
+// checkDaemonBinaryPath warns if the daemon's configured binary differs from
+// the binary running this doctor invocation. This catches install-time mistakes
+// where a LaunchAgent plist points at ~/bin/agentcookie while the operator
+// invokes doctor from ~/go/bin/agentcookie.
+func checkDaemonBinaryPath(srcCfg *config.SourceConfig, sinkCfg *config.SinkConfig) Check {
+	self, err := os.Executable()
+	if err != nil {
+		return Check{
+			Name:     "Daemon binary path",
+			Severity: SeveritySkipped,
+			Detail:   "could not determine this binary's path",
+		}
+	}
+	self, _ = filepath.EvalSymlinks(self)
+
+	var mismatches []string
+
+	// Check source daemon on macOS (Linux doesn't use LaunchAgents).
+	if srcCfg != nil && !config.IsLinux() {
+		daemonPath := extractLaunchAgentBinaryPath(launchd.Spec{Role: launchd.RoleSource})
+		if daemonPath != "" && daemonPath != self {
+			mismatches = append(mismatches, fmt.Sprintf("source daemon: %s", daemonPath))
+		}
+	}
+
+	// Check sink daemon on macOS.
+	if sinkCfg != nil && !config.IsLinux() {
+		daemonPath := extractLaunchAgentBinaryPath(launchd.Spec{Role: launchd.RoleSink})
+		if daemonPath != "" && daemonPath != self {
+			mismatches = append(mismatches, fmt.Sprintf("sink daemon: %s", daemonPath))
+		}
+	}
+
+	if len(mismatches) == 0 {
+		return Check{
+			Name:     "Daemon binary path",
+			Severity: SeverityOK,
+			Detail:   fmt.Sprintf("daemon binary matches this invocation (%s)", self),
+		}
+	}
+
+	return Check{
+		Name:        "Daemon binary path",
+		Severity:    SeverityWarn,
+		Detail:      fmt.Sprintf("this doctor runs from %s but daemon(s) configured to use: %s", self, strings.Join(mismatches, ", ")),
+		Remediation: "re-run `agentcookie wizard install` from the binary you want the daemon to use, or reinstall to a single location",
+	}
+}
+
+// extractLaunchAgentBinaryPath reads the plist file for the given spec and
+// extracts the first element of ProgramArguments (the binary path).
+func extractLaunchAgentBinaryPath(spec launchd.Spec) string {
+	plistPath, err := spec.Path()
+	if err != nil {
+		return ""
+	}
+	data, err := os.ReadFile(plistPath)
+	if err != nil {
+		return ""
+	}
+	// Simple extraction: find the first <string> after ProgramArguments.
+	// This is a pragmatic approach that avoids importing plist libraries.
+	idx := strings.Index(string(data), "<key>ProgramArguments</key>")
+	if idx == -1 {
+		return ""
+	}
+	rest := string(data)[idx:]
+	start := strings.Index(rest, "<string>")
+	if start == -1 {
+		return ""
+	}
+	rest = rest[start+8:]
+	end := strings.Index(rest, "</string>")
+	if end == -1 {
+		return ""
+	}
+	binPath := rest[:end]
+	// Resolve symlinks for comparison.
+	if resolved, err := filepath.EvalSymlinks(binPath); err == nil {
+		return resolved
+	}
+	return binPath
 }
 
 // --- individual checks ---
@@ -1252,6 +1357,88 @@ func checkCDPInjector(sinkCfg *config.SinkConfig) Check {
 		Detail:      "Chrome.app not found in /Applications or ~/Applications; CDP injection will fail at sync time",
 		Remediation: "install Google Chrome from https://www.google.com/chrome/, or pass --no-cdp at wizard install to disable CDP injection",
 	}
+}
+
+// checkLiveCDPEndpoint verifies the Linux sink's live CDP injection endpoint
+// is reachable. When live_cdp.enabled is true, this is the primary injection
+// path: the sink attaches to an already-running Chrome via CDP. If the
+// configured endpoint is not reachable, probes common debug ports to help
+// the operator set live_cdp.endpoint correctly.
+func checkLiveCDPEndpoint(sinkCfg *config.SinkConfig) Check {
+	return checkLiveCDPEndpointWith(sinkCfg, probeCDPEndpoint)
+}
+
+// checkLiveCDPEndpointWith is the testable core over an injected probe.
+func checkLiveCDPEndpointWith(sinkCfg *config.SinkConfig, probe func(endpoint string) error) Check {
+	if !sinkCfg.LiveCDP.Enabled {
+		return Check{
+			Name:     "Live CDP endpoint",
+			Severity: SeveritySkipped,
+			Detail:   "live_cdp.enabled is false",
+		}
+	}
+
+	endpoint := sinkCfg.LiveCDP.Endpoint
+	if endpoint == "" {
+		endpoint = livecdp.DefaultCDPEndpoint
+	}
+
+	if err := probe(endpoint); err == nil {
+		return Check{
+			Name:     "Live CDP endpoint",
+			Severity: SeverityOK,
+			Detail:   fmt.Sprintf("live CDP endpoint %s is reachable", endpoint),
+		}
+	}
+
+	// Configured endpoint not reachable. Probe common debug ports to help.
+	commonPorts := []string{
+		"http://127.0.0.1:9222",
+		"http://127.0.0.1:9223",
+		"http://127.0.0.1:9224",
+		"http://127.0.0.1:9228",
+		"http://127.0.0.1:9229",
+		"http://127.0.0.1:9400",
+	}
+	var reachable []string
+	for _, ep := range commonPorts {
+		if ep == endpoint {
+			continue
+		}
+		if probe(ep) == nil {
+			reachable = append(reachable, ep)
+		}
+	}
+
+	if len(reachable) > 0 {
+		return Check{
+			Name:        "Live CDP endpoint",
+			Severity:    SeverityWarn,
+			Detail:      fmt.Sprintf("configured endpoint %s is not reachable, but found Chrome at: %s", endpoint, strings.Join(reachable, ", ")),
+			Remediation: fmt.Sprintf("set live_cdp.endpoint in sink.yaml to one of the reachable ports (e.g. %s)", reachable[0]),
+		}
+	}
+
+	return Check{
+		Name:        "Live CDP endpoint",
+		Severity:    SeverityFail,
+		Detail:      fmt.Sprintf("live_cdp.enabled but endpoint %s is not reachable; no Chrome with --remote-debugging-port found on common ports", endpoint),
+		Remediation: "start Chrome with --remote-debugging-port=9223 (or 9222/9228), then re-run doctor; or set live_cdp.endpoint to the actual port in sink.yaml",
+	}
+}
+
+// probeCDPEndpoint checks if the CDP endpoint responds to /json/version.
+func probeCDPEndpoint(endpoint string) error {
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get(endpoint + "/json/version")
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("status %d", resp.StatusCode)
+	}
+	return nil
 }
 
 // checkCookieDelivery (v0.13 universal cookie delivery) reports whether

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -525,21 +525,18 @@ func extractLaunchAgentBinaryPath(spec launchd.Spec) string {
 	}
 	// Simple extraction: find the first <string> after ProgramArguments.
 	// This is a pragmatic approach that avoids importing plist libraries.
-	idx := strings.Index(string(data), "<key>ProgramArguments</key>")
-	if idx == -1 {
+	_, afterKey, found := strings.Cut(string(data), "<key>ProgramArguments</key>")
+	if !found {
 		return ""
 	}
-	rest := string(data)[idx:]
-	start := strings.Index(rest, "<string>")
-	if start == -1 {
+	_, afterOpen, found := strings.Cut(afterKey, "<string>")
+	if !found {
 		return ""
 	}
-	rest = rest[start+8:]
-	end := strings.Index(rest, "</string>")
-	if end == -1 {
+	binPath, _, found := strings.Cut(afterOpen, "</string>")
+	if !found {
 		return ""
 	}
-	binPath := rest[:end]
 	// Resolve symlinks for comparison.
 	if resolved, err := filepath.EvalSymlinks(binPath); err == nil {
 		return resolved

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -752,9 +752,10 @@ peer:
 	// adapters added the Source adapter check. The cmux delivery surface added
 	// the cmux delivery check. Browser-bound-session honesty added the cmux
 	// session health check (source role only; present here since this fixture
-	// is source).
-	if got := len(report.Checks); got != 20 {
-		t.Fatalf("got %d checks, want 20", got)
+	// is source). Linux sink polish added Live CDP endpoint + Daemon binary
+	// path checks.
+	if got := len(report.Checks); got != 22 {
+		t.Fatalf("got %d checks, want 22", got)
 	}
 
 	// Serialize the envelope and confirm it round-trips.
@@ -948,4 +949,100 @@ func TestCheckCmuxLocalLoop_ConfigEnabledButAgentDown(t *testing.T) {
 	if !strings.Contains(c.Remediation, "enable") {
 		t.Errorf("remediation should point at enable: %q", c.Remediation)
 	}
+}
+
+// TestCheckLiveCDPEndpoint covers the Linux sink's live CDP endpoint check.
+func TestCheckLiveCDPEndpoint(t *testing.T) {
+	okProbe := func(string) error { return nil }
+	errProbe := func(string) error { return errors.New("connection refused") }
+
+	t.Run("disabled is skipped", func(t *testing.T) {
+		cfg := &config.SinkConfig{LiveCDP: config.LiveCDPRef{Enabled: false}}
+		c := checkLiveCDPEndpointWith(cfg, okProbe)
+		if c.Severity != SeveritySkipped {
+			t.Fatalf("got %q, want SKIPPED", c.Severity)
+		}
+	})
+
+	t.Run("enabled and reachable is OK", func(t *testing.T) {
+		cfg := &config.SinkConfig{LiveCDP: config.LiveCDPRef{Enabled: true, Endpoint: "http://127.0.0.1:9223"}}
+		c := checkLiveCDPEndpointWith(cfg, okProbe)
+		if c.Severity != SeverityOK {
+			t.Fatalf("got %q (%q), want OK", c.Severity, c.Detail)
+		}
+		if !strings.Contains(c.Detail, "9223") {
+			t.Errorf("detail should mention the endpoint: %q", c.Detail)
+		}
+	})
+
+	t.Run("unreachable with no alternatives is FAIL", func(t *testing.T) {
+		cfg := &config.SinkConfig{LiveCDP: config.LiveCDPRef{Enabled: true, Endpoint: "http://127.0.0.1:9999"}}
+		c := checkLiveCDPEndpointWith(cfg, errProbe)
+		if c.Severity != SeverityFail {
+			t.Fatalf("got %q (%q), want FAIL", c.Severity, c.Detail)
+		}
+		if !strings.Contains(c.Remediation, "--remote-debugging-port") {
+			t.Errorf("remediation should mention --remote-debugging-port: %q", c.Remediation)
+		}
+	})
+
+	t.Run("unreachable but alternative found is WARN", func(t *testing.T) {
+		calls := make(map[string]bool)
+		probe := func(ep string) error {
+			calls[ep] = true
+			if ep == "http://127.0.0.1:9228" {
+				return nil
+			}
+			return errors.New("connection refused")
+		}
+		cfg := &config.SinkConfig{LiveCDP: config.LiveCDPRef{Enabled: true, Endpoint: "http://127.0.0.1:9999"}}
+		c := checkLiveCDPEndpointWith(cfg, probe)
+		if c.Severity != SeverityWarn {
+			t.Fatalf("got %q (%q), want WARN", c.Severity, c.Detail)
+		}
+		if !strings.Contains(c.Detail, "found Chrome at") {
+			t.Errorf("detail should mention found Chrome: %q", c.Detail)
+		}
+		if !strings.Contains(c.Remediation, "9228") {
+			t.Errorf("remediation should suggest the reachable port: %q", c.Remediation)
+		}
+	})
+
+	t.Run("default endpoint used when empty", func(t *testing.T) {
+		var probed string
+		probe := func(ep string) error {
+			probed = ep
+			return nil
+		}
+		cfg := &config.SinkConfig{LiveCDP: config.LiveCDPRef{Enabled: true}}
+		c := checkLiveCDPEndpointWith(cfg, probe)
+		if c.Severity != SeverityOK {
+			t.Fatalf("got %q, want OK", c.Severity)
+		}
+		if probed != "http://127.0.0.1:9223" {
+			t.Errorf("expected default endpoint 9223, got %q", probed)
+		}
+	})
+}
+
+// TestCheckDaemonBinaryPath covers the daemon binary path mismatch check.
+func TestCheckDaemonBinaryPath(t *testing.T) {
+	t.Run("no configs is OK", func(t *testing.T) {
+		c := checkDaemonBinaryPath(nil, nil)
+		if c.Severity != SeverityOK {
+			t.Fatalf("got %q, want OK", c.Severity)
+		}
+	})
+
+	t.Run("no plist files is OK (Linux or fresh install)", func(t *testing.T) {
+		srcCfg := &config.SourceConfig{}
+		sinkCfg := &config.SinkConfig{}
+		c := checkDaemonBinaryPath(srcCfg, sinkCfg)
+		// On Linux, this will be OK because we skip LaunchAgent checks.
+		// On macOS without plist files, it's also OK because extractLaunchAgentBinaryPath
+		// returns empty string when the file doesn't exist.
+		if c.Severity != SeverityOK {
+			t.Fatalf("got %q, want OK (no plist files)", c.Severity)
+		}
+	})
 }

--- a/internal/cli/sink.go
+++ b/internal/cli/sink.go
@@ -319,16 +319,37 @@ func newSinkMux(
 		// no Keychain, no Chrome SQLite rewrite, just live CDP injection
 		// into a Chrome that the agent runtime (e.g., Grok Bot) already
 		// started with --remote-debugging-port.
+		var liveCDPContexts int
+		var liveCDPErr error
 		if cfg.LiveCDP.Enabled && len(cookies) > 0 {
 			endpoint := cfg.LiveCDP.Endpoint
 			if endpoint == "" {
 				endpoint = livecdp.DefaultCDPEndpoint
 			}
-			if n, lcdpErr := livecdp.AttachAndInject(r.Context(), endpoint, cookies); lcdpErr != nil {
-				fmt.Fprintf(os.Stderr, "agentcookie sink: live CDP injection failed (sidecar write succeeded): %v\n", lcdpErr)
+			liveCDPContexts, liveCDPErr = livecdp.AttachAndInject(r.Context(), endpoint, cookies)
+			if liveCDPErr != nil {
+				fmt.Fprintf(os.Stderr, "agentcookie sink: live CDP injection failed (sidecar write succeeded): %v\n", liveCDPErr)
 			} else {
-				fmt.Fprintf(os.Stderr, "agentcookie sink: live CDP injection pushed %d cookies into %d context(s) at %s\n", len(cookies), n, endpoint)
+				fmt.Fprintf(os.Stderr, "agentcookie sink: live CDP injection pushed %d cookies into %d context(s) at %s\n", len(cookies), liveCDPContexts, endpoint)
 				sinkState.LastWriteMode = writeMode + "+livecdp"
+			}
+
+			// Track live CDP state for status/doctor visibility.
+			if sinkState.LiveCDP == nil {
+				sinkState.LiveCDP = &state.LiveCDPState{
+					Enabled:  true,
+					Endpoint: endpoint,
+				}
+			}
+			sinkState.LiveCDP.LastInjectAt = time.Now().UTC()
+			sinkState.LiveCDP.LastCookies = len(cookies)
+			sinkState.LiveCDP.LastContexts = liveCDPContexts
+			if liveCDPErr != nil {
+				sinkState.LiveCDP.LastError = liveCDPErr.Error()
+				sinkState.LiveCDP.TotalFailures++
+			} else {
+				sinkState.LiveCDP.LastError = ""
+				sinkState.LiveCDP.TotalInjects++
 			}
 		}
 
@@ -362,7 +383,27 @@ func newSinkMux(
 		}
 
 		_ = stateWriter.Save(sinkState)
-		_, _ = fmt.Fprintf(w, "ok: wrote %d cookies (%d sidecar), %d localStorage origins, %d indexedDB origins; dropped %d %s cookies\n", result.Cookies, result.SidecarCookies, result.LocalStorage, result.IndexedDB, dropped, blockMatcher.DropLabel())
+
+		// Build the ok-line. When live CDP ran, include inject result so
+		// operators don't mistake "wrote 0 cookies" for a failure (Linux
+		// skips SQLite and injects via live CDP; the sidecar+livecdp path
+		// is the real delivery).
+		okLine := fmt.Sprintf("ok: wrote %d cookies (%d sidecar), %d localStorage origins, %d indexedDB origins; dropped %d %s cookies",
+			result.Cookies, result.SidecarCookies, result.LocalStorage, result.IndexedDB, dropped, blockMatcher.DropLabel())
+		if cfg.LiveCDP.Enabled {
+			endpoint := cfg.LiveCDP.Endpoint
+			if endpoint == "" {
+				endpoint = livecdp.DefaultCDPEndpoint
+			}
+			if liveCDPErr != nil {
+				okLine += fmt.Sprintf("; live_cdp: FAILED at %s: %v", endpoint, liveCDPErr)
+			} else if liveCDPContexts > 0 {
+				okLine += fmt.Sprintf("; live_cdp: injected %d cookies into %d context(s) at %s", len(cookies), liveCDPContexts, endpoint)
+			} else if len(cookies) == 0 {
+				okLine += fmt.Sprintf("; live_cdp: no cookies to inject (endpoint=%s)", endpoint)
+			}
+		}
+		_, _ = fmt.Fprintln(w, okLine)
 	})
 	return mux
 }

--- a/internal/cli/sink.go
+++ b/internal/cli/sink.go
@@ -8,19 +8,20 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/mvanhorn/agentcookie/internal/cdp"
 	"github.com/mvanhorn/agentcookie/internal/chrome"
-	"github.com/mvanhorn/agentcookie/internal/livecdp"
 	"github.com/mvanhorn/agentcookie/internal/chromectl"
 	"github.com/mvanhorn/agentcookie/internal/chromedirsync"
 	"github.com/mvanhorn/agentcookie/internal/chromepaths"
 	"github.com/mvanhorn/agentcookie/internal/cli/httpserver"
 	"github.com/mvanhorn/agentcookie/internal/config"
 	"github.com/mvanhorn/agentcookie/internal/keystore"
+	"github.com/mvanhorn/agentcookie/internal/livecdp"
 	"github.com/mvanhorn/agentcookie/internal/protocol"
 	"github.com/mvanhorn/agentcookie/internal/secretsbus"
 	"github.com/mvanhorn/agentcookie/internal/sinkpush"
@@ -146,7 +147,8 @@ func runSink(cmd *cobra.Command, args []string) error {
 		fmt.Fprintln(os.Stderr, "agentcookie sink: cmux delivery surface enabled")
 	}
 
-	mux := newSinkMux(cfg, transportSecret, key, seqTracker, stateWriter, sinkState)
+	var stateMu sync.Mutex
+	mux := newSinkMux(cfg, transportSecret, key, seqTracker, stateWriter, sinkState, &stateMu)
 
 	srv := httpserver.Configure(&http.Server{Addr: cfg.Listen.Addr, Handler: mux}, httpserver.SinkSync)
 	if sinkDryRun {
@@ -181,6 +183,7 @@ func newSinkMux(
 	seqTracker *protocol.SequenceTracker,
 	stateWriter *state.Writer,
 	sinkState *state.SinkState,
+	stateMu *sync.Mutex,
 ) *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
@@ -215,7 +218,7 @@ func newSinkMux(
 		bl, err := loadFreshBlocklist()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "agentcookie sink: cookie policy load failed: %v\n", err)
-			recordSinkReject(sinkState, stateWriter, err)
+			recordSinkReject(sinkState, stateWriter, stateMu, err)
 			http.Error(w, "load blocklist: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
@@ -247,12 +250,14 @@ func newSinkMux(
 				"cookies":         cookies,
 			}, "", "  ")
 			fmt.Fprintf(os.Stderr, "agentcookie sink (dry-run): accepted batch:\n%s\n", string(dump))
+			stateMu.Lock()
 			sinkState.LastWrite = time.Now().UTC()
 			sinkState.LastWriteCount = len(cookies)
 			sinkState.LastWriteMode = "dry-run"
 			sinkState.TotalWrites++
 			sinkState.TotalDropped += dropped
 			_ = stateWriter.Save(sinkState)
+			stateMu.Unlock()
 			_, _ = fmt.Fprintf(w, "dry-run ok: accepted %d cookies; dropped %d %s cookies\n", len(cookies), dropped, blockMatcher.DropLabel())
 			return
 		}
@@ -275,23 +280,11 @@ func newSinkMux(
 		}
 		if writeErr != nil {
 			fmt.Fprintf(os.Stderr, "agentcookie sink: write failed (cookies=%d ls=%d idb=%d mode=%s): %v\n", result.Cookies, result.LocalStorage, result.IndexedDB, writeMode, writeErr)
-			recordSinkReject(sinkState, stateWriter, writeErr)
+			recordSinkReject(sinkState, stateWriter, stateMu, writeErr)
 			http.Error(w, fmt.Sprintf("apply envelope: %v", writeErr), http.StatusInternalServerError)
 			return
 		}
 		fmt.Fprintf(os.Stderr, "agentcookie sink: wrote %d cookies (+ %d sidecar) + %d localStorage origins + %d indexedDB origins (mode=%s, dropped %d %s cookies)\n", result.Cookies, result.SidecarCookies, result.LocalStorage, result.IndexedDB, writeMode, dropped, blockMatcher.DropLabel())
-		sinkState.LastWrite = time.Now().UTC()
-		// In skip_chrome_sqlite mode, result.Cookies is zero (we did not
-		// write Chrome SQLite); report the sidecar count so sink-state
-		// reflects what actually shipped to PP CLI consumers.
-		if cfg.SkipChromeSQLite {
-			sinkState.LastWriteCount = result.SidecarCookies
-		} else {
-			sinkState.LastWriteCount = result.Cookies
-		}
-		sinkState.LastWriteMode = writeMode
-		sinkState.TotalWrites++
-		sinkState.TotalDropped += dropped
 
 		// v0.12.0-beta.3: when CDP injection is enabled, spawn a
 		// one-shot headless Chrome and push the cookies via
@@ -300,6 +293,7 @@ func newSinkMux(
 		// Keychain item on this path. Failures are logged but do not
 		// fail the /sync response -- the sidecar write already
 		// succeeded above, so PP CLIs are still served.
+		var cdpWriteMode string
 		if cfg.CDP.Enabled && len(cookies) > 0 {
 			profileDir := cfg.CDP.ProfileDir
 			if profileDir == "" {
@@ -309,7 +303,7 @@ func newSinkMux(
 				fmt.Fprintf(os.Stderr, "agentcookie sink: CDP injection failed (sidecar write succeeded, PP CLIs unaffected): %v\n", cdpErr)
 			} else {
 				fmt.Fprintf(os.Stderr, "agentcookie sink: CDP injection pushed %d cookies into %s\n", len(cookies), profileDir)
-				sinkState.LastWriteMode = writeMode + "+cdp"
+				cdpWriteMode = "+cdp"
 			}
 		}
 
@@ -321,35 +315,17 @@ func newSinkMux(
 		// started with --remote-debugging-port.
 		var liveCDPContexts int
 		var liveCDPErr error
+		var liveCDPEndpoint string
 		if cfg.LiveCDP.Enabled && len(cookies) > 0 {
-			endpoint := cfg.LiveCDP.Endpoint
-			if endpoint == "" {
-				endpoint = livecdp.DefaultCDPEndpoint
+			liveCDPEndpoint = cfg.LiveCDP.Endpoint
+			if liveCDPEndpoint == "" {
+				liveCDPEndpoint = livecdp.DefaultCDPEndpoint
 			}
-			liveCDPContexts, liveCDPErr = livecdp.AttachAndInject(r.Context(), endpoint, cookies)
+			liveCDPContexts, liveCDPErr = livecdp.AttachAndInject(r.Context(), liveCDPEndpoint, cookies)
 			if liveCDPErr != nil {
 				fmt.Fprintf(os.Stderr, "agentcookie sink: live CDP injection failed (sidecar write succeeded): %v\n", liveCDPErr)
 			} else {
-				fmt.Fprintf(os.Stderr, "agentcookie sink: live CDP injection pushed %d cookies into %d context(s) at %s\n", len(cookies), liveCDPContexts, endpoint)
-				sinkState.LastWriteMode = writeMode + "+livecdp"
-			}
-
-			// Track live CDP state for status/doctor visibility.
-			if sinkState.LiveCDP == nil {
-				sinkState.LiveCDP = &state.LiveCDPState{
-					Enabled:  true,
-					Endpoint: endpoint,
-				}
-			}
-			sinkState.LiveCDP.LastInjectAt = time.Now().UTC()
-			sinkState.LiveCDP.LastCookies = len(cookies)
-			sinkState.LiveCDP.LastContexts = liveCDPContexts
-			if liveCDPErr != nil {
-				sinkState.LiveCDP.LastError = liveCDPErr.Error()
-				sinkState.LiveCDP.TotalFailures++
-			} else {
-				sinkState.LiveCDP.LastError = ""
-				sinkState.LiveCDP.TotalInjects++
+				fmt.Fprintf(os.Stderr, "agentcookie sink: live CDP injection pushed %d cookies into %d context(s) at %s\n", len(cookies), liveCDPContexts, liveCDPEndpoint)
 			}
 		}
 
@@ -359,9 +335,9 @@ func newSinkMux(
 		// headlessly on this sink with zero per-binary Keychain prompts.
 		// Adapter failures are reported but do not block the sync. See
 		// plan 2026-05-17-007.
+		var adapterResults []sinkpush.Result
 		if len(cookies) > 0 {
-			adapterResults := sinkpush.RunAll(cookies)
-			sinkState.LastAdapterResults = toStateAdapterResults(adapterResults)
+			adapterResults = sinkpush.RunAll(cookies)
 			logAdapterResults(adapterResults)
 		}
 
@@ -382,7 +358,41 @@ func newSinkMux(
 				secResult.CLIsWritten, secResult.KeysWritten, secResult.SealedWritten, secResult.FilesMaterialized)
 		}
 
+		// Update sink state under mutex to avoid races from concurrent /sync handlers.
+		stateMu.Lock()
+		sinkState.LastWrite = time.Now().UTC()
+		if cfg.SkipChromeSQLite {
+			sinkState.LastWriteCount = result.SidecarCookies
+		} else {
+			sinkState.LastWriteCount = result.Cookies
+		}
+		sinkState.LastWriteMode = writeMode + cdpWriteMode
+		sinkState.TotalWrites++
+		sinkState.TotalDropped += dropped
+		if cfg.LiveCDP.Enabled && len(cookies) > 0 {
+			sinkState.LastWriteMode = writeMode + "+livecdp"
+			if sinkState.LiveCDP == nil {
+				sinkState.LiveCDP = &state.LiveCDPState{
+					Enabled:  true,
+					Endpoint: liveCDPEndpoint,
+				}
+			}
+			sinkState.LiveCDP.LastInjectAt = time.Now().UTC()
+			sinkState.LiveCDP.LastCookies = len(cookies)
+			sinkState.LiveCDP.LastContexts = liveCDPContexts
+			if liveCDPErr != nil {
+				sinkState.LiveCDP.LastError = liveCDPErr.Error()
+				sinkState.LiveCDP.TotalFailures++
+			} else {
+				sinkState.LiveCDP.LastError = ""
+				sinkState.LiveCDP.TotalInjects++
+			}
+		}
+		if len(adapterResults) > 0 {
+			sinkState.LastAdapterResults = toStateAdapterResults(adapterResults)
+		}
 		_ = stateWriter.Save(sinkState)
+		stateMu.Unlock()
 
 		// Build the ok-line. When live CDP ran, include inject result so
 		// operators don't mistake "wrote 0 cookies" for a failure (Linux
@@ -391,9 +401,12 @@ func newSinkMux(
 		okLine := fmt.Sprintf("ok: wrote %d cookies (%d sidecar), %d localStorage origins, %d indexedDB origins; dropped %d %s cookies",
 			result.Cookies, result.SidecarCookies, result.LocalStorage, result.IndexedDB, dropped, blockMatcher.DropLabel())
 		if cfg.LiveCDP.Enabled {
-			endpoint := cfg.LiveCDP.Endpoint
+			endpoint := liveCDPEndpoint
 			if endpoint == "" {
-				endpoint = livecdp.DefaultCDPEndpoint
+				endpoint = cfg.LiveCDP.Endpoint
+				if endpoint == "" {
+					endpoint = livecdp.DefaultCDPEndpoint
+				}
 			}
 			if liveCDPErr != nil {
 				okLine += fmt.Sprintf("; live_cdp: FAILED at %s: %v", endpoint, liveCDPErr)
@@ -408,16 +421,18 @@ func newSinkMux(
 	return mux
 }
 
-func recordSinkReject(sinkState *state.SinkState, stateWriter *state.Writer, err error) {
+func recordSinkReject(sinkState *state.SinkState, stateWriter *state.Writer, stateMu *sync.Mutex, err error) {
 	if sinkState == nil {
 		return
 	}
+	stateMu.Lock()
 	sinkState.LastError = err.Error()
 	sinkState.LastErrorAt = time.Now().UTC()
 	sinkState.TotalRejects++
 	if stateWriter != nil {
 		_ = stateWriter.Save(sinkState)
 	}
+	stateMu.Unlock()
 }
 
 // toStateAdapterResults converts sinkpush.Result slices to the state

--- a/internal/cli/sink_test.go
+++ b/internal/cli/sink_test.go
@@ -12,6 +12,7 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/mvanhorn/agentcookie/internal/chrome"
@@ -495,7 +496,8 @@ func newSinkHandlerFixture(t *testing.T, dryRun bool) *sinkHandlerFixture {
 	seqTracker := protocol.NewSequenceTracker()
 	sinkState := &state.SinkState{Role: "sink", ListenAddr: cfg.Listen.Addr}
 	stateWriter := state.NewWriter(filepath.Join(t.TempDir(), "sink-state.json"))
-	mux := newSinkMux(cfg, secret, []byte("0123456789abcdef"), seqTracker, stateWriter, sinkState)
+	var stateMu sync.Mutex
+	mux := newSinkMux(cfg, secret, []byte("0123456789abcdef"), seqTracker, stateWriter, sinkState, &stateMu)
 
 	return &sinkHandlerFixture{
 		configDir:  configDir,

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -119,6 +119,20 @@ var statusCmd = &cobra.Command{
 				}
 				fmt.Printf("    adapters (last run): %d ok, %d skipped, %d failed (of %d)\n", ok, skipped, failed, n)
 			}
+			if cdp := st.SinkState.LiveCDP; cdp != nil && cdp.Enabled {
+				cdpAgo := "never"
+				if !cdp.LastInjectAt.IsZero() {
+					cdpAgo = time.Since(cdp.LastInjectAt).Round(time.Second).String() + " ago"
+				}
+				fmt.Printf("    live_cdp: endpoint=%s, %d injects, %d failures, last inject %s\n",
+					cdp.Endpoint, cdp.TotalInjects, cdp.TotalFailures, cdpAgo)
+				if cdp.LastCookies > 0 || cdp.LastContexts > 0 {
+					fmt.Printf("      last inject: %d cookies into %d context(s)\n", cdp.LastCookies, cdp.LastContexts)
+				}
+				if cdp.LastError != "" {
+					fmt.Printf("      last error: %s\n", cdp.LastError)
+				}
+			}
 		}
 		for _, e := range st.Errors {
 			fmt.Fprintf(os.Stderr, "  warning: %s\n", e)

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -213,17 +213,23 @@ func wizardInstallSource(ctx context.Context, binPath, logDir string) error {
 		fmt.Fprintf(os.Stderr, "agentcookie wizard: paired with %q (code was %s)\n", wizardPeer, code)
 	}
 
-	// Step 4: install the LaunchAgent unless skipped.
+	// Step 4: install the daemon unless skipped.
 	if !wizardSkipDaemon {
-		if err := installLaunchAgent(launchd.Spec{
-			Role:       launchd.RoleSource,
-			BinaryPath: binPath,
-			LogDir:     logDir,
-			ExtraArgs:  []string{"--watch"},
-		}); err != nil {
-			return fmt.Errorf("install source LaunchAgent: %w", err)
+		if config.IsLinux() {
+			// Linux: no LaunchAgents. Print systemd user unit or supervisor
+			// instructions so the operator can install the daemon themselves.
+			printLinuxDaemonInstructions("source", binPath, logDir, []string{"--watch"})
+		} else {
+			if err := installLaunchAgent(launchd.Spec{
+				Role:       launchd.RoleSource,
+				BinaryPath: binPath,
+				LogDir:     logDir,
+				ExtraArgs:  []string{"--watch"},
+			}); err != nil {
+				return fmt.Errorf("install source LaunchAgent: %w", err)
+			}
+			fmt.Fprintln(os.Stderr, "agentcookie wizard: source LaunchAgent installed and started")
 		}
-		fmt.Fprintln(os.Stderr, "agentcookie wizard: source LaunchAgent installed and started")
 	}
 
 	if !wizardSkipExitNode {
@@ -341,14 +347,20 @@ func wizardInstallSink(ctx context.Context, binPath, logDir string) error {
 	_ = keychainOpened
 
 	if !wizardSkipDaemon {
-		if err := installLaunchAgent(launchd.Spec{
-			Role:       launchd.RoleSink,
-			BinaryPath: binPath,
-			LogDir:     logDir,
-		}); err != nil {
-			return fmt.Errorf("install sink LaunchAgent: %w", err)
+		if config.IsLinux() {
+			// Linux: no LaunchAgents. Print systemd user unit or supervisor
+			// instructions so the operator can install the daemon themselves.
+			printLinuxDaemonInstructions("sink", binPath, logDir, nil)
+		} else {
+			if err := installLaunchAgent(launchd.Spec{
+				Role:       launchd.RoleSink,
+				BinaryPath: binPath,
+				LogDir:     logDir,
+			}); err != nil {
+				return fmt.Errorf("install sink LaunchAgent: %w", err)
+			}
+			fmt.Fprintln(os.Stderr, "agentcookie wizard: sink LaunchAgent installed and started")
 		}
-		fmt.Fprintln(os.Stderr, "agentcookie wizard: sink LaunchAgent installed and started")
 	}
 
 	if !wizardSkipExitNode {
@@ -980,4 +992,52 @@ func errIsAlreadyLoaded(err error) bool {
 	// We do not enumerate them here; the kickstart attempt is safe regardless.
 	_ = time.Second // placeholder reference to avoid import-cleanup issues
 	return false
+}
+
+// printLinuxDaemonInstructions prints systemd user unit instructions for Linux.
+// LaunchAgents are macOS-only; on Linux the operator must install the daemon
+// themselves. This function prints exact instructions including a systemd user
+// unit file the operator can copy, or supervisor/manual run commands.
+func printLinuxDaemonInstructions(role, binPath, logDir string, extraArgs []string) {
+	home, _ := os.UserHomeDir()
+	unitName := "agentcookie-" + role + ".service"
+	unitPath := filepath.Join(home, ".config", "systemd", "user", unitName)
+
+	// Build the command line from the actual binary path (os.Executable()).
+	cmdArgs := []string{binPath, role}
+	cmdArgs = append(cmdArgs, extraArgs...)
+	execStart := strings.Join(cmdArgs, " ")
+
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "agentcookie wizard: Linux detected; LaunchAgents are macOS-only.")
+	fmt.Fprintln(os.Stderr, "agentcookie wizard: To run the daemon, use one of these methods:")
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "  1. SYSTEMD USER UNIT (recommended for persistent operation):")
+	fmt.Fprintf(os.Stderr, "     mkdir -p %s\n", filepath.Dir(unitPath))
+	fmt.Fprintf(os.Stderr, "     cat > %s << 'EOF'\n", unitPath)
+	fmt.Fprintln(os.Stderr, "[Unit]")
+	fmt.Fprintf(os.Stderr, "Description=agentcookie %s daemon\n", role)
+	fmt.Fprintln(os.Stderr, "After=network.target")
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "[Service]")
+	fmt.Fprintf(os.Stderr, "ExecStart=%s\n", execStart)
+	fmt.Fprintln(os.Stderr, "Restart=on-failure")
+	fmt.Fprintln(os.Stderr, "RestartSec=10")
+	fmt.Fprintf(os.Stderr, "StandardOutput=append:%s/%s.out.log\n", logDir, role)
+	fmt.Fprintf(os.Stderr, "StandardError=append:%s/%s.err.log\n", logDir, role)
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "[Install]")
+	fmt.Fprintln(os.Stderr, "WantedBy=default.target")
+	fmt.Fprintln(os.Stderr, "EOF")
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "     Then run:")
+	fmt.Fprintf(os.Stderr, "     mkdir -p %s\n", logDir)
+	fmt.Fprintln(os.Stderr, "     systemctl --user daemon-reload")
+	fmt.Fprintf(os.Stderr, "     systemctl --user enable --now %s\n", unitName)
+	fmt.Fprintf(os.Stderr, "     systemctl --user status %s\n", unitName)
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "  2. SUPERVISOR / MANUAL RUN:")
+	fmt.Fprintf(os.Stderr, "     %s\n", execStart)
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintf(os.Stderr, "agentcookie wizard: %s config written; daemon must be started manually on Linux\n", role)
 }

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -994,9 +994,9 @@ func errIsAlreadyLoaded(err error) bool {
 	return false
 }
 
-// systemdQuote returns a path quoted for use in systemd unit files.
-// Systemd uses C-style escaping: backslash-escape special characters and
-// wrap in double quotes if the path contains whitespace or systemd specifiers.
+// systemdQuote returns an argument quoted for use in systemd ExecStart and
+// similar command-line directives. Systemd uses C-style escaping and wraps
+// in double quotes if the argument contains whitespace or systemd specifiers.
 func systemdQuote(path string) string {
 	needsQuotes := false
 	for _, c := range path {
@@ -1022,6 +1022,32 @@ func systemdQuote(path string) string {
 		}
 	}
 	b.WriteByte('"')
+	return b.String()
+}
+
+// systemdEscapePath returns a path escaped for use in systemd file-path
+// directives like StandardOutput=append: and StandardError=append:.
+// These directives do NOT support quote-wrapped paths after the prefix;
+// instead, special characters must be C-style escaped directly.
+// See systemd.exec(5) for details.
+func systemdEscapePath(path string) string {
+	var b strings.Builder
+	for _, c := range path {
+		switch c {
+		case ' ':
+			b.WriteString("\\x20")
+		case '\t':
+			b.WriteString("\\x09")
+		case '\n':
+			b.WriteString("\\x0a")
+		case '\\':
+			b.WriteString("\\\\")
+		case '%':
+			b.WriteString("%%")
+		default:
+			b.WriteRune(c)
+		}
+	}
 	return b.String()
 }
 
@@ -1078,8 +1104,8 @@ func printLinuxDaemonInstructions(role, binPath, logDir string, extraArgs []stri
 	fmt.Fprintf(os.Stderr, "ExecStart=%s\n", execStart)
 	fmt.Fprintln(os.Stderr, "Restart=on-failure")
 	fmt.Fprintln(os.Stderr, "RestartSec=10")
-	fmt.Fprintf(os.Stderr, "StandardOutput=append:%s\n", systemdQuote(outLog))
-	fmt.Fprintf(os.Stderr, "StandardError=append:%s\n", systemdQuote(errLog))
+	fmt.Fprintf(os.Stderr, "StandardOutput=append:%s\n", systemdEscapePath(outLog))
+	fmt.Fprintf(os.Stderr, "StandardError=append:%s\n", systemdEscapePath(errLog))
 	fmt.Fprintln(os.Stderr, "")
 	fmt.Fprintln(os.Stderr, "[Install]")
 	fmt.Fprintln(os.Stderr, "WantedBy=default.target")

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -994,6 +994,46 @@ func errIsAlreadyLoaded(err error) bool {
 	return false
 }
 
+// systemdQuote returns a path quoted for use in systemd unit files.
+// Systemd uses C-style escaping: backslash-escape special characters and
+// wrap in double quotes if the path contains whitespace or systemd specifiers.
+func systemdQuote(path string) string {
+	needsQuotes := false
+	for _, c := range path {
+		if c == ' ' || c == '\t' || c == '%' || c == '"' || c == '\\' {
+			needsQuotes = true
+			break
+		}
+	}
+	if !needsQuotes {
+		return path
+	}
+	var b strings.Builder
+	b.WriteByte('"')
+	for _, c := range path {
+		switch c {
+		case '\\', '"':
+			b.WriteByte('\\')
+			b.WriteRune(c)
+		case '%':
+			b.WriteString("%%")
+		default:
+			b.WriteRune(c)
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
+}
+
+// shellQuote returns a path quoted for use in shell commands.
+// Uses single quotes which prevent all expansion except for embedded single quotes.
+func shellQuote(path string) string {
+	if !strings.ContainsAny(path, " \t'\"\\$`!") {
+		return path
+	}
+	return "'" + strings.ReplaceAll(path, "'", "'\\''") + "'"
+}
+
 // printLinuxDaemonInstructions prints systemd user unit instructions for Linux.
 // LaunchAgents are macOS-only; on Linux the operator must install the daemon
 // themselves. This function prints exact instructions including a systemd user
@@ -1004,17 +1044,32 @@ func printLinuxDaemonInstructions(role, binPath, logDir string, extraArgs []stri
 	unitPath := filepath.Join(home, ".config", "systemd", "user", unitName)
 
 	// Build the command line from the actual binary path (os.Executable()).
-	cmdArgs := []string{binPath, role}
-	cmdArgs = append(cmdArgs, extraArgs...)
-	execStart := strings.Join(cmdArgs, " ")
+	// Quote each argument for systemd's ExecStart parsing.
+	quotedArgs := make([]string, 0, len(extraArgs)+2)
+	quotedArgs = append(quotedArgs, systemdQuote(binPath), role)
+	for _, arg := range extraArgs {
+		quotedArgs = append(quotedArgs, systemdQuote(arg))
+	}
+	execStart := strings.Join(quotedArgs, " ")
+
+	// Build shell-quoted manual run command.
+	shellArgs := make([]string, 0, len(extraArgs)+2)
+	shellArgs = append(shellArgs, shellQuote(binPath), role)
+	for _, arg := range extraArgs {
+		shellArgs = append(shellArgs, shellQuote(arg))
+	}
+	manualRun := strings.Join(shellArgs, " ")
+
+	outLog := filepath.Join(logDir, role+".out.log")
+	errLog := filepath.Join(logDir, role+".err.log")
 
 	fmt.Fprintln(os.Stderr, "")
 	fmt.Fprintln(os.Stderr, "agentcookie wizard: Linux detected; LaunchAgents are macOS-only.")
 	fmt.Fprintln(os.Stderr, "agentcookie wizard: To run the daemon, use one of these methods:")
 	fmt.Fprintln(os.Stderr, "")
 	fmt.Fprintln(os.Stderr, "  1. SYSTEMD USER UNIT (recommended for persistent operation):")
-	fmt.Fprintf(os.Stderr, "     mkdir -p %s\n", filepath.Dir(unitPath))
-	fmt.Fprintf(os.Stderr, "     cat > %s << 'EOF'\n", unitPath)
+	fmt.Fprintf(os.Stderr, "     mkdir -p %s\n", shellQuote(filepath.Dir(unitPath)))
+	fmt.Fprintf(os.Stderr, "     cat > %s << 'EOF'\n", shellQuote(unitPath))
 	fmt.Fprintln(os.Stderr, "[Unit]")
 	fmt.Fprintf(os.Stderr, "Description=agentcookie %s daemon\n", role)
 	fmt.Fprintln(os.Stderr, "After=network.target")
@@ -1023,21 +1078,21 @@ func printLinuxDaemonInstructions(role, binPath, logDir string, extraArgs []stri
 	fmt.Fprintf(os.Stderr, "ExecStart=%s\n", execStart)
 	fmt.Fprintln(os.Stderr, "Restart=on-failure")
 	fmt.Fprintln(os.Stderr, "RestartSec=10")
-	fmt.Fprintf(os.Stderr, "StandardOutput=append:%s/%s.out.log\n", logDir, role)
-	fmt.Fprintf(os.Stderr, "StandardError=append:%s/%s.err.log\n", logDir, role)
+	fmt.Fprintf(os.Stderr, "StandardOutput=append:%s\n", systemdQuote(outLog))
+	fmt.Fprintf(os.Stderr, "StandardError=append:%s\n", systemdQuote(errLog))
 	fmt.Fprintln(os.Stderr, "")
 	fmt.Fprintln(os.Stderr, "[Install]")
 	fmt.Fprintln(os.Stderr, "WantedBy=default.target")
 	fmt.Fprintln(os.Stderr, "EOF")
 	fmt.Fprintln(os.Stderr, "")
 	fmt.Fprintln(os.Stderr, "     Then run:")
-	fmt.Fprintf(os.Stderr, "     mkdir -p %s\n", logDir)
+	fmt.Fprintf(os.Stderr, "     mkdir -p %s\n", shellQuote(logDir))
 	fmt.Fprintln(os.Stderr, "     systemctl --user daemon-reload")
 	fmt.Fprintf(os.Stderr, "     systemctl --user enable --now %s\n", unitName)
 	fmt.Fprintf(os.Stderr, "     systemctl --user status %s\n", unitName)
 	fmt.Fprintln(os.Stderr, "")
 	fmt.Fprintln(os.Stderr, "  2. SUPERVISOR / MANUAL RUN:")
-	fmt.Fprintf(os.Stderr, "     %s\n", execStart)
+	fmt.Fprintf(os.Stderr, "     %s\n", manualRun)
 	fmt.Fprintln(os.Stderr, "")
 	fmt.Fprintf(os.Stderr, "agentcookie wizard: %s config written; daemon must be started manually on Linux\n", role)
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -53,6 +53,24 @@ type SinkState struct {
 	// no sync has yet triggered a sinkpush run. `agentcookie status`
 	// surfaces this; `agentcookie wizard verify-adapters` reads it.
 	LastAdapterResults []AdapterResult `json:"last_adapter_results,omitempty"`
+
+	// LiveCDP tracks the Linux sink's live CDP injection path (attach to
+	// an already-running Chrome via --remote-debugging-port). Populated
+	// when live_cdp.enabled is true in sink.yaml.
+	LiveCDP *LiveCDPState `json:"live_cdp,omitempty"`
+}
+
+// LiveCDPState records the outcome of live CDP injection into an
+// already-running Chrome. This is the Linux sink's primary injection path.
+type LiveCDPState struct {
+	Enabled        bool      `json:"enabled"`
+	Endpoint       string    `json:"endpoint"`
+	LastInjectAt   time.Time `json:"last_inject_at,omitempty"`
+	LastContexts   int       `json:"last_contexts,omitempty"`
+	LastCookies    int       `json:"last_cookies,omitempty"`
+	LastError      string    `json:"last_error,omitempty"`
+	TotalInjects   int       `json:"total_injects"`
+	TotalFailures  int       `json:"total_failures"`
 }
 
 // AdapterResult is the per-adapter outcome of the most recent sinkpush

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -63,14 +63,14 @@ type SinkState struct {
 // LiveCDPState records the outcome of live CDP injection into an
 // already-running Chrome. This is the Linux sink's primary injection path.
 type LiveCDPState struct {
-	Enabled        bool      `json:"enabled"`
-	Endpoint       string    `json:"endpoint"`
-	LastInjectAt   time.Time `json:"last_inject_at,omitempty"`
-	LastContexts   int       `json:"last_contexts,omitempty"`
-	LastCookies    int       `json:"last_cookies,omitempty"`
-	LastError      string    `json:"last_error,omitempty"`
-	TotalInjects   int       `json:"total_injects"`
-	TotalFailures  int       `json:"total_failures"`
+	Enabled       bool      `json:"enabled"`
+	Endpoint      string    `json:"endpoint"`
+	LastInjectAt  time.Time `json:"last_inject_at,omitempty"`
+	LastContexts  int       `json:"last_contexts,omitempty"`
+	LastCookies   int       `json:"last_cookies,omitempty"`
+	LastError     string    `json:"last_error,omitempty"`
+	TotalInjects  int       `json:"total_injects"`
+	TotalFailures int       `json:"total_failures"`
 }
 
 // AdapterResult is the per-adapter outcome of the most recent sinkpush


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Ship-blocking polish for Linux sink. Addresses visibility issues, daemon installation, and documentation gaps discovered in production on `grok-bot` / `cursor` at 100.87.49.2.

## Summary

### Status / HTTP ok-line / sink-state
- When live CDP runs, the ok-line now reports inject result: cookies attempted, context count, endpoint, and error if inject failed
- `agentcookie status` and `--json` now display live CDP state: endpoint, last inject cookie/context counts, total injects/failures, last error
- Sink state updates protected by mutex to prevent race conditions from concurrent `/sync` handlers

### Wizard on Linux
- Does not install LaunchAgents (macOS-only)
- Prints systemd user unit instructions with properly escaped paths:
  - `ExecStart` uses `systemdQuote()` (quote-wrapped for arguments)
  - `StandardOutput=append:` and `StandardError=append:` use `systemdEscapePath()` (C-style hex escapes, no quotes after `append:`)
  - Shell commands use `shellQuote()` for safe copy-paste
- Handles whitespace, systemd specifiers (`%`), and special characters correctly
- Mac wizard unchanged except: LaunchAgent `ProgramArguments` uses `os.Executable()` binary path

### Doctor
- Checks if `live_cdp.endpoint` (default 9223) is reachable
- If not, probes common loopback debug ports (9222, 9223, 9224, 9228, 9229, 9400) and suggests alternatives
- Warns if running daemon binary path differs from `os.Executable()` of doctor invocation

### Docs
- README updated with Linux sink configuration guidance:
  - `live_cdp.endpoint` configuration
  - Cookie policy behavior (allowlist-empty default)
  - Expected ok-line output (`wrote 0 cookies` is expected with live CDP)
  - Daemon setup instructions (systemd user unit, manual run)
  - `doctor` check overview

## Testing
- `go test ./...` passes
- `go vet ./...` passes
- New tests for `checkLiveCDPEndpoint` and `checkDaemonBinaryPath` doctor checks
- Updated `TestRunDoctorJSONEnvelope` check count

## Verification
- No cookie values in fixtures or logs
- No re-litigation of Tailscale-only, no re-add of import, no Linux Chrome SQLite/libsecret writes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d38eba69-d261-45ca-9858-818a11540a1e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d38eba69-d261-45ca-9858-818a11540a1e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

