### PR TITLE
feat(browser): add Dia source adapter with discovery identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Dia source-browser support
+
+Dia (The Browser Company) is a Chromium-family source adapter using the same Safe Storage model as Arc, Brave, and Edge. Set `browser.name: dia` in `source.yaml`. Discovery labels Dia's `User Data` root as `dia` so key lookup uses `Dia Safe Storage` rather than Chrome's.
+
 ### Multi-sink fan-out
 
 One source can now push the same cookies and secrets to several sinks.

--- a/examples/source.yaml
+++ b/examples/source.yaml
@@ -14,11 +14,11 @@ chrome:
 
 # Optional source browser adapter. Omit for Google Chrome. Set name/profile
 # when reading cookies from another Chromium-family source browser.
-# Supported: chrome, brave, edge, arc. (atlas is recognized but cannot be
+# Supported: chrome, brave, edge, arc, dia. (atlas is recognized but cannot be
 # decrypted by a third-party tool -- see issue #80; `agentcookie doctor`
 # reports the gap.)
 # browser:
-#   name: brave # chrome | brave | edge | arc
+#   name: brave # chrome | brave | edge | arc | dia
 #   profile: Default
 
 peer:

--- a/internal/chrome/browser.go
+++ b/internal/chrome/browser.go
@@ -97,6 +97,15 @@ var browserRegistry = map[string]Browser{
 		KeychainAccount: "Arc",
 		KeychainService: "Arc Safe Storage",
 	},
+	// Dia (The Browser Company) follows the same "User Data" layout as Arc.
+	// Profile paths verified on disk 2026-08-24; keychain account/service
+	// follow the standard macOS Chromium-fork convention.
+	"dia": {
+		Name:            "dia",
+		SupportDir:      []string{"Dia", "User Data"},
+		KeychainAccount: "Dia",
+		KeychainService: "Dia Safe Storage",
+	},
 }
 
 // LookupBrowser returns the browser descriptor for name. Empty name defaults
@@ -168,6 +177,8 @@ func linuxSupportDir(macDirs []string) []string {
 		return macDirs
 	case "Microsoft Edge":
 		return []string{"microsoft-edge"}
+	case "Arc", "Dia":
+		return macDirs // Arc and Dia are macOS-only
 	default:
 		return macDirs
 	}

--- a/internal/chrome/browser_test.go
+++ b/internal/chrome/browser_test.go
@@ -56,7 +56,7 @@ func TestLookupBrowserAtlas(t *testing.T) {
 }
 
 func TestLookupBrowserUnknownListsSupportedNames(t *testing.T) {
-	_, err := LookupBrowser("dia")
+	_, err := LookupBrowser("vivaldi")
 	if err == nil {
 		t.Fatal("expected unsupported browser error")
 	}
@@ -76,6 +76,7 @@ func TestLookupBrowserStandardForks(t *testing.T) {
 		{"brave", []string{"BraveSoftware", "Brave-Browser"}, "Brave", "Brave Safe Storage"},
 		{"edge", []string{"Microsoft Edge"}, "Microsoft Edge", "Microsoft Edge Safe Storage"},
 		{"arc", []string{"Arc", "User Data"}, "Arc", "Arc Safe Storage"},
+		{"dia", []string{"Dia", "User Data"}, "Dia", "Dia Safe Storage"},
 	}
 	for _, tc := range cases {
 		b, err := LookupBrowser(tc.name)

--- a/internal/chromepaths/discover.go
+++ b/internal/chromepaths/discover.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
-	"slices"
 	"strings"
 )
 
@@ -155,20 +154,28 @@ func browserForRoot(root string) string {
 		return "edge"
 	case strings.Contains(lower, "chromium"):
 		return "chromium"
-	case pathHasComponent(lower, "dia"):
-		// Path-component match: strings.Contains("media", "dia") is true, so
-		// a substring check would mislabel any root whose path includes
-		// "media" as Dia and then look up Dia Safe Storage.
+	case isDiaUserDataRoot(lower):
+		// Require the Dia/User Data pair, not a lone "dia" component.
+		// CHROME_USER_DATA_DIR or cdp.profile_dir under a folder named
+		// dia (or a user named dia) must stay Chrome so key lookup does
+		// not request Dia Safe Storage and drop the store.
 		return "dia"
 	default:
 		return "chrome"
 	}
 }
 
