### PR TITLE
feat(browser): add Dia browser support

### DIFF
--- a/internal/chrome/browser.go
+++ b/internal/chrome/browser.go
@@ -97,6 +97,15 @@ var browserRegistry = map[string]Browser{
 		KeychainAccount: "Arc",
 		KeychainService: "Arc Safe Storage",
 	},
+	// Dia (The Browser Company) follows the same "User Data" layout as Arc.
+	// Profile paths verified on disk 2026-08-24; keychain account/service
+	// follow the standard macOS Chromium-fork convention.
+	"dia": {
+		Name:            "dia",
+		SupportDir:      []string{"Dia", "User Data"},
+		KeychainAccount: "Dia",
+		KeychainService: "Dia Safe Storage",
+	},
 }
 
 // LookupBrowser returns the browser descriptor for name. Empty name defaults

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -151,6 +151,7 @@ var sourceBrowserPaths = map[string]browserPathRef{
 	"brave":            {SupportDir: []string{"BraveSoftware", "Brave-Browser"}},
 	"edge":             {SupportDir: []string{"Microsoft Edge"}},
 	"arc":              {SupportDir: []string{"Arc", "User Data"}},
+	"dia":              {SupportDir: []string{"Dia", "User Data"}},
 }
 
 // SecurityRef holds transport credentials. SharedSecret is the pre-pairing


### PR DESCRIPTION
## What

Adds Dia (The Browser Company) to the browser registry so agentcookie can sync cookies from Dia on macOS.

Dia is a Chromium-based browser that uses the standard `<App> Safe Storage` keychain model — the same pattern as Arc, Brave, and Edge — so the existing path + keychain adapter applies directly.

## Changes

- `internal/chrome/browser.go`: added `"dia"` entry to `browserRegistry`
- `internal/config/config.go`: added `"dia"` entry to `sourceBrowserPaths`

**Profile path:** `~/Library/Application Support/Dia/User Data/<profile>/Cookies`
**Keychain:** account `Dia`, service `Dia Safe Storage`

## Verification

Tested on macOS arm64 (M2 Mini) with Dia installed. `agentcookie source --once` with `browser: {name: dia}` in `source.yaml` successfully posted 1627 cookies to a Linux sink.

```
agentcookie source: posted 1627 cookies, sink replied: ok
```

`agentcookie doctor` reports `[OK] Chrome stores: 1 readable store(s)` with the Dia profile.