-// pathHasComponent reports whether name is a path element of slashPath.
-// slashPath must already use forward slashes (filepath.ToSlash).
-func pathHasComponent(slashPath, name string) bool {
-	return slices.Contains(strings.Split(slashPath, "/"), name)
+// isDiaUserDataRoot reports whether slashPath contains consecutive Dia
+// support-dir components ("dia" then "user data"). slashPath must already
+// use forward slashes and be lowercased.
+func isDiaUserDataRoot(slashPath string) bool {
+	parts := strings.Split(slashPath, "/")
+	for i := 0; i+1 < len(parts); i++ {
+		if parts[i] == "dia" && parts[i+1] == "user data" {
+			return true
+		}
+	}
+	return false
 }
 
 // Discover scans known Chrome user-data-dirs and returns all usable

--- a/internal/chromepaths/discover.go
+++ b/internal/chromepaths/discover.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"slices"
 	"strings"
 )
 
@@ -99,6 +100,10 @@ func chromeRoots() []string {
 			filepath.Join(appSupport, "Chromium"),
 			filepath.Join(appSupport, "BraveSoftware", "Brave-Browser"),
 			filepath.Join(appSupport, "Microsoft Edge"),
+			// Dia uses Arc's User Data layout. Scan the user-data-dir itself
+			// (profiles live under Dia/User Data/<profile>/), not the Dia
+			// support dir, or Default/Profile N would not be found.
+			filepath.Join(appSupport, "Dia", "User Data"),
 		)
 	case "linux":
 		configDir := filepath.Join(home, ".config")
@@ -142,7 +147,7 @@ func osDefaultChromeRoot() string {
 
 // browserForRoot returns a browser identifier based on the root path.
 func browserForRoot(root string) string {
-	lower := strings.ToLower(root)
+	lower := strings.ToLower(filepath.ToSlash(root))
 	switch {
 	case strings.Contains(lower, "brave"):
 		return "brave"
@@ -150,9 +155,20 @@ func browserForRoot(root string) string {
 		return "edge"
 	case strings.Contains(lower, "chromium"):
 		return "chromium"
+	case pathHasComponent(lower, "dia"):
+		// Path-component match: strings.Contains("media", "dia") is true, so
+		// a substring check would mislabel any root whose path includes
+		// "media" as Dia and then look up Dia Safe Storage.
+		return "dia"
 	default:
 		return "chrome"
 	}
+}
+
+// pathHasComponent reports whether name is a path element of slashPath.
+// slashPath must already use forward slashes (filepath.ToSlash).
+func pathHasComponent(slashPath, name string) bool {
+	return slices.Contains(strings.Split(slashPath, "/"), name)
 }
 
 // Discover scans known Chrome user-data-dirs and returns all usable

--- a/internal/chromepaths/discover_test.go
+++ b/internal/chromepaths/discover_test.go
@@ -516,7 +516,10 @@ func TestBrowserForRoot(t *testing.T) {
 		{"/home/me/chrome-profile", "chrome"},
 		{"/some/random/path", "chrome"}, // Default
 		{"/Users/me/Library/Application Support/Dia/User Data", "dia"},
+		{"/Users/me/Library/Application Support/Dia/User Data/Default", "dia"},
 		{"/Users/me/Library/Application Support/some-media-app", "chrome"}, // "media" contains "dia"
+		{"/Users/dia/Library/Application Support/Google/Chrome", "chrome"},
+		{"/tmp/dia/chrome-profile", "chrome"},
 	}
 
 	for _, tc := range cases {
@@ -551,5 +554,38 @@ func TestDiscoverForConfig_DiaUserDataKeepsDiaIdentity(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("expected dia/Default store from Dia User Data root, got %+v", result.Stores)
+	}
+}
+
+// TestDiscoverForConfig_CustomRootUnderDiaDirStaysChrome is the inverse of
+// the Dia identity guard: a Chrome user-data-dir whose path merely contains
+// a "dia" directory (CHROME_USER_DATA_DIR / cdp.profile_dir) must not be
+// labeled dia, or key lookup would request Dia Safe Storage and skip the
+// store.
+func TestDiscoverForConfig_CustomRootUnderDiaDirStaysChrome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	chromeRoot := filepath.Join(home, "dia", "agent-chrome")
+	if err := os.MkdirAll(chromeRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	makeProfile(t, chromeRoot, "Default", true, false)
+
+	result := DiscoverForConfig(chromeRoot)
+	found := false
+	for _, s := range result.Stores {
+		if s.CookiesPath == "" {
+			continue
+		}
+		if s.Browser != "chrome" {
+			t.Errorf("store under %q labeled %q, want chrome", chromeRoot, s.Browser)
+		}
+		if s.Profile == "Default" && s.Browser == "chrome" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected chrome/Default store under a dia/ parent, got %+v", result.Stores)
 	}
 }

--- a/internal/chromepaths/discover_test.go
+++ b/internal/chromepaths/discover_test.go
@@ -515,6 +515,8 @@ func TestBrowserForRoot(t *testing.T) {
 		{"/home/me/.config/microsoft-edge", "edge"},
 		{"/home/me/chrome-profile", "chrome"},
 		{"/some/random/path", "chrome"}, // Default
+		{"/Users/me/Library/Application Support/Dia/User Data", "dia"},
+		{"/Users/me/Library/Application Support/some-media-app", "chrome"}, // "media" contains "dia"
 	}
 
 	for _, tc := range cases {
@@ -522,5 +524,32 @@ func TestBrowserForRoot(t *testing.T) {
 		if got != tc.want {
 			t.Errorf("browserForRoot(%q) = %q, want %q", tc.root, got, tc.want)
 		}
+	}
+}
+
+// TestDiscoverForConfig_DiaUserDataKeepsDiaIdentity is the #120 discovery
+// guard: a Dia User Data root must stay labeled "dia" so key lookup uses
+// Dia Safe Storage, not Chrome Safe Storage.
+func TestDiscoverForConfig_DiaUserDataKeepsDiaIdentity(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	diaRoot := filepath.Join(home, "Library", "Application Support", "Dia", "User Data")
+	if err := os.MkdirAll(diaRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	makeProfile(t, diaRoot, "Default", true, false)
+
+	result := DiscoverForConfig(diaRoot)
+
+	found := false
+	for _, s := range result.Stores {
+		if s.Profile == "Default" && s.Browser == "dia" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected dia/Default store from Dia User Data root, got %+v", result.Stores)
 	}
 }

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -705,7 +705,7 @@ func TestCheckSourceAdapter(t *testing.T) {
 	t.Run("unknown browser lists supported names", func(t *testing.T) {
 		cfg := &config.SourceConfig{
 			Chrome:  config.ChromeRef{DBPath: "/tmp/Cookies"},
-			Browser: config.BrowserRef{Name: "dia"},
+			Browser: config.BrowserRef{Name: "vivaldi"},
 		}
 		c := checkSourceAdapter(cfg, exists, password, decryptOK)
 		if c.Severity != SeverityFail {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -186,6 +186,7 @@ var sourceBrowserPaths = map[string]browserPathRef{
 	"brave":            {SupportDir: []string{"BraveSoftware", "Brave-Browser"}},
 	"edge":             {SupportDir: []string{"Microsoft Edge"}},
 	"arc":              {SupportDir: []string{"Arc", "User Data"}},
+	"dia":              {SupportDir: []string{"Dia", "User Data"}},
 }
 
 // SecurityRef holds transport credentials. SharedSecret is the pre-pairing
@@ -437,8 +438,8 @@ func linuxSupportDir(macDirs []string) []string {
 		return []string{"microsoft-edge"}
 	case "com.openai.atlas":
 		return macDirs // Atlas is macOS-only
-	case "Arc":
-		return macDirs // Arc is macOS-only
+	case "Arc", "Dia":
+		return macDirs // Arc and Dia are macOS-only
 	default:
 		return macDirs
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -74,6 +74,35 @@ security:
 	}
 }
 
+func TestLoadSourceBrowserDiaDerivesUserDataPath(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "source.yaml", `
+sink:
+  url: http://example.test:9999/sync
+browser:
+  name: dia
+security:
+  shared_secret: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+`)
+	cfg, err := LoadSource(dir)
+	if err != nil {
+		t.Fatalf("LoadSource: %v", err)
+	}
+	if cfg.Browser.Name != "dia" {
+		t.Errorf("browser name: got %q, want dia", cfg.Browser.Name)
+	}
+	home, _ := os.UserHomeDir()
+	var want string
+	if runtime.GOOS == "linux" {
+		want = filepath.Join(home, ".config", "Dia", "User Data", "Default", "Cookies")
+	} else {
+		want = filepath.Join(home, "Library", "Application Support", "Dia", "User Data", "Default", "Cookies")
+	}
+	if cfg.Chrome.DBPath != want {
+		t.Errorf("derived DBPath: got %q, want %q", cfg.Chrome.DBPath, want)
+	}
+}
+
 func TestLoadSourceDBPathOverridesBrowserDerivedPath(t *testing.T) {
 	dir := t.TempDir()
 	explicit := filepath.Join(dir, "Custom", "Cookies")
@@ -123,7 +152,7 @@ func TestLoadSourceUnknownBrowserFailsWithSupportedNames(t *testing.T) {
 sink:
   url: http://example.test:9999/sync
 browser:
-  name: dia
+  name: vivaldi
 security:
   shared_secret: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 `)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Dia (The Browser Company) as a Chromium-family source browser so `source.yaml` `browser.name: dia` reads `~/Library/Application Support/Dia/User Data/<profile>/Cookies` with keychain account `Dia` / service `Dia Safe Storage`.

This supersedes https://github.com/mvanhorn/agentcookie/pull/120 (fork `alexknowshtml/agentcookie` / `add-dia-browser`). We cannot push to that fork, so this is a fresh branch off latest `main` that keeps #120's registry intent and lands the two gaps that blocked it.

## Fixes beyond #120

1. **Discovery identity.** `browserForRoot` in `internal/chromepaths/discover.go` had no Dia case, so a discovered Dia User Data root was labeled `chrome` and key lookup used Chrome Safe Storage. Dia is classified by consecutive `Dia/User Data` path components (not a lone `dia` folder, and not the substring `media`) and Darwin `chromeRoots` scans `Dia/User Data` so extra-profile / `cookies` / doctor discovery actually finds it.
2. **Unsupported-browser fixtures.** `TestLoadSourceUnknownBrowserFailsWithSupportedNames` (and the matching LookupBrowser / doctor tests) still used `dia` as the unsupported name. They now use `vivaldi`, which remains unsupported.

## Verified

- [x] `go build ./...`
- [x] `go vet ./internal/chrome ./internal/config ./internal/chromepaths ./internal/cli`
- [x] `go test ./internal/chrome ./internal/config ./internal/chromepaths ./internal/cli`

## Notes

- Explicit config and discovery now share the same Dia keychain identity. Cookie decryption was verified on a real Dia install in #120 (`agentcookie source --once` posted 1627 cookies); this PR adds the missing identity + test coverage on latest main.
- Darwin extra-profile union (`cookies` command, sink adapter paste) will include Dia stores when Dia is installed and `Dia Safe Storage` is readable, matching Brave/Edge. Arc is still not in `chromeRoots` (pre-existing); this PR does not expand Arc discovery.
- Custom Chrome roots under a directory or user named `dia` (via `CHROME_USER_DATA_DIR` / `cdp.profile_dir`) stay labeled Chrome.
- No wire-format, blocklist, or on-disk config schema change. `browser.name: dia` is opt-in for `agentcookie source`.
- Does not merge, comment on, or close #120.
- `govulncheck` fail is existing go1.26.4 stdlib debt (same as #122 / main); not chased here.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a75dc7af-1054-522f-b817-4f542d49f149?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a75dc7af-1054-522f-b817-4f542d49f149&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